### PR TITLE
Disable dev server cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"jshint": "^2.10.2"
 	},
 	"scripts": {
-		"start": "http-server",
+		"start": "http-server -c-1",
 		"test": "jshint travis.js"
 	}
 }


### PR DESCRIPTION
For some reason `http-server` has a default cache header of 1 hour. That isn't very useful in dev mode. This disables that.