### PR TITLE
Display error message

### DIFF
--- a/script.js
+++ b/script.js
@@ -136,6 +136,10 @@ const app = new Vue({
           this.response.body = xhr.responseText
         }
       }
+      xhr.onerror = e => {
+        this.response.status = '0'
+        this.response.body = 'Error ;('
+      }
     },
     addRequestParam() {
       this.params.push({


### PR DESCRIPTION
If the XHR request fails, show a simple error message.

Test URL `https://api.twitter.com`