### PR TITLE
Add Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "Dependency upgrade"
+    default_reviewers:
+      - "liyasthomas"


### PR DESCRIPTION
Add a [validated](https://dependabot.com/docs/config-file/validator/) Dependabot config so we can auto-update our JS dependencies.
<img width="1000" alt="Screen Shot 2019-08-23 at 22 43 17" src="https://user-images.githubusercontent.com/1557529/63597000-6db9d500-c5f7-11e9-9939-73a248b935c4.png">

👉We'll have to create a label called `Dependency upgrade` for `default_labels` to work.👈

Alternative to https://github.com/liyasthomas/postwoman/pull/27.