### PR TITLE
History fieldset minimized.

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -130,6 +130,10 @@ fieldset.history legend {
   color: #9B9B9B;
 }
 
+fieldset.history .collapsible {
+  overflow: auto;
+}
+
 fieldset.authentication {
   border-color: #B8E986;
 }
@@ -225,4 +229,24 @@ ol li {
 
 #installPWA {
   display: none;
+}
+
+.info-response {
+  background-color: #ffeb3b;
+}
+
+.success-response {
+  background-color: #66BB6A;
+}
+
+.redir-response {
+  background-color: #ff5722;
+}
+
+.cl-error-response {
+  background-color: #ef5350;
+}
+
+.sv-error-response {
+  background-color: #b71c1c;
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -157,12 +157,12 @@
     </fieldset>
     <fieldset class="history">
       <legend v-on:click="collapse">History ↕</legend>
-      <div class="collapsible">
-        <ul>
-          <li>
-            <button v-bind:class="{ disabled: noHistoryToClear }" v-on:click="clearHistory">Clear History</button>
-          </li>
-        </ul>
+      <ul>
+        <li>
+          <button v-bind:class="{ disabled: noHistoryToClear }" v-on:click="clearHistory">Clear History</button>
+        </li>
+      </ul>
+      <div class="collapsible" :style="{'max-height': (Math.min(5, history.length) * 88) + 'px'}">
         <ul v-for="entry in history">
           <li>
             <label for="time">Time</label>


### PR DESCRIPTION
History fieldset is minimized by setting a `max-height` style to `fieldset.history .collapsible` to minimize the application view.

This minimization doesn't occur until five `entry` items are added to history.

Also, button to clear history has been moved to the parent to keep its position upon history scroll.