### PR TITLE
Enable shareable requests with parameters in url queries

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -528,7 +528,15 @@
             this.$refs.previewFrame.setAttribute('data-previewing-url', this.url);
           }
         }
+      },
+      setRouteQueries(queries) {
+        for (const key in queries) {
+          if (this[key]) this[key] = queries[key];
+        }
       }
+    },
+    created() {
+      if (Object.keys(this.$route.query).length) this.setRouteQueries(this.$route.query);
     }
   }
 


### PR DESCRIPTION
I think this is maybe related to #29. 

It enable shareable requests using query parameters in the url. Examples:

[/url=https://api.thecatapi.com&path=/v1/images/search](https://yubathom.github.io/postwoman/?url=https://api.thecatapi.com&path=/v1/images/search)

[/method=POST](https://yubathom.github.io/postwoman/?method=POST
)

[/method=PUT&contentType=/?method=PUT&contentType=www-form/urlencoded](https://yubathom.github.io/postwoman/?method=PUT&contentType=www-form/urlencoded)


it can be applied to the other items of `data` of the `pages/index` component. 

Maybe would be simpler to store theese settings (that could be stored in the router) in a collection than a encoding/decodign static files.
