### PR TITLE
Adds HTML preview.

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -171,7 +171,7 @@ fieldset.orange legend {
   color: #F5A623;
 }
 
-.collapsible.hidden {
+.hidden {
   display: none;
 }
 
@@ -288,5 +288,31 @@ fieldset#history {
       right: 20px;
       font-family: monospace, monospace;
     }
+  }
+}
+
+.align-left { text-align: left; }
+.align-right { text-align: right; }
+
+#response-details-wrapper {
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  margin: 4px;
+
+  #response-details {
+    margin: 0;
+  }
+
+  .covers-response {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: white;
+
+    height: 100%;
+    width: 100%;
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -393,6 +393,7 @@
           behavior: 'smooth'
         });
 
+        this.previewEnabled = false;
         this.response.status = 'Fetching...';
         this.response.body = 'Loading...';
 


### PR DESCRIPTION
Resolves #41 - adds an HTML preview toggle-able with the 'Preview HTML' / 'Hide Preview' button in the bottom right of the response area.
When 'Preview HTML' is clicked, the HTML source is covered by a preview of the rendered HTML.

This button only shows when content type is HTML and a response has been submitted.
As always, you can test the changes here: https://nbtx.github.io/postwoman-vue/

![image](https://user-images.githubusercontent.com/43181178/63816829-839a0380-c931-11e9-8d25-2a544c48ba06.png)
