### PR TITLE
fixes #74 fallback for findEntryStatus when match is missing or other…

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -278,6 +278,10 @@ ol li {
   background-color: #B71C1C;
 }
 
+.missing-data-response {
+  background-color: #676767;
+}
+
 fieldset#history {
   .method-list-item {
     position: relative;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -241,6 +241,13 @@
       statusCodeRegex: new RegExp(/[5][0-9]+/),
       className: 'sv-error-response'
     },
+    {
+      // this object is a catch-all for when no other objects match and should always be last
+      name: 'unknown',
+      statusCodeRegex: new RegExp(/.*/),
+      className: 'missing-data-response'
+    }
+
   ];
   const parseHeaders = xhr => {
     const headers = xhr.getAllResponseHeaders().trim().split(/[\r\n]+/);


### PR DESCRIPTION
…wise invalid

Small change with big implication!

As mentoned in #74, it would be best for both old history (which has no status number) _and_ new history to be preserved. 

`findEntryStatus` which in turn calls `findStatusGroup`, calls the `Array.prototype.find` which will return undefined if the callback function provided does not return true on any item. Since the callback function uses a RegEx.prototype.test on the `statusCategories`'s `.statusCodeRegex` to determine a match, I added a final object with a `.statusCodeRegex` of `/.*/` to match anything. Think of it as a default in a switch statement, since all other objects before it have to not match before hitting it. 