### PR TITLE
Syntax Highlighting for HTML, CSS, JS, XML, JSON and SVG

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -166,8 +166,7 @@ fieldset.orange legend {
 select,
 input,
 option,
-textarea,
-pre {
+textarea {
   margin: 4px;
   padding: 8px 16px;
   border-radius: 4px;
@@ -176,6 +175,16 @@ pre {
   color: var(--fg-color);
   font-weight: 700;
   font-size: 18px;
+  font-family: monospace;
+}
+
+pre {
+  margin: 4px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  width: calc(100% - 8px);
+  background-color: var(--bg-dark-color);
+  color: var(--fg-color);
   font-family: monospace;
 }
 
@@ -278,6 +287,10 @@ ol li {
 
 #installPWA {
   display: none;
+}
+
+.token {
+  background-color: transparent !important;
 }
 
 .info-response {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2966,6 +2966,17 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -3729,6 +3740,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -4747,6 +4764,15 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -7959,6 +7985,14 @@
       "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
       "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA=="
     },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -8583,6 +8617,12 @@
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "semver": {
       "version": "5.7.1",
@@ -9440,6 +9480,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@nuxtjs/pwa": "^3.0.0-0",
     "nuxt": "^2.0.0",
+    "prismjs": "^1.17.1",
     "vuex-persist": "^2.0.1"
   },
   "devDependencies": {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -472,6 +472,7 @@
         xhr.onerror = e => {
           this.response.status = xhr.status;
           this.response.body = xhr.statusText;
+          this.responseHtml = `<textarea rows=10 readonly>${this.response.body}</textarea>`;
         }
 
         this.responseHtml = '<textarea rows=10 readonly>Loading...</textarea>';


### PR DESCRIPTION
Sorry for the delays, I am kinda busy with travelling these days...

So yeah, this PR adds syntax highlighting to the responses powered by [Prism](https://prismjs.com/).
It looks at the returned content-type and applies the equivalent highlighting...

Well, I had to change a bit in the way how the responses are rendered, it relies on a property (responseHtml) now to render the raw html into the response box. Also, since textarea doesn't allow formatting, when an unsupported MIME type is returned, it defaults to the old textarea based layout but when a supported mime is returned, instead the content is rendered within a code tag inside a pre tag (ie, `<pre><code>{{ content }}</code></pre>`).

There are some stuff we will lose like the stretching textarea and stuff, and if there are no line breaks, the content box keeps expanding even out of the viewport. Someone should like update this PR with the ability to have proper overflow handling (I kinda don't want to work with the CSS on that one).