### PR TITLE
Fix intersection button send

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -533,9 +533,10 @@
       },
       observeRequestButton() {
         const requestElement = this.$refs.request.$el;
+        const sendButton = this.$refs.sendButton;
         const observer = new IntersectionObserver((entries, observer) => {
           entries.forEach(entry => {
-            this.$refs.sendButton.classList.toggle('show');
+           sendButton.className = entry.isIntersecting ? '' : 'show';
           });
         }, { threshold: 1 });
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -531,22 +531,15 @@
           if (this[key]) this[key] = queries[key];
         }
       },
-      observeRequestButton: function () {
-		      let isTheInitialIntersection = true;
-		      const sendButtonElement = this.$refs.sendButton;
-		      const requestElement = this.$refs.request.$el;
-		      const observer = new IntersectionObserver((entries, observer) => {
-				      entries.forEach(entry => {
-						      if (entry.isIntersecting) {
-								      if (!isTheInitialIntersection) {
-										      sendButtonElement.classList.toggle('show');
-								      } else {
-										      isTheInitialIntersection = false;
-								      }
-						      }
-				      });
-		      }, {threshold: 1});
-		      observer.observe(requestElement);
+      observeRequestButton() {
+        const requestElement = this.$refs.request.$el;
+        const observer = new IntersectionObserver((entries, observer) => {
+          entries.forEach(entry => {
+            this.$refs.sendButton.classList.toggle('show');
+          });
+        }, { threshold: 1 });
+
+        observer.observe(requestElement);
       }
     },
     created() {


### PR DESCRIPTION
In my opinion something is wrong right now with the button fixed, using the Intersection API (ref #107 #94). At my environment, it only works on the first scroll and every two full page scrolls after that.

This PR changes the logic a bit to make it work all the time.

**Right now:**

![screencast-liyasthomas github io-2019 08 30-09-31-02](https://user-images.githubusercontent.com/22016005/64021763-104be980-cb0b-11e9-888f-45d49a5ab778.gif)

**After this PR:**

![screencast-localhost-3000-2019 08 30-09-35-06](https://user-images.githubusercontent.com/22016005/64021794-22c62300-cb0b-11e9-925c-d3bb76476d53.gif)
