### PR TITLE
Bind history state and query params of requests

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -532,7 +532,7 @@
           }
         }
       },
-      setRouteQuerieState () {
+      setRouteQueryState () {
         const flat = key => this[key] !== '' ? `${key}=${this[key]}&` : ''
         const deep = key => {
           const haveItems = [...this[key]].length
@@ -582,7 +582,7 @@
           vm.bodyParams,
           vm.contentType
         ], val => {
-        this.setRouteQuerieState()
+        this.setRouteQueryState()
       })
     }
   }


### PR DESCRIPTION
* Enable uri with preseted headers, params and body. Examples:

- <a href="https://yubathom.github.io/postwoman/?headers=%5B%7B%22key%22%3A%22foo%22,%20%22value%22%3A%22bar%22%7D%5D">/?headers=[{"key":"foo", "value":"bar"}]
 - <a href="https://yubathom.github.io/postwoman/?params=%5B%7B%22key%22%3A%22foo%22,%20%22value%22%3A%22bar%22%7D%5D">/?params=[{"key":"foo", "value":"bar"}]
 - <a href="https://yubathom.github.io/postwoman/?method=POST&bodyParams=%5B%7B%22key%22%3A%22foo%22,%20%22value%22%3A%22bar%22%7D%5D">/?method=POST&bodyParams=[{"key":"foo", "value":"bar"}]</a>

or combined with other params like:
[/?method=POST&auth=Basic&httpUser=someUser&httpPassword=somePass](https://yubathom.github.io/postwoman/?method=POST&url=https%3A%2F%2Freqres.in&path=%2Fapi%2Fusers&auth=Basic&httpUser=someUser&httpPassword=somePass)
* The url and router state are now binded. So the requests can be shared (just copy it from the url bar)