### PR TITLE
update with PR for issue/bug #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ See the [CHANGELOG](CHANGELOG.md) file for details.
 * [Nicholas La Roux](https://github.com/larouxn)
 * [RifqiAlAbqary](https://github.com/reefqi037)
 * [izerozlu](https://github.com/izerozlu)
+* [Nilesh Patel](https://github.com/NileshSP)
 
 ### Thanks
 * [Dribbble](https://dribbble.com)

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -1,8 +1,7 @@
 # MIDDLEWARE
-
-**This directory is not required, you can delete it if you don't want to use it.**
-
-This directory contains your application middleware.
-Middleware let you define custom functions that can be run before rendering either a page or a group of pages.
+<br/>
+parsedefaulturl.js - parse default url for appropriate path  
+<br/>
+<br/>
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/routing#middleware).

--- a/middleware/parsedefaulturl.js
+++ b/middleware/parsedefaulturl.js
@@ -1,0 +1,5 @@
+export default function({ route, redirect }) {
+  if(route.fullPath !== '/') {
+    return redirect('/');
+  }
+} 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -243,7 +243,8 @@
   export const findStatusGroup = responseStatus => statusCategories.find(status => status.statusCodeRegex.test(responseStatus));
 
   export default {
-  		directives: {
+    middleware: 'parsedefaulturl', // calls middleware before loading the page
+    directives: {
   				textareaAutoHeight
     },
     components: {


### PR DESCRIPTION
Issue - ideally the default url expected is '/' to highlight the 'Http' menu option but in PWA's case the url passed is '/?standalone=true' to indicate and load it as an app where 'standalone=true' is automatically appended by the rendering browser engine 

Solution - newly added middleware 'parsedefaulturl.js' would intercept the request before loading the default page and redirect appropriately as desired