### PR TITLE
Clear history is now disabled when there aren't any histories

### DIFF
--- a/components/history.vue
+++ b/components/history.vue
@@ -126,6 +126,7 @@
         updateOnLocalStorage('history', this.history);
       },
       enableHistoryClearing() {
+				if (!this.history || !this.history.length) return;
         this.isClearingHistory = true;
       },
       disableHistoryClearing() {


### PR DESCRIPTION
Small minor improvement. Right now I can click on the clear history even if there aren't any histories there. This PR should fix this.

**Issue:**

![postwoman](https://user-images.githubusercontent.com/22016005/64079866-96ab2b80-ccc3-11e9-816f-9384a3c1c453.gif)
