### PR TITLE
Bind raw body input to url of requests

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -583,14 +583,20 @@
           } else return ''
         }
         let flats = ['method', 'url', 'path', 'auth', 'httpUser', 'httpPassword', 'bearerToken', 'contentType'].map(item => flat(item))
-        let deeps = ['headers', 'params', 'bodyParams'].map(item => deep(item))
-        this.$router.replace('/?' + flats.concat(deeps).join('').slice(0, -1))
+        let deeps = ['headers', 'params'].map(item => deep(item))
+        let bodyParams = this.rawInput ? [flat('rawParams')] : [deep('bodyParams')]; 
+        
+        this.$router.replace('/?' + flats.concat(deeps, bodyParams).join('').slice(0, -1))
       },
       setRouteQueries(queries) {
         if (typeof(queries) !== 'object') throw new Error('Route query parameters must be a Object')
         for (const key in queries) {
           if (key === 'headers' || key === 'params' || key === 'bodyParams') this[key] = JSON.parse(queries[key])
-          else if (typeof(this[key]) === 'string') this[key] = queries[key];
+          if (key === 'rawParams') {
+            this.rawInput = true
+            this.rawParams = queries['rawParams']
+          }
+          else if (typeof(this[key]) === 'string') this[key] = queries[key]
         }
       },
       observeRequestButton() {
@@ -623,11 +629,11 @@
         vm.headers,
         vm.params,
         vm.bodyParams,
-        vm.contentType
+        vm.contentType,
+        vm.rawParams
       ], val => {
         this.setRouteQueryState()
       })
-
     }
   }
 


### PR DESCRIPTION
Enable raw input binding to the url. Raw inputs are now shareable. Example:
[/?method=PUT&rawParams={"foo":"bar","col":[1,2,3]}](https://yubathom.github.io/postwoman/?method=PUT&rawParams=%7B%0A%22foo%22%3A%22bar%22,%0A%22col%22%3A%5B1,2,3%5D%0A%7D)
