### PR TITLE
Update url at keyup and at bodyParam/rawParam toggle state changes

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -95,11 +95,11 @@
         <ol v-for="(param, index) in bodyParams">
           <li>
             <label :for="'bparam'+index">Key {{index + 1}}</label>
-            <input :name="'bparam'+index" v-model="param.key">
+            <input :name="'bparam'+index" v-model="param.key" @keyup.prevent="setRouteQueryState">
           </li>
           <li>
             <label :for="'bvalue'+index">Value {{index + 1}}</label>
-            <input :name="'bvalue'+index" v-model="param.value">
+            <input :name="'bvalue'+index" v-model="param.value" @keyup.prevent="setRouteQueryState">
           </li>
           <li>
             <label class="hide-on-small-screen" for="request">&nbsp;</label>
@@ -199,11 +199,11 @@
       <ol v-for="(header, index) in headers">
         <li>
           <label :for="'header'+index">Key {{index + 1}}</label>
-          <input :name="'header'+index" v-model="header.key">
+          <input :name="'header'+index" v-model="header.key" @keyup.prevent="setRouteQueryState">
         </li>
         <li>
           <label :for="'value'+index">Value {{index + 1}}</label>
-          <input :name="'value'+index" v-model="header.value">
+          <input :name="'value'+index" v-model="header.value" @keyup.prevent="setRouteQueryState">
         </li>
         <li>
           <label class="hide-on-small-screen" for="header">&nbsp;</label>
@@ -369,6 +369,10 @@
     watch: {
       contentType(val) {
         this.rawInput = !this.knownContentTypes.includes(val);
+      },
+      rawInput (status) {
+        if (status && this.rawParams === '') this.rawParams = '{}'
+        else this.setRouteQueryState()
       }
     },
     computed: {


### PR DESCRIPTION
Update url at keyup at key-value params (bodyParams and headers) and bodyParam/rawParam at toggle state changes.

Fix [this](https://github.com/liyasthomas/postwoman/pull/118#issuecomment-527864188):
> 
> 
> @yubathom I've found an issue. Raw parameters are binded to URL automatically whereas key-value params are only binded to URL on adding another key-value pair. And when switching from raw parameters to key-value and vice versa, parameters are only binded after a change in input. Check on your free time.


This PR is related to #29.
And is an update of #72, #118 and #131 .