### PR TITLE
fix: error color for light mode

### DIFF
--- a/assets/css/themes.scss
+++ b/assets/css/themes.scss
@@ -63,7 +63,7 @@
   // Border color
   --brd-color: #f2f2f2;
   // Error color
-  --err-color: invert(#303341, 1);
+  --err-color: #e8f0fe;
   // Acent color
   --ac-color: #57b5f9;
   // Active text color


### PR DESCRIPTION
In light mode the URL field becomes "transparent" when you delete the value.

![Captura de Tela 2019-10-01 às 08 31 50](https://user-images.githubusercontent.com/4539235/65958705-6a9bdb00-e426-11e9-9150-df845361e2d9.png)

Set the same color as `bg-dark-color`, just like other themes.