### PR TITLE
Add Request name label for every requests

### DIFF
--- a/components/history.vue
+++ b/components/history.vue
@@ -6,6 +6,9 @@
       </li>
     </ul>
     <ul>
+      <li @click="sort_by_label()">
+        <label for="" class="flex-wrap">Name<i class="material-icons">sort</i></label>
+      </li>
       <li @click="sort_by_time()">
         <label for="" class="flex-wrap">Time<i class="material-icons">sort</i></label>
       </li>
@@ -21,6 +24,9 @@
     </ul>
     <virtual-list class="virtual-list" :class="{filled: filteredHistory.length}" :size="54" :remain="Math.min(5, filteredHistory.length)">
       <ul v-for="(entry, index) in filteredHistory" :key="index" class="entry">
+        <li>
+          <input aria-label="Label" type="text" readonly :value="entry.label" :title="entry.label">
+        </li>
         <li>
           <input aria-label="Time" type="text" readonly :value="entry.time" :title="entry.date">
         </li>
@@ -104,7 +110,8 @@
         reverse_sort_time: false,
         reverse_sort_status_code: false,
         reverse_sort_url: false,
-        reverse_sort_path: false
+        reverse_sort_path: false,
+        reverse_sort_label: false
       }
     },
     computed: {
@@ -191,12 +198,23 @@
         let byUrl = this.history.slice(0);
         byUrl.sort((a, b)=>{
           if(this.reverse_sort_url)
-            return a.url == b.url ? 0 : +(a.url < b.url) || -1;
+            return a.url === b.url ? 0 : +(a.url < b.url) || -1;
           else
-            return a.url == b.url ? 0 : +(a.url > b.url) || -1;
+            return a.url === b.url ? 0 : +(a.url > b.url) || -1;
         });
         this.history = byUrl;
         this.reverse_sort_url = !this.reverse_sort_url;
+      },
+      sort_by_label() {
+        let byLabel = this.history.slice(0);
+        byLabel.sort((a, b)=>{
+          if(this.reverse_sort_label)
+            return a.label === b.label ? 0 : +(a.label < b.label) || -1;
+          else
+            return a.label === b.label ? 0 : +(a.label > b.label) || -1;
+        });
+        this.history = byLabel;
+        this.reverse_sort_label = !this.reverse_sort_label;
       },
       sort_by_path() {
         let byPath = this.history.slice(0);

--- a/components/history.vue
+++ b/components/history.vue
@@ -107,11 +107,11 @@
         filterText: '',
         showFilter: false,
         isClearingHistory: false,
+        reverse_sort_label: false,
         reverse_sort_time: false,
         reverse_sort_status_code: false,
         reverse_sort_url: false,
-        reverse_sort_path: false,
-        reverse_sort_label: false
+        reverse_sort_path: false
       }
     },
     computed: {
@@ -198,9 +198,9 @@
         let byUrl = this.history.slice(0);
         byUrl.sort((a, b)=>{
           if(this.reverse_sort_url)
-            return a.url === b.url ? 0 : +(a.url < b.url) || -1;
+            return a.url == b.url ? 0 : +(a.url < b.url) || -1;
           else
-            return a.url === b.url ? 0 : +(a.url > b.url) || -1;
+            return a.url == b.url ? 0 : +(a.url > b.url) || -1;
         });
         this.history = byUrl;
         this.reverse_sort_url = !this.reverse_sort_url;
@@ -209,9 +209,9 @@
         let byLabel = this.history.slice(0);
         byLabel.sort((a, b)=>{
           if(this.reverse_sort_label)
-            return a.label === b.label ? 0 : +(a.label < b.label) || -1;
+            return a.label == b.label ? 0 : +(a.label < b.label) || -1;
           else
-            return a.label === b.label ? 0 : +(a.label > b.label) || -1;
+            return a.label == b.label ? 0 : +(a.label > b.label) || -1;
         });
         this.history = byLabel;
         this.reverse_sort_label = !this.reverse_sort_label;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page">
-      <input :class="{ error: !requestName }" @keyup.enter="requestName ? validRequestName() : null" id="label" name="label" type="label" v-model="label">
+      <input @keyup.enter="requestName" id="label" name="label" type="label" v-model="label">
     <pw-modal v-if="showModal" @close="showModal = false">
       <div slot="header">
         <ul>
@@ -523,7 +523,7 @@
     },
     computed: {
       requestName() {
-        return this.label.match(/^([^?]*)\??/)[1]
+        return this.label
       },
       statusCategory() {
         return findStatusGroup(this.response.status);
@@ -691,13 +691,6 @@
           behavior: 'smooth'
         });
       },
-      async validRequestName() {
-        if (!this.requestName) {
-          this.$toast.error('Request Name is not valid', {
-            icon: 'error'
-          });
-          return;
-        }},
       async sendRequest() {
         if (!this.isValidURL) {
           this.$toast.error('URL is not formatted properly', {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="page">
+      <input :class="{ error: !requestName }" @keyup.enter="requestName ? validRequestName() : null" id="label" name="label" type="label" v-model="label">
     <pw-modal v-if="showModal" @close="showModal = false">
       <div slot="header">
         <ul>
@@ -416,6 +417,7 @@
     },
     data() {
       return {
+        label:'Enter request name',
         showModal: false,
         copyButton: '<i class="material-icons">file_copy</i>',
         copiedButton: '<i class="material-icons">done</i>',
@@ -520,6 +522,9 @@
       }
     },
     computed: {
+      requestName() {
+        return this.label.match(/^([^?]*)\??/)[1]
+      },
       statusCategory() {
         return findStatusGroup(this.response.status);
       },
@@ -686,6 +691,13 @@
           behavior: 'smooth'
         });
       },
+      async validRequestName() {
+        if (!this.requestName) {
+          this.$toast.error('Request Name is not valid', {
+            icon: 'error'
+          });
+          return;
+        }},
       async sendRequest() {
         if (!this.isValidURL) {
           this.$toast.error('URL is not formatted properly', {
@@ -773,6 +785,7 @@
 
             // Addition of an entry to the history component.
             const entry = {
+              label: this.requestName,
               status,
               date,
               time,
@@ -790,6 +803,7 @@
 
             // Addition of an entry to the history component.
             const entry = {
+              label: this.requestName,
               status: this.response.status,
               date: new Date().toLocaleDateString(),
               time: new Date().toLocaleTimeString(),
@@ -1043,6 +1057,7 @@
             this.params = [];
             break;
           default:
+            this.label = '',
             this.method= 'GET',
             this.url = 'https://reqres.in',
             this.auth = 'None',
@@ -1066,6 +1081,7 @@
     created() {
       if (Object.keys(this.$route.query).length) this.setRouteQueries(this.$route.query);
       this.$watch(vm => [
+        vm.label,
         vm.method,
         vm.url,
         vm.auth,


### PR DESCRIPTION
This pull request is based on issue #133 

I've added a field to Enter the request name for each request. Please find the screenshot below - 

<img width="1196" alt="Screenshot 2019-10-04 at 2 47 24 PM" src="https://user-images.githubusercontent.com/25933070/66196321-f11a1c00-e6b5-11e9-8f38-661733cebbbf.png">

Ideally, the same request name should be listed down in the History section of the request. The changes are also made in the corresponding files.
