### PR TITLE
Add quotation marks for generated code

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -615,7 +615,7 @@
         } else if (this.requestType == 'Fetch') {
           var requestString = [];
           var headers = [];
-          requestString.push('fetch(' + this.url + this.path + this.queryString + ', {\n')
+          requestString.push('fetch("' + this.url + this.path + this.queryString + '", {\n')
           requestString.push('  method: "' + this.method + '",\n')
           if (this.auth === 'Basic') {
             var basic = this.httpUser + ':' + this.httpPassword;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -593,7 +593,7 @@
           requestString.push('const xhr = new XMLHttpRequest()');
           const user = this.auth === 'Basic' ? this.httpUser : null
           const pswd = this.auth === 'Basic' ? this.httpPassword : null
-          requestString.push('xhr.open(' + this.method + ', ' + this.url + this.path + this.queryString + ', true, ' +
+          requestString.push('xhr.open("' + this.method + '", "' + this.url + this.path + this.queryString + '", true, ' +
             user + ', ' + pswd + ')');
           if (this.auth === 'Bearer Token') {
             requestString.push("xhr.setRequestHeader('Authorization', 'Bearer ' + " + this.bearerToken + ")");


### PR DESCRIPTION
This fixes an issue where the generated code for Javascript XHR and Fetch are missing quotation marks preventing the user from easily coping and pasting the code.