### PR TITLE
fix: don't display 'Collection is empty' label if collection has any …

### DIFF
--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -41,7 +41,7 @@
                         v-on:edit-folder="editFolder"
                     />
                 </li>
-                <li v-if="collection.folders.length === 0">
+                <li v-if="(collection.folders.length === 0) && (collection.requests.length === 0)">
                   <label>Collection is empty</label>
                 </li>
             </ul>


### PR DESCRIPTION
…requests