### PR TITLE
Fixed frame colors toggle

### DIFF
--- a/components/section.vue
+++ b/components/section.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset :id="label.toLowerCase()" :class="{ 'no-colored-frames': noFrameColors }">
+  <fieldset :id="label.toLowerCase()" :class="{ 'no-colored-frames': !frameColorsEnabled }">
     <legend @click.prevent="collapse">
       <i class="material-icons icon">{{ icon }}</i>
       <span>{{ label }}</span>
@@ -24,8 +24,8 @@
 <script>
   export default {
     computed: {
-      noFrameColors() {
-        return this.$store.state.postwoman.settings.DISABLE_FRAME_COLORS || false;
+      frameColorsEnabled() {
+        return this.$store.state.postwoman.settings.FRAME_COLORS_ENABLED || false;
       }
     },
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -51,6 +51,7 @@
       <ul>
         <li>
           <pw-toggle
+            :on="settings.PROXY_ENABLED"
             @change="applySetting('PROXY_ENABLED', $event)"
           >Proxy {{ settings.PROXY_ENABLED ? "enabled" : "disabled" }}</pw-toggle>
         </li>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -40,9 +40,9 @@
           <h3 class="title">Frames</h3>
           <span>
             <pw-toggle
-              :on="!settings.DISABLE_FRAME_COLORS"
-              @change="applySetting('DISABLE_FRAME_COLORS', $event)"
-            >Multi-color {{ settings.DISABLE_FRAME_COLORS ? "Disabled" : "Enabled" }}</pw-toggle>
+              :on="settings.FRAME_COLORS_ENABLED"
+              @change="applySetting('FRAME_COLORS_ENABLED', $event)"
+            >Multi-color {{ settings.FRAME_COLORS_ENABLED ? "Enabled" : "Disabled" }}</pw-toggle>
           </span>
         </li>
       </ul>
@@ -51,7 +51,6 @@
       <ul>
         <li>
           <pw-toggle
-            :on="settings.PROXY_ENABLED"
             @change="applySetting('PROXY_ENABLED', $event)"
           >Proxy {{ settings.PROXY_ENABLED ? "enabled" : "disabled" }}</pw-toggle>
         </li>
@@ -165,9 +164,8 @@
           THEME_CLASS: this.$store.state.postwoman.settings.THEME_CLASS || "",
           THEME_COLOR: "",
           THEME_COLOR_VIBRANT: true,
-
-          DISABLE_FRAME_COLORS:
-            this.$store.state.postwoman.settings.DISABLE_FRAME_COLORS || false,
+          FRAME_COLORS_ENABLED:
+            this.$store.state.postwoman.settings.FRAME_COLORS_ENABLED || false,
           PROXY_ENABLED:
             this.$store.state.postwoman.settings.PROXY_ENABLED || false,
           PROXY_URL: this.$store.state.postwoman.settings.PROXY_URL || "",
@@ -219,6 +217,7 @@
         ).toUpperCase()}`;
       },
       applySetting(key, value) {
+        console.log(key, value)
         this.settings[key] = value;
         this.$store.commit("postwoman/applySetting", [key, value]);
       },

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -41,7 +41,7 @@
           <span>
             <pw-toggle
               :on="settings.FRAME_COLORS_ENABLED"
-              @change="applySetting('FRAME_COLORS_ENABLED', $event)"
+              @change="toggleSetting('FRAME_COLORS_ENABLED')"
             >Multi-color {{ settings.FRAME_COLORS_ENABLED ? "Enabled" : "Disabled" }}</pw-toggle>
           </span>
         </li>
@@ -52,7 +52,7 @@
         <li>
           <pw-toggle
             :on="settings.PROXY_ENABLED"
-            @change="applySetting('PROXY_ENABLED', $event)"
+            @change="toggleSetting('PROXY_ENABLED')"
           >Proxy {{ settings.PROXY_ENABLED ? "enabled" : "disabled" }}</pw-toggle>
         </li>
       </ul>
@@ -165,6 +165,7 @@
           THEME_CLASS: this.$store.state.postwoman.settings.THEME_CLASS || "",
           THEME_COLOR: "",
           THEME_COLOR_VIBRANT: true,
+
           FRAME_COLORS_ENABLED:
             this.$store.state.postwoman.settings.FRAME_COLORS_ENABLED || false,
           PROXY_ENABLED:
@@ -218,7 +219,6 @@
         ).toUpperCase()}`;
       },
       applySetting(key, value) {
-        console.log(key, value)
         this.settings[key] = value;
         this.$store.commit("postwoman/applySetting", [key, value]);
       },

--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -26,7 +26,7 @@ export const SETTINGS_KEYS = [
    * to emphasise the different sections.
    * This setting allows that to be turned off.
    */
-  "DISABLE_FRAME_COLORS",
+  "FRAME_COLORS_ENABLED",
 
   /**
    * Whether or not requests should be proxied.


### PR DESCRIPTION
There ~is~ was a bug on frame colors toggle. When you click once the toggle changes.
- Change the setting name to `FRAME_COLORS_ENABLED` to match the pattern and improve readability
- Using `toggleSetting` method for toggle components

To reproduce this bug, just open https://postwoman.io/settings and try to toggle Multi-Color in Frames section

fixed: https://www.loom.com/share/bd598afe32b44cb583fed608ccb50584