### PR TITLE
bodyParams and params equal when method change

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1531,8 +1531,13 @@ export default {
         this.setRouteQueryState();
     },
     methodChange() {
-      // this.$store.commit('setState', { 'value': ["POST", "PUT", "PATCH"].includes(this.method) ? 'application/json' : '', 'attribute': 'contentType' })
-      this.contentType = ["POST", "PUT", "PATCH"].includes(this.method) ? 'application/json' : '';
+      if(["POST", "PUT", "PATCH"].includes(this.method)) {
+        this.contentType = 'application/json';
+        this.bodyParams = this.params
+      } else {
+        this.contentType = 'application/json';
+        this.params = this.bodyParams
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
I don't know if that makes sense, but I think when method change `bodyParams` and `params` should be the same

### Now (postwoman.io)
![image](https://user-images.githubusercontent.com/52707897/67637307-f256f700-f8b7-11e9-9940-113c2818a549.png)

when I change to POST `bodyParams` is empty

![image](https://user-images.githubusercontent.com/52707897/67637336-58dc1500-f8b8-11e9-9350-ff55e84e276c.png)

### This PR
![image](https://user-images.githubusercontent.com/52707897/67637354-a22c6480-f8b8-11e9-8f1e-6df2468eb91f.png)

when I change to POST `bodyParams` are equal to `params`

![image](https://user-images.githubusercontent.com/52707897/67637361-b8d2bb80-f8b8-11e9-882f-a79377526743.png)
