### PR TITLE
Feature/pre request script

### DIFF
--- a/components/history.vue
+++ b/components/history.vue
@@ -12,6 +12,7 @@
       </li>
     </ul>
     <ul>
+      <li style="max-width: 44px"></li>
       <li @click="sort_by_label()">
         <label class="flex-wrap">
           Label
@@ -50,6 +51,12 @@
       :remain="Math.min(5, filteredHistory.length)"
     >
       <ul v-for="(entry, index) in filteredHistory" :key="index" class="entry">
+        <li style="width: 44px">
+          <button v-if="entry.usesScripts"
+            v-tooltip="'This entry used pre-request scripts.'"
+            class="icon"
+          ><i class="material-icons" style="z-index: 10050;">code</i></button>
+        </li>
         <li>
           <input
             aria-label="Label"

--- a/functions/preRequest.js
+++ b/functions/preRequest.js
@@ -1,0 +1,17 @@
+export default function getEnvironmentVariablesFromScript(script) {
+  let _variables = {};
+
+  // the pw object is the proxy by which pre-request scripts can pass variables to the request.
+  // for security and control purposes, this is the only way a pre-request script should modify variables.
+  let pw = {
+    environment: {
+      set: (key, value) => _variables[key] = value,
+    },
+    // globals that the script is allowed to have access to.
+  };
+
+  // run pre-request script within this function so that it has access to the pw object.
+  (new Function('pw', script))(pw);
+
+  return _variables;
+}

--- a/functions/templating.js
+++ b/functions/templating.js
@@ -1,4 +1,7 @@
 export default function parseTemplateString(string, variables) {
-    const searchTerm = /\${([^}]*)}/g; // "${myVariable}"
+    if(!variables || !string) {
+      return string;
+    }
+    const searchTerm = /<<([^>]*)>>/g; // "<<myVariable>>"
     return string.replace(searchTerm, (match, p1) => variables[p1] || '');
 }

--- a/functions/templating.js
+++ b/functions/templating.js
@@ -1,0 +1,4 @@
+export default function parseTemplateString(string, variables) {
+    const searchTerm = /\${([^}]*)}/g; // "${myVariable}"
+    return string.replace(searchTerm, (match, p1) => variables[p1] || '');
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1052,7 +1052,14 @@ export default {
       if (preRequestScript) {
         const environmentVariables = getEnvironmentVariablesFromScript(preRequestScript);
         requestOptions.url = parseTemplateString(requestOptions.url, environmentVariables);
-        //TODO parse all other headers
+        requestOptions.data = parseTemplateString(requestOptions.data, environmentVariables);
+        for (let k in requestOptions.headers) {
+          const kParsed = parseTemplateString(k, environmentVariables);
+          const valParsed = parseTemplateString(requestOptions.headers[k], environmentVariables);
+          delete requestOptions.headers[k];
+          requestOptions.headers[kParsed] = valParsed;
+        }
+
       }
       if (typeof requestOptions.data === 'string') {
         requestOptions.data = parseTemplateString(requestOptions.data);
@@ -1145,7 +1152,7 @@ export default {
       try {
         const startTime = Date.now();
 
-        const payload = await this.makeRequest(auth, headers, requestBody, this.preRequestScript);
+        const payload = await this.makeRequest(auth, headers, requestBody, this.showPreRequestScript && this.preRequestScript);
 
         const duration = Date.now() - startTime;
         this.$toast.info(`Finished in ${duration}ms`, {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,6 +5,7 @@
       v-on:hide-model="hideRequestModal"
       v-bind:editing-request="editRequest"
     ></save-request-as>
+
     <pw-modal v-if="showModal" @close="showModal = false">
       <div slot="header">
         <ul>
@@ -38,9 +39,11 @@
         </ul>
       </div>
     </pw-modal>
-    <pw-section v-if="showPreRequestScript" label="Pre-Request" ref="preRequest">
+
+    <pw-section v-if="showPreRequestScript" class="orange" icon="code" label="Pre-Request • β (experimental)" ref="preRequest">
       <textarea id="preRequestScript" @keydown="formatRawParams" rows="8" v-model="preRequestScript" v-textarea-auto-height="rawParams" spellcheck="false"></textarea>
     </pw-section>
+
     <pw-section class="blue" icon="cloud_upload" label="Request" ref="request">
       <ul>
         <li>
@@ -200,16 +203,17 @@
             :disabled="!isValidURL"
             v-tooltip.bottom="{ content: isHidden ? 'Show Code' : 'Hide Code'}"
           >
-            <i class="material-icons" v-if="isHidden">visibility</i>
-            <i class="material-icons" v-if="!isHidden">visibility_off</i>
+            <i class="material-icons" v-if="isHidden">flash_on</i>
+            <i class="material-icons" v-if="!isHidden">flash_off</i>
           </button>
           <button
             :class="'icon' + (showPreRequestScript ? ' info-response' : '')"
             id="preRequestScriptButton"
-            v-tooltip.bottom="'Pre-Request Script'"
+            v-tooltip.bottom="{ content: !showPreRequestScript ? 'Show Pre-Request Script' : 'Hide Pre-Request Script'}"
             @click="showPreRequestScript = !showPreRequestScript"
           >
-            <i class="material-icons" :class="showPreRequestScript">code</i>
+            <i class="material-icons" :class="showPreRequestScript" v-if="!showPreRequestScript">code</i>
+            <i class="material-icons" :class="showPreRequestScript" v-if="showPreRequestScript">close</i>
           </button>
         </div>
         <div style="text-align: center;">
@@ -239,7 +243,8 @@
         </div>
       </div>
     </pw-section>
-    <pw-section class="yellow" icon="code" label="Code" ref="requestCode" v-if="!isHidden">
+
+    <pw-section class="yellow" icon="flash_on" label="Code" ref="requestCode" v-if="!isHidden">
       <ul>
         <li>
           <label for="requestType">Request Type</label>


### PR DESCRIPTION
fixes #218 

scrapped the old branch `feature/dynamic-headers` after merge woes (will delete soon).

Lots more to think about, but I feel it satisfies mvp (and would love to get this in master so I can take a break from keeping it up-to-date manually 😅)

Request section has a `code` button. When clicked, it enables pre-request scripts. A pre-request script section appears above where javascript can be entered.

pre-request script has access to a postwoman api object (`pw`) that can be interacted with. Right now the only thing to do is `pw.environment.set("key", "value")` to set a variable that can be used in areas of the request. Note this is native javascript, so any js method can be used. Final values are all treated as strings.

Test by setting something in the pre-request script `pw.environment.set("route", "/api/users");` and replacing parts of the request within double angle brackets (path = `<<route>>`). Response should function the same as if the final value was statically typed.

Additionally, requests made this way end up in history with the same `code` icon. Hovering over it informs the user that this entry in the history used pre-request scripts. Due to it's highly dynamic potential, you could say that note serves as a warning!

tangentially -- @NBTX can you make the request-chaining into its own issue? I realized it's quite separate from this one so it would be good to address that after this. 