### PR TITLE
Make page changes more fluid

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -510,3 +510,7 @@ input[type="radio"]:checked+label+div.tab {
 .toasted.bubble .action {
   color: inherit !important;
 }
+
+.wrapper .content {
+    min-height: 100vh;
+}


### PR DESCRIPTION
A very simple tweak; by making the pages a minimum height of 100vh, it makes the app feel smoother as the footer can be scrolled into view on any page and the app does not 'jump' in height when pages are changed.