### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ _HTML responses have "Preview HTML" feature_
 
 _History entries can be sorted by any fields_
 
-_Histories can deleted one-by-one or all together_
+_Histories can be deleted one-by-one or all together_
 
 📁 **Collections**: Keep your API requests organized with collections and folders. Reuse them with a single click.
 


### PR DESCRIPTION
# Fixed Typo

## Before
``` _Histories can deleted one-by-one or all together_ ```

## AFTER
``` _Histories can be deleted one-by-one or all together_ ```
