### PR TITLE
GraphQL endpoint field is now persisted

### DIFF
--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -136,13 +136,22 @@ export default {
   },
   data() {
     return {
-      url: "https://rickandmortyapi.com/graphql",
       schemaString: "",
       queryFields: [],
       mutationFields: [],
       subscriptionFields: [],
       gqlTypes: []
     };
+  },
+  computed: {
+    url: {
+      get() {
+        return this.$store.state.gql.url;
+      },
+      set(value) {
+        this.$store.commit("setGQLState", { value, attribute: "url" });
+      }
+    }
   },
   methods: {
     copySchema() {

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -3,6 +3,10 @@ export default {
     state.request[object.attribute] = object.value
   },
 
+  setGQLState(state, object) {
+    state.gql[object.attribute] = object.value;
+  },
+
   addHeaders(state, value) {
     state.request.headers.push(value);
   },

--- a/store/state.js
+++ b/store/state.js
@@ -16,5 +16,8 @@ export default () => ({
     rawInput: false,
     requestType: '',
     contentType: '',
+  },
+  gql: {
+    url: 'https://rickandmortyapi.com/graphql'
   }
 });


### PR DESCRIPTION
* A section for GraphQL related fields is added to the global store
* A new reducer `setGQLState` is added to the global store for updating the GQL store
* GraphQL endpoint field is now persisted through the GQL store