### PR TITLE
GraphQL introspection requests now support and respect proxying

### DIFF
--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -175,11 +175,36 @@ export default {
       this.$nuxt.$loading.start();
 
       try {
-        const res = await axios.post(this.url, {
+
+        const query = JSON.stringify({
           query: gql.getIntrospectionQuery()
         });
 
-        const schema = gql.buildClientSchema(res.data.data);
+        const reqOptions = {
+          method: "post",
+          url: this.url,
+          headers: {
+            "content-type": "application/json"
+          },
+          data: query
+        }
+
+        const reqConfig = this.$store.state.postwoman.settings.PROXY_ENABLED
+          ? {
+            method: "post",
+            url: `https://postwoman.apollotv.xyz/`,
+            data: reqOptions
+          }
+          : reqOptions;
+
+
+        const res = await axios(reqConfig);
+
+        const data = this.$store.state.postwoman.settings.PROXY_ENABLED
+          ? res.data
+          : res;
+
+        const schema = gql.buildClientSchema(data.data.data);
         this.schemaString = gql.printSchema(schema, {
           commentDescriptions: true
         });


### PR DESCRIPTION
Pretty much explained by the title. :stuck_out_tongue: 