### PR TITLE
Undo header/param/body param deletion

### DIFF
--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -604,10 +604,22 @@ export default {
       return false;
     },
     removeRequestHeader(index) {
+      // .slice() is used so we get a separate array, rather than just a reference
+      const oldHeaders = this.headers.slice();
+
       this.$store.commit("removeGQLHeader", index);
       this.$toast.error("Deleted", {
-        icon: "delete"
+        icon: "delete",
+        action: {
+          text: "Undo",
+          duration: 4000,
+          onClick: (e, toastObject) => {
+            this.headers = oldHeaders;
+            toastObject.remove();
+          }
+        }
       });
+      console.log(oldHeaders);
     }
   }
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1606,9 +1606,19 @@ export default {
       return false;
     },
     removeRequestHeader(index) {
+      // .slice() gives us an entirely new array rather than giving us just the reference
+      const oldHeaders = this.headers.slice();
+
       this.$store.commit("removeHeaders", index);
       this.$toast.error("Deleted", {
-        icon: "delete"
+        icon: "delete",
+        action: {
+          text: "Undo",
+          onClick: (e, toastObject) => {
+            this.headers = oldHeaders;
+            toastObject.remove();
+          }
+        }
       });
     },
     addRequestParam() {
@@ -1616,9 +1626,19 @@ export default {
       return false;
     },
     removeRequestParam(index) {
+      // .slice() gives us an entirely new array rather than giving us just the reference
+      const oldParams = this.params.slice();
+
       this.$store.commit("removeParams", index);
       this.$toast.error("Deleted", {
-        icon: "delete"
+        icon: "delete",
+        action: {
+          text: "Undo",
+          onClick: (e, toastObject) => {
+            this.params = oldParams;
+            toastObject.remove();
+          }
+        }
       });
     },
     addRequestBodyParam() {
@@ -1626,9 +1646,19 @@ export default {
       return false;
     },
     removeRequestBodyParam(index) {
+      // .slice() gives us an entirely new array rather than giving us just the reference
+      const oldBodyParams = this.bodyParams.slice();
+
       this.$store.commit("removeBodyParams", index);
       this.$toast.error("Deleted", {
-        icon: "delete"
+        icon: "delete",
+        action: {
+          text: "Undo",
+          onClick: (e, toastObject) => {
+            this.bodyParams = oldBodyParams;
+            toastObject.remove();
+          }
+        }
       });
     },
     formatRawParams(event) {


### PR DESCRIPTION
Added the ability to undo header/param/body param deletion.

NOTE : Because toasts are for some reason not appearing in `index.vue`, I haven't tested the code used in that page, but it works in the GraphQL page. I am working really late, so I might have made some mistakes, reviewers, please do check :stuck_out_tongue: 