### PR TITLE
Added nav shortcuts to GraphQL query and response, updated GraphQL shortcut icons

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -273,11 +273,21 @@
               <ul>
                 <li>
                   <a href="#endpoint" v-tooltip.right="$t('endpoint')">
-                    <i class="material-icons">cloud_upload</i>
+                    <i class="material-icons">cloud</i>
                   </a>
                 </li>
                 <li>
                   <a href="#schema" v-tooltip.right="$t('schema')">
+                    <i class="material-icons">assignment_returned</i>
+                  </a>
+                </li>
+                <li>
+                  <a href="#query" v-tooltip.right="$t('query')">
+                    <i class="material-icons">cloud_upload</i>
+                  </a>
+                </li>
+                <li>
+                  <a href="#response" v-tooltip.right="$t('response')">
                     <i class="material-icons">cloud_download</i>
                   </a>
                 </li>


### PR DESCRIPTION
Added the missing shortcuts to query and response panels for GraphQL in the navbar.

Along with that, I updated the icons for the endpoint and schema shortcuts to something which made more sense to me (feel free to edit that out, I am pretty sleep deprived and my eyes maybe deceiving me :sweat_smile: )