### PR TITLE
fix: twitter summary card image url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -151,7 +151,7 @@ export default {
       },
       {
         name: "twitter:image",
-        content: `${routerBase.router.base}logo.jpg`
+        content: "https://postwoman.io/logo.jpg"
       }
     ],
     link: [


### PR DESCRIPTION
According my todays tweet (https://twitter.com/daviddalbusco/status/1200671798708391937?s=20) it seems that the image provided in the meta tag `twitter:image` respectively `./logo.jpg` wasn't interpreted by Twitter.

For DeckDeckGo I use absolute URL and I double checked DEV.to, which also use absolute.

Therefore I think that the image might need to be provide in such form respectively `https://postwoman.io/logo.jpg`

P.S.: I didn't modified the `og:image` because I quickly tested Facebook and it seems they are fine with a relative path