### PR TITLE
Two Way Data Binding (v-model) to Ace Editor component

### DIFF
--- a/components/ace-editor.vue
+++ b/components/ace-editor.vue
@@ -60,10 +60,16 @@ export default {
       ...this.options
     });
 
-    editor.setValue(this.value);
+    if (this.value) editor.setValue(this.value, 1);
 
     this.editor = editor;
     this.cacheValue = this.value;
+    
+    editor.on('change', () => {
+      const content = editor.getValue();
+      this.$emit("input", content);
+      this.cacheValue = content;
+    });
   },
 
   methods: {

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -171,7 +171,17 @@
               </button>
             </div>
           </div>
-          <textarea id="gqlQuery" rows="8" v-model="gqlQueryString"></textarea>
+          <Editor
+            v-model="gqlQueryString"
+            :options="{
+              maxLines: responseBodyMaxLines,
+              minLines: '16',
+              fontSize: '16px',
+              autoScrollEditorIntoView: true,
+              showPrintMargin: false,
+              useWorker: false
+            }"
+          />
         </pw-section>
         <pw-section class="purple" label="Response" ref="response">
           <div class="flex-wrap">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,14 +24,18 @@
                   </a>
                 </div>
               </div>
-              <textarea
-                id="preRequestScript"
-                @keydown="formatRawParams"
-                rows="8"
+              <Editor
                 v-model="preRequestScript"
-                spellcheck="false"
-                placeholder="pw.env.set('variable', 'value');"
-              ></textarea>
+                :lang="'javascript'"
+                :options="{
+                  maxLines: responseBodyMaxLines,
+                  minLines: '16',
+                  fontSize: '16px',
+                  autoScrollEditorIntoView: true,
+                  showPrintMargin: false,
+                  useWorker: false
+                }"
+              />
             </li>
           </ul>
         </pw-section>
@@ -626,7 +630,7 @@
                 </div>
               </div>
               <div id="response-details-wrapper">
-                <ResponseBody
+                <Editor
                   :value="responseBodyText"
                   :lang="responseBodyType"
                   :options="{
@@ -860,7 +864,7 @@ export default {
     autocomplete: () => import("../components/autocomplete"),
     collections: () => import("../components/collections"),
     saveRequestAs: () => import("../components/collections/saveRequestAs"),
-    ResponseBody: AceEditor
+    Editor: AceEditor
   },
   data() {
     return {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -870,7 +870,7 @@ export default {
     return {
       showModal: false,
       showPreRequestScript: false,
-      preRequestScript: "",
+      preRequestScript: "// pw.env.set('variable', 'value');",
       copyButton: '<i class="material-icons">file_copy</i>',
       downloadButton: '<i class="material-icons">get_app</i>',
       doneButton: '<i class="material-icons">done</i>',


### PR DESCRIPTION
Added two way data binding features (v-model) to the Ace Editor component.

Along with that, updated the GraphQL Query Field and the Pre-Request Script field to use this two-way binding supported Ace Editor.

This PR fixes #235 .

( alright, imma gonna sleep now :sweat_smile: )