### PR TITLE
[Fix #417] Set detectBrowserLanguage as false to i18n

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -349,6 +349,7 @@ export default {
       }
     ],
     defaultLocale: "en",
+    detectBrowserLanguage: false,
     lazy: true,
     langDir: "lang/"
   },


### PR DESCRIPTION
Fix #417 

# Scope of work

Set `detectBrowserLanguage` as `false` to `i18n`