### PR TITLE
Add proxy auto-detection.

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -925,3 +925,8 @@ input[type="radio"]:checked + label + .tab {
     margin-bottom: 68px;
   }
 }
+
+.inline-icon {
+  font-size: 16pt !important;
+  vertical-align: middle;
+}

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -85,5 +85,16 @@ export default {
   connect: "Connect",
   disconnect: "Disconnect",
   start: "Start",
-  stop: "Stop"
+  stop: "Stop",
+  key: "Key",
+  leave_key_blank_if_not_required: "If the Proxy does not require a key, you can leave this blank.",
+  local_proxy_detected: "Local Proxy Detected...",
+  local_proxy_detected_description: "A local instance of the Postwoman Proxy server has been detected running at:",
+  local_proxy_detected_prompt: "Would you like Postwoman to use this proxy server to make requests?",
+  local_proxy_protected: "The proxy server requires an access token to use it. Please enter it to use this proxy server:",
+  yes: "Yes",
+  no: "No",
+  continue: "Continue...",
+  cancel: "Cancel",
+  proxy_authentication_error: "Proxy authentication failed. Please check the access token and try again."
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1559,13 +1559,16 @@ export default {
       if (typeof requestOptions.data === "string") {
         requestOptions.data = parseTemplateString(requestOptions.data);
       }
+
       const config = this.$store.state.postwoman.settings.PROXY_ENABLED
         ? {
             method: "POST",
             url:
               this.$store.state.postwoman.settings.PROXY_URL ||
               "https://postwoman.apollotv.xyz/",
-            data: requestOptions
+            data: Object.assign(requestOptions, {
+              accessToken: this.$store.state.postwoman.settings.PROXY_KEY || null
+            })
           }
         : requestOptions;
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -103,6 +103,27 @@
           />
         </li>
       </ul>
+      <ul>
+        <li>
+          <div class="flex-wrap">
+            <label for="key">{{ $t("key") }}</label>
+            <button
+              class="icon"
+              @click="settings.PROXY_KEY = ``"
+              v-tooltip.bottom="'Reset to default'"
+            >
+              <i class="material-icons">clear_all</i>
+            </button>
+          </div>
+          <input
+            id="key"
+            type="text"
+            v-model="settings.PROXY_KEY"
+            :disabled="!settings.PROXY_ENABLED"
+          />
+          <p class="info"><i class="material-icons inline-icon">info</i> {{ $t("leave_key_blank_if_not_required") }}</p>
+        </li>
+      </ul>
       <ul class="info">
         <li>
           <p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43181178/71216729-36141e80-22b3-11ea-851e-5003109974f0.png)

![image](https://user-images.githubusercontent.com/43181178/71216745-3f04f000-22b3-11ea-9797-1a1429015899.png)

This obviously includes changes to the `lang` strings.

---

The proxy auto-detection is shown under the following criteria:
1. the user is running the postwoman-proxy application locally, and has installed the SSL certificates,
2. the user is not already using a functioning proxy server.