### PR TITLE
Added variables to graphql page.

### DIFF
--- a/lang/de-DE.js
+++ b/lang/de-DE.js
@@ -66,6 +66,7 @@ export default {
   response: "Antwort",
   query: "Abfrage",
   queries: "Abfragen",
+  query_variables: "Variablen",
   mutations: "Mutationen",
   subscriptions: "Abonnements",
   types: "Typen",

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -66,6 +66,7 @@ export default {
   response: "Response",
   query: "Query",
   queries: "Queries",
+  query_variables: "Variables",
   mutations: "Mutations",
   subscriptions: "Subscriptions",
   types: "Types",

--- a/lang/es-ES.js
+++ b/lang/es-ES.js
@@ -66,6 +66,7 @@ export default {
   response: "Respuesta",
   query: "Consulta",
   queries: "Consultas",
+  query_variables: "Variables",
   mutations: "Mutaciones",
   subscriptions: "Subscripciones",
   types: "Tipos",

--- a/lang/fa-IR.js
+++ b/lang/fa-IR.js
@@ -66,6 +66,7 @@ export default {
   response: "Response",
   query: "Query",
   queries: "Queries",
+  query_variables: "Variables",
   mutations: "Mutations",
   subscriptions: "Subscriptions",
   types: "Types",

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -66,6 +66,7 @@ export default {
   response: "Réponse",
   query: "Requête",
   queries: "Requêtes",
+  query_variables: "Variables",
   mutations: "Mutations",
   subscriptions: "Abonnements",
   types: "Types",

--- a/lang/id-ID.js
+++ b/lang/id-ID.js
@@ -66,6 +66,7 @@ export default {
   response: "Balasan",
   query: "Kueri",
   queries: "Kueri",
+  query_variables: "Variables",
   mutations: "Mutasi",
   subscriptions: "Langganan",
   types: "Jenis",

--- a/lang/ja-JP.js
+++ b/lang/ja-JP.js
@@ -66,6 +66,7 @@ export default {
   response: "レスポンス",
   query: "クエリ",
   queries: "クエリ",
+  query_variables: "変数 (へんすう)",
   mutations: "ミューテーション",
   subscriptions: "サブスクリプション",
   types: "タイプ",

--- a/lang/pt-BR.js
+++ b/lang/pt-BR.js
@@ -66,6 +66,7 @@ export default {
   response: "Response",
   query: "Query",
   queries: "Queries",
+  query_variables: "Variáveis",
   mutations: "Mutações",
   subscriptions: "Assinaturas",
   types: "Tipos",

--- a/lang/tr-TR.js
+++ b/lang/tr-TR.js
@@ -66,6 +66,7 @@ export default {
   response: "Cevap",
   query: "Sorgu",
   queries: "Sorgular",
+  query_variables: "Değişkenler",
   mutations: "Değişimler",
   subscriptions: "Aboneler",
   types: "Tipler",

--- a/lang/zh-CN.js
+++ b/lang/zh-CN.js
@@ -66,6 +66,7 @@ export default {
   response: "响应",
   query: "查询",
   queries: "查询",
+  query_variables: "变数",
   mutations: "Mutations",
   subscriptions: "订阅",
   types: "种类",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11286,8 +11286,7 @@
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "bundled": true,
-                            "optional": true
+                            "bundled": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -11427,7 +11426,6 @@
                         "minipass": {
                             "version": "2.9.0",
                             "bundled": true,
-                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -11444,7 +11442,6 @@
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
-                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -11536,7 +11533,6 @@
                         "once": {
                             "version": "1.4.0",
                             "bundled": true,
-                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -11612,8 +11608,7 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "bundled": true,
-                            "optional": true
+                            "bundled": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -11643,7 +11638,6 @@
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -11700,13 +11694,11 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "bundled": true,
-                            "optional": true
+                            "bundled": true
                         },
                         "yallist": {
                             "version": "3.1.1",
-                            "bundled": true,
-                            "optional": true
+                            "bundled": true
                         }
                     }
                 },

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -23,6 +23,22 @@ export default {
     gql.headers[index].value = value;
   },
 
+  addGQLVariable({ gql }, object) {
+    gql.variables.push(object);
+  },
+
+  removeGQLVariable({ gql }, index) {
+    gql.variables.splice(index, 1);
+  },
+
+  setGQLVariableKey({ gql }, { index, value }) {
+    gql.variables[index].key = value;
+  },
+
+  setGQLVariableValue({ gql }, { index, value }) {
+    gql.variables[index].value = value;
+  },
+
   addHeaders({ request }, value) {
     request.headers.push(value);
   },

--- a/store/state.js
+++ b/store/state.js
@@ -20,6 +20,7 @@ export default () => ({
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],
+    variables: [],
     query: ""
   }
 });


### PR DESCRIPTION
Added the ability to add variables for queries.
E.g. if you do the following query:
```gql
query MySearch($limit: Int, $where: JSON) {
  nodes(limit: $limit, where: $where) {
    id
    title
  }
}
```
You can now add the variables `$limit` and `$where`.

![image](https://user-images.githubusercontent.com/6832715/71622692-805ca000-2bcf-11ea-99a6-465a53c6fb95.png)

There is still one problem which requires discussion:
The type validation of variables is required. So if it's an `Int` it needs to be converted. I've done it with a regex for now, but apollo-client would do better with this. I wasn't really sure if I should introduce a new dependency or not.