### PR TITLE
Firefox Extension compatibility

### DIFF
--- a/functions/network.js
+++ b/functions/network.js
@@ -4,6 +4,11 @@ import FirefoxStrategy from "./strategies/FirefoxStrategy";
 
 
 const runAppropriateStrategy = (req, store) => {
+  // The firefox plugin injects a function to send requests through it
+  // If that is available, then we can use the FirefoxStrategy
+  if (window.firefoxExtSendRequest) {
+    return FirefoxStrategy(req, store); 
+  }
 
   if (store.state.postwoman.settings.PROXY_ENABLED) {
     return ProxyStrategy(req, store);

--- a/functions/network.js
+++ b/functions/network.js
@@ -1,12 +1,19 @@
 import AxiosStrategy from "./strategies/AxiosStrategy";
 import ProxyStrategy from "./strategies/ProxyStrategy";
+import FirefoxStrategy from "./strategies/FirefoxStrategy";
 
-const sendNetworkRequest = (req, store) => {
+
+const runAppropriateStrategy = (req, store) => {
+
   if (store.state.postwoman.settings.PROXY_ENABLED) {
     return ProxyStrategy(req, store);
   }
 
   return AxiosStrategy(req, store);
-};
+}
+
+const sendNetworkRequest = (req, store) => 
+  runAppropriateStrategy(req, store)
+    .finally(() => window.$nuxt.$loading.finish());
 
 export { sendNetworkRequest };

--- a/functions/strategies/AxiosStrategy.js
+++ b/functions/strategies/AxiosStrategy.js
@@ -2,7 +2,6 @@ import axios from "axios";
 
 const axiosStrategy = async (req, _store) => {
   const res = await axios(req);
-  window.$nuxt.$loading.finish();
   return res;
 };
 

--- a/functions/strategies/FirefoxStrategy.js
+++ b/functions/strategies/FirefoxStrategy.js
@@ -1,0 +1,15 @@
+const firefoxStrategy = (req, _store) => new Promise((resolve, reject) => {
+
+  const eventListener = (event) => {
+    window.removeEventListener("firefoxExtSendRequestComplete", eventListener);
+
+    if (event.detail.error) reject(JSON.parse(event.detail.error));
+    else resolve(JSON.parse(event.detail.response));
+  };
+
+  window.addEventListener("firefoxExtSendRequestComplete", eventListener);
+
+  window.firefoxExtSendRequest(req);
+});
+
+export default firefoxStrategy;

--- a/functions/strategies/ProxyStrategy.js
+++ b/functions/strategies/ProxyStrategy.js
@@ -6,7 +6,6 @@ const proxyStrategy = async (req, store) => {
       "https://postwoman.apollotv.xyz/",
     req
   );
-  window.$nuxt.$loading.finish();
   return data;
 };
 


### PR DESCRIPTION
This PR intends to introduce compatibility with [Postwoman Firefox Extension](https://addons.mozilla.org/en-US/firefox/addon/postwoman/)

This adds a new NetworkStrategy to hook with the Firefox Content Script to run the query.

### NOTE
Do NOT use the extension from the store to test the strategy, because, the extension is configured to only hook into the postwoman.io and postwoman.netlify.com domains. Other domains won't get hooked and hence won't get access to the extension hooks.

So, to test this PR, you have to clone the [postwoman-firefox](https://github.com/AndrewBastin/postwoman-firefox) repo.

Then head into the `manifest.json` file and edit it to match this snippet below

```
 "content_scripts": [
    {
      "matches": [
        "*://*/*",
        "https://postwoman.io/",
        "https://postwoman.io/*",
        "https://postwoman.netlify.com/*",
        "https://postwoman.netlify.com/"
      ],
      "js": [ "index.js" ]
    }
  ],
```

Then run `npm install` and then `npm run build`.
NOTE: `npm run build` may fail on non-Unix compliant systems as it uses the cp command, if it fails, just copy the icons folder and the manifest.json to the dist folder

This will create a folder called dist with the generated code.

Then, open Firefox and navigate to `about:debugging`, select `This Firefox` and the click on `Load Temporary Add-on...` and then select the manifest.json file in the generated dist folder.

After this you can navigate to the Postwoman app in localhost and access it, you can check if the hook was successful or not by opening the console on the Postwoman app and checking for the log "Connected to the Postwoman Firefox Extension!" after load.

Once that is done, just fire a request anywhere and you will see that CORS restrictions won't be applied.