### PR TITLE
update e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ sw.*
 
 # File explorer
 .directory
+
+# Tests screenshots
+tests/*/screenshots
+
+# Tests videos
+tests/*/videos

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
   - "npm install"
 
 before_script:
+  - "npm run build" # use nuxt build and start to run tests
   - "npm run test"
 
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,10 +1169,10 @@
             "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
             "dev": true
         },
-        "@hapi/bourne": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-            "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+        "@hapi/formula": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+            "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
             "dev": true
         },
         "@hapi/hoek": {
@@ -1182,16 +1182,23 @@
             "dev": true
         },
         "@hapi/joi": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-            "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+            "version": "16.1.8",
+            "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+            "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
             "dev": true,
             "requires": {
-                "@hapi/address": "2.x.x",
-                "@hapi/bourne": "1.x.x",
-                "@hapi/hoek": "8.x.x",
-                "@hapi/topo": "3.x.x"
+                "@hapi/address": "^2.1.2",
+                "@hapi/formula": "^1.2.0",
+                "@hapi/hoek": "^8.2.4",
+                "@hapi/pinpoint": "^1.0.2",
+                "@hapi/topo": "^3.1.3"
             }
+        },
+        "@hapi/pinpoint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+            "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
+            "dev": true
         },
         "@hapi/topo": {
             "version": "3.1.6",
@@ -10130,6 +10137,26 @@
                 "throttleit": "^1.0.0"
             }
         },
+        "request-promise-core": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.3",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10232,12 +10259,6 @@
             "requires": {
                 "aproba": "^1.1.1"
             }
-        },
-        "rx": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-            "dev": true
         },
         "rxjs": {
             "version": "5.5.12",
@@ -10785,18 +10806,18 @@
             "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg=="
         },
         "start-server-and-test": {
-            "version": "1.10.6",
-            "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.10.6.tgz",
-            "integrity": "sha512-Gr/TDePT4JczaoBiKZLZRIWmYgRcoGcFQePtPEHEvZFUuxbdUqTZozx8dqrlKl/67+pipg5OOtBH21U1oJXJIQ==",
+            "version": "1.10.8",
+            "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.10.8.tgz",
+            "integrity": "sha512-5I190MiIHBqmArTnxk9dfHlwO8I35B1hFhuAgv2L/UMDArRCtIXL/QftgNtgfuIz5NQN3yrN0kCsY+zYkX+dUg==",
             "dev": true,
             "requires": {
                 "bluebird": "3.7.1",
                 "check-more-types": "2.24.0",
                 "debug": "4.1.1",
-                "execa": "2.1.0",
+                "execa": "4.0.0",
                 "lazy-ass": "1.6.0",
                 "ps-tree": "1.2.0",
-                "wait-on": "3.3.0"
+                "wait-on": "4.0.0"
             },
             "dependencies": {
                 "bluebird": {
@@ -10826,18 +10847,18 @@
                     }
                 },
                 "execa": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-                    "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
+                    "integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "^7.0.0",
                         "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
                         "is-stream": "^2.0.0",
                         "merge-stream": "^2.0.0",
-                        "npm-run-path": "^3.0.0",
+                        "npm-run-path": "^4.0.0",
                         "onetime": "^5.1.0",
-                        "p-finally": "^2.0.0",
                         "signal-exit": "^3.0.2",
                         "strip-final-newline": "^2.0.0"
                     }
@@ -10858,19 +10879,13 @@
                     "dev": true
                 },
                 "npm-run-path": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-                    "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
                     "dev": true,
                     "requires": {
                         "path-key": "^3.0.0"
                     }
-                },
-                "p-finally": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-                    "dev": true
                 },
                 "path-key": {
                     "version": "3.1.1",
@@ -10970,6 +10985,12 @@
                     }
                 }
             }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "stream-browserify": {
             "version": "2.0.2",
@@ -12095,16 +12116,28 @@
             }
         },
         "wait-on": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
-            "integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-4.0.0.tgz",
+            "integrity": "sha512-QrW3J8LzS5ADPfD9Rx5S6KJck66xkqyiFKQs9jmUTkIhiEOmkzU7WRZc+MjsnmkrgjitS2xQ4bb13hnlQnKBUQ==",
             "dev": true,
             "requires": {
-                "@hapi/joi": "^15.0.3",
-                "core-js": "^2.6.5",
+                "@hapi/joi": "^16.1.8",
+                "lodash": "^4.17.15",
                 "minimist": "^1.2.0",
                 "request": "^2.88.0",
-                "rx": "^4.1.0"
+                "request-promise-native": "^1.0.8",
+                "rxjs": "^6.5.4"
+            },
+            "dependencies": {
+                "rxjs": {
+                    "version": "6.5.4",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+                    "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^1.9.0"
+                    }
+                }
             }
         },
         "watchpack": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
         "generate": "nuxt generate",
         "e2e": "cypress run",
         "e2e:open": "cypress open",
-        "dev:e2e": "start-server-and-test dev http://localhost:3000 e2e:open",
-        "test": "start-server-and-test dev http://localhost:3000 e2e"
+        "dev:e2e": "server-test dev :3000 e2e:open",
+        "test": "start-server-and-test start http-get://localhost:3000 e2e"
     },
     "dependencies": {
         "@nuxtjs/axios": "^5.9.4",
@@ -41,6 +41,6 @@
         "cypress": "^3.8.3",
         "node-sass": "^4.13.1",
         "sass-loader": "^8.0.2",
-        "start-server-and-test": "^1.10.6"
+        "start-server-and-test": "^1.10.8"
     }
 }

--- a/tests/e2e/integration/app.starter.spec.js
+++ b/tests/e2e/integration/app.starter.spec.js
@@ -1,7 +1,7 @@
 describe('Visit home', () => {
   it('Have a page title with "Postwoman"', () => {
-    cy.visit('/')
-      .get('title')
+    cy.visit('/', { retryOnStatusCodeFailure: true })
+    .get('title')
       .should('contain','Postwoman')
   })
 })

--- a/tests/e2e/integration/feature.url-queries.spec.js
+++ b/tests/e2e/integration/feature.url-queries.spec.js
@@ -1,57 +1,34 @@
-describe('Methods', () => {
-  const methods = [ 'POST', 'HEAD', 'POST', 'PUT', 'DELETE','OPTIONS', 'PATCH']
-  methods.forEach((method) => {
-      it(`Change the default method GET to ${method} with url query`, () => {
-        cy.visit(`/?method=${method}`)
-          .get('#method').should('have.value', method)
-      })
-  })
-})
-
-describe('Url and path', () => {
-  it('Change default url with query and reset default path to empty string and make a request to cat api', () => {
-      cy.seedAndVisit('catapi', '/?url=https://api.thecatapi.com&path=')
-      .get('#url').then((el) => expect(el.val() === 'https://api.thecatapi.com').to.equal(true))
-      .get("#path").then((el) => expect(el.val() === '').to.equal(true))
-      .get('#response-details-wrapper').should($wrapper => {
-        expect($wrapper).to.contain('FAKE Cat API')
-      })
-  })
-})
-
 describe('Authentication', () => {
-  it(`Change default auth 'None' to 'Basic' and set httpUser and httpPassword with url query`, () => {
+  it(`Change default auth user and pass with url`, () => {
     cy.visit(`?&auth=Basic Auth&httpUser=foo&httpPassword=bar`, { retryOnStatusCodeFailure: true })
-      .get('#authentication').contains('Authentication').click()
-        .then(() => {
-          cy.get('input[name="http_basic_user"]', { timeout: 500 })
-            .invoke('val')
-            .then((user) => {
-              expect(user === 'foo').to.equal(true)
-              cy.log('Success! user === foo')
-            })
+      .get('input[name="http_basic_user"]', { timeout: 500 })
+      .invoke('val')
+      .then((user) => {
+        expect(user === 'foo').to.equal(true)
+      })
 
-          cy.get('input[name="http_basic_passwd"]')
-            .invoke('val')
-            .then((user) => {
-              expect(user === 'bar').to.equal(true)
-              cy.log('Success! password === bar')
-            })
-        })
+      .get('input[name="http_basic_passwd"]')
+      .invoke('val')
+      .then((pass) => {
+        expect(pass === 'bar').to.equal(true)
+      })
   })
 
-  const base64Tkn = encodeURI(btoa('{"alg":"HS256", "typ": "JWT"}'))
-
-  it(`Change default auth 'None' to 'Bearer token' and set bearerToken with url query`, () => {
-    cy.visit(`/?auth=Bearer Token&bearerToken=${base64Tkn}`, { retryOnStatusCodeFailure: true })
-        .get('#authentication').contains('Authentication').click()
-          .then(() => {
-            cy.get('input[name="bearer_token"]', { timeout: 500 })
-              .invoke('val')
-              .then((tkn) => {
-                expect(tkn === base64Tkn).to.equal(true)
-                cy.log(`Success! input[name="bearer_token"] === ${base64Tkn}`)
-              })
-          })
-  })
+  it('Enable user and pass at url with toggler', () => {
+    cy.visit('/', { retryOnStatusCodeFailure: true })
+      .get('#auth')
+      .select('Basic Auth')
+      .get('input[name="http_basic_user"]', { timeout: 500 })
+      .type('foo')
+      .get('input[name="http_basic_passwd"]', { timeout: 500 })
+      .type('bar')
+      .url()
+      .should('not.contain', 'foo')
+      .should('not.contain', 'bar')
+      .get('.toggle')
+      .click()
+      .url()
+      .should('contain', 'foo')
+      .should('contain', 'bar')
+    })
 })

--- a/tests/e2e/integration/proxy.spec.js
+++ b/tests/e2e/integration/proxy.spec.js
@@ -1,0 +1,20 @@
+describe('Proxy disabled - local request', () => {
+  it('Change default url with query and make a request to local cat api', () => {
+    cy.seedAndVisit('catapi', '/?url=https://api.thecatapi.com&path=')
+      .get('#url').then((el) => expect(el.val() === 'https://api.thecatapi.com').to.equal(true))
+      .get("#path").then((el) => expect(el.val() === '').to.equal(true))
+      .get('#response-details-wrapper').should($wrapper => {
+        expect($wrapper).to.contain('FAKE Cat API')
+      })
+  })
+})
+
+describe('Proxy enabled - external request', () => {
+  it('Enable the proxy and make a request to the real cat api', () => {
+    cy.enableProxy('/?url=https://api.thecatapi.com&path=')
+      .get('#send').click()
+      .get('#response-details-wrapper').should($wrapper => {
+        expect($wrapper).to.contain('Cat API')
+      })
+  })
+})

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -7,10 +7,23 @@
 */
 Cypress.Commands.add('seedAndVisit', (seedData, path = '/', method = 'GET') => {
   cy.server()
-    .route(method, 'https://api.thecatapi.com/', `fixture:${seedData}`).as(
-    'load'
-  )
+    .route(method, 'https://api.thecatapi.com/', `fixture:${seedData}`).as('load')
+
   cy.visit(path)
     .get('#send').click()
-    .wait('@load')
+      .wait('@load')
+})
+
+/**
+* Creates cy.enableProxy() function
+* This function will enable the proxy and navigate back to a given path
+* @param { String } goBackPath The page go back
+*/
+Cypress.Commands.add('enableProxy', (goBackPath) => {
+  cy.visit('/settings')
+    .get('#proxy')
+    .find('.toggle')
+    .click( { force: true } )
+    .should('have.class', 'on')
+    .visit(goBackPath)
 })


### PR DESCRIPTION
Some updates to e2e tests:
 * fix error of dependency start-server-and-test update (`^1.10.8`) #544
 * add test to proxy feature
 * update test to url queries feature (test to add/remove passwords at url with the toggler)
 * use nuxt `build/start` to run tests instead of `nuxt` 
> Some tests were failing because the vm of the ci was loading the assets (and the page was not ready to run the first test). This is a screenshot from a test that runned at travis:

![cypress-screenshot](https://user-images.githubusercontent.com/4117768/73603446-7547b780-4561-11ea-9ee3-9dd4b08be861.png)
