### PR TITLE
Added toggle to decide whether extensions should be used

### DIFF
--- a/functions/network.js
+++ b/functions/network.js
@@ -2,16 +2,25 @@ import AxiosStrategy from "./strategies/AxiosStrategy";
 import FirefoxStrategy from "./strategies/FirefoxStrategy";
 import ChromeStrategy, { hasChromeExtensionInstalled } from "./strategies/ChromeStrategy";
 
+const isExtensionsAllowed = ({ state }) => {
+  console.log(typeof(state.postwoman.settings.EXTENSIONS_ENABLED) === 'undefined'
+    || state.postwoman.settings.EXTENSIONS_ENABLED);
+  return typeof(state.postwoman.settings.EXTENSIONS_ENABLED) === 'undefined'
+    || state.postwoman.settings.EXTENSIONS_ENABLED;
+}
+
 const runAppropriateStrategy = (req, store) => {
-  // Chrome Provides a chrome object for scripts to access
-  // Check its availability to say whether you are in Google Chrome
-  if (window.chrome && hasChromeExtensionInstalled()) {
-      return ChromeStrategy(req, store);
-  }
-  // The firefox plugin injects a function to send requests through it
-  // If that is available, then we can use the FirefoxStrategy
-  if (window.firefoxExtSendRequest) {
-    return FirefoxStrategy(req, store); 
+  if (isExtensionsAllowed(store)) {
+    // Chrome Provides a chrome object for scripts to access
+    // Check its availability to say whether you are in Google Chrome
+    if (window.chrome && hasChromeExtensionInstalled()) {
+        return ChromeStrategy(req, store);
+    }
+    // The firefox plugin injects a function to send requests through it
+    // If that is available, then we can use the FirefoxStrategy
+    if (window.firefoxExtSendRequest) {
+      return FirefoxStrategy(req, store); 
+    }
   }
 
   return AxiosStrategy(req, store);

--- a/functions/network.js
+++ b/functions/network.js
@@ -3,8 +3,6 @@ import FirefoxStrategy from "./strategies/FirefoxStrategy";
 import ChromeStrategy, { hasChromeExtensionInstalled } from "./strategies/ChromeStrategy";
 
 const isExtensionsAllowed = ({ state }) => {
-  console.log(typeof(state.postwoman.settings.EXTENSIONS_ENABLED) === 'undefined'
-    || state.postwoman.settings.EXTENSIONS_ENABLED);
   return typeof(state.postwoman.settings.EXTENSIONS_ENABLED) === 'undefined'
     || state.postwoman.settings.EXTENSIONS_ENABLED;
 }
@@ -19,14 +17,14 @@ const runAppropriateStrategy = (req, store) => {
     // The firefox plugin injects a function to send requests through it
     // If that is available, then we can use the FirefoxStrategy
     if (window.firefoxExtSendRequest) {
-      return FirefoxStrategy(req, store); 
+      return FirefoxStrategy(req, store);
     }
   }
 
   return AxiosStrategy(req, store);
 }
 
-const sendNetworkRequest = (req, store) => 
+const sendNetworkRequest = (req, store) =>
   runAppropriateStrategy(req, store)
     .finally(() => window.$nuxt.$loading.finish());
 

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -247,6 +247,7 @@ export default {
   enter_curl: "Enter cURL",
   empty: "Empty",
   extensions: "Extensions",
+  extensions_use_toggle: "Use the browser extension to send requests (if present)",
   extensions_info1: "Browser extension that simplifies access to Postwoman",
   extensions_info2: "Get Postwoman browser extension!",
   installed: "Installed",

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -141,6 +141,20 @@
       </ul>
     </pw-section>
 
+    <pw-section class="purple" :label="$t('extensions')" ref="extensions">
+      <ul>
+        <li>
+          <div class="flex-wrap">
+            <pw-toggle
+              :on="settings.EXTENSIONS_ENABLED"
+              @change="toggleSetting('EXTENSIONS_ENABLED')"
+            >
+              {{ $t("extensions_use_toggle") }}
+            </pw-toggle>
+          </div>
+        </li>
+      </ul>
+    </pw-section>
     <pw-section class="blue" :label="$t('proxy')" ref="proxy">
       <ul>
         <li>
@@ -323,7 +337,11 @@ export default {
         PROXY_URL:
           this.$store.state.postwoman.settings.PROXY_URL ||
           "https://postwoman.apollotv.xyz/",
-        PROXY_KEY: this.$store.state.postwoman.settings.PROXY_KEY || ""
+        PROXY_KEY: this.$store.state.postwoman.settings.PROXY_KEY || "",
+        EXTENSIONS_ENABLED:
+          (typeof(this.$store.state.postwoman.settings.EXTENSIONS_ENABLED) !== 'undefined') ? 
+            this.$store.state.postwoman.settings.EXTENSIONS_ENABLED 
+            : true
       },
 
       doneButton: '<i class="material-icons">done</i>',

--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -56,7 +56,13 @@ export const SETTINGS_KEYS = [
    * An array of properties to exclude from the URL.
    * e.g. 'auth'
    */
-  "URL_EXCLUDES"
+  "URL_EXCLUDES",
+  
+  /**
+   * A boolean value indicating whether to use the browser extensions
+   * to run the requests
+  */
+  "EXTENSIONS_ENABLED"
 ];
 
 export const state = () => ({


### PR DESCRIPTION
This PR intends to add a toggle in the Settings page to turn off and on the use of extensions to send requests.

**NOTE for Translators:**
New entries added in the translations file