### PR TITLE
chore: use typeof as an operator and make use of localizable strings

### DIFF
--- a/components/collections/addCollection.vue
+++ b/components/collections/addCollection.vue
@@ -58,7 +58,7 @@ export default {
   methods: {
     addNewCollection() {
       if (!this.$data.name) {
-        this.$toast.info("Please provide a valid name for the collection");
+        this.$toast.info($t("invalid_collection_name"));
         return;
       }
       this.$store.commit("postwoman/addNewCollection", {

--- a/components/collections/editCollection.vue
+++ b/components/collections/editCollection.vue
@@ -60,7 +60,7 @@ export default {
   methods: {
     saveCollection() {
       if (!this.$data.name) {
-        this.$toast.info("Please provide a valid name for the collection");
+        this.$toast.info($t("invalid_collection_name"));
         return;
       }
       const collectionUpdated = {

--- a/functions/network.js
+++ b/functions/network.js
@@ -3,7 +3,7 @@ import FirefoxStrategy from "./strategies/FirefoxStrategy";
 import ChromeStrategy, { hasChromeExtensionInstalled } from "./strategies/ChromeStrategy";
 
 const isExtensionsAllowed = ({ state }) => {
-  return typeof(state.postwoman.settings.EXTENSIONS_ENABLED) === 'undefined'
+  return typeof state.postwoman.settings.EXTENSIONS_ENABLED === 'undefined'
     || state.postwoman.settings.EXTENSIONS_ENABLED;
 }
 

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -140,6 +140,7 @@ export default {
   deleted: "Deleted",
   undo: "Undo",
   collection_empty: "Collection is empty",
+  invalid_collection_name: "Please provide a valid name for the collection",
   new_collection: "New Collection",
   my_new_collection: "My New Collection",
   edit_collection: "Edit Collection",

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -339,7 +339,7 @@ export default {
           "https://postwoman.apollotv.xyz/",
         PROXY_KEY: this.$store.state.postwoman.settings.PROXY_KEY || "",
         EXTENSIONS_ENABLED:
-          (typeof(this.$store.state.postwoman.settings.EXTENSIONS_ENABLED) !== 'undefined') ? 
+          (typeof this.$store.state.postwoman.settings.EXTENSIONS_ENABLED !== 'undefined') ? 
             this.$store.state.postwoman.settings.EXTENSIONS_ENABLED 
             : true
       },


### PR DESCRIPTION
Follow up of #551

- Use `typeof` as an operator to ensure consistency across the codebase.
- Replace hard-coded strings with localizable strings.