### PR TITLE
fix: drop the toast which doesn't show up

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -715,7 +715,7 @@ export default {
           .then(() => {})
           .catch(console.error);
       } else {
-      	this.$toast.info("Web Share API is not supported in your browser")
+      	// fallback
       }
     }
   },


### PR DESCRIPTION
Follow up of #571 

The `share` button seems to show up only if `Web Share API` is supported in the user's browser.