### PR TITLE
Fix variablesJSONString store default for GraphQL page

### DIFF
--- a/store/state.js
+++ b/store/state.js
@@ -20,7 +20,7 @@ export default () => ({
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],
-    variablesJSONString: "",
+    variablesJSONString: "{}",
     query: ""
   },
   oauth2: {


### PR DESCRIPTION
I don't have any variables set, and when running a mutation; I get the following error:

```
Error SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at VueComponent._callee$ (graphql.vue?f047:505)
    at tryCatch (runtime.js?96cf:45)
    at Generator.invoke [as _invoke] (runtime.js?96cf:271)
    at Generator.prototype.<computed> [as next] (runtime.js?96cf:97)
    at asyncGeneratorStep (asyncToGenerator.js?1da1:3)
    at _next (asyncToGenerator.js?1da1:25)
    at eval (asyncToGenerator.js?1da1:32)
    at new Promise (<anonymous>)
    at VueComponent.eval (asyncToGenerator.js?1da1:21)
```

**This error is caused by Postwoman trying to JSON parse an empty string, which is set as the default.**
https://github.com/liyasthomas/postwoman/blob/f690ea01c4319d57ea311261c9857faf4a8f6baa/pages/graphql.vue#L505

Setting the `variablesJSONString` variable to the correct default (`{}`) fixes this issue :)

**Before**:
![image](https://user-images.githubusercontent.com/20114263/75123381-dcdeb780-5674-11ea-8029-ee13fe5340af.png)

**After**:
![image](https://user-images.githubusercontent.com/20114263/75123396-e9fba680-5674-11ea-983a-e0eaacb1cd9e.png)
