### PR TITLE
POST request body editor reacts to the content type

### DIFF
--- a/functions/editorutils.js
+++ b/functions/editorutils.js
@@ -1,0 +1,11 @@
+const mimeToMode = {
+  "text/plain": "plain_text",
+  "text/html": "html",
+  "application/xml": "xml",
+  "application/hal+json": "json",
+  "application/json": "json"
+}
+
+export function getEditorLangForMimeType(mimeType) {
+  return mimeToMode[mimeType] || "plain_text";
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -375,7 +375,7 @@
                   <label for="rawBody">{{ $t("raw_request_body") }}</label>
                   <Editor
                     v-model="rawParams"
-                    :lang="'json'"
+                    :lang="rawInputEditorLang"
                     :options="{
                       maxLines: '16',
                       minLines: '8',
@@ -1385,6 +1385,7 @@ import AceEditor from "../components/ace-editor";
 import { tokenRequest, oauthRedirect } from "../assets/js/oauth";
 import { sendNetworkRequest } from "../functions/network";
 import { fb } from "../functions/fb";
+import { getEditorLangForMimeType } from "~/functions/editorutils";
 
 const statusCategories = [
   {
@@ -1807,6 +1808,9 @@ export default {
       set(value) {
         this.$store.commit("setState", { value, attribute: "rawInput" });
       }
+    },
+    rawInputEditorLang() {
+      return getEditorLangForMimeType(this.contentType);
     },
     requestType: {
       get() {


### PR DESCRIPTION
The Raw Request Body editor for POST requests is set to JSON mode and only provided the syntax highlighting mode for JSON. This PR intends to add the ability to for the user to update the syntax highlighting by updating the Content-Type.

So, for example, if the POST Content-Type is set to `application/xml`, the raw request editor updates the language mode to XML mode and if the request mode is set to `application/json`, it updates the mode to JSON Syntax Highlighting mode.