### PR TITLE
Added settings toggle for enabling/disabling auto scrolling (scrollInto functionality)

### DIFF
--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -265,6 +265,7 @@ export default {
   logged_out: "Logged out",
   logout: "Logout",
   account: "Account",
+  scrollInto_use_toggle: "Auto scroll",
   sync: "Sync",
   syncHistory: "History",
   syncCollections: "Collections",

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -431,7 +431,7 @@ export default {
       const rootTypeName = this.resolveRootType(type).name;
 
       const target = document.getElementById(`type_${rootTypeName}`);
-      if (target) {
+      if (target && this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED) {
         target.scrollIntoView({
           behavior: "smooth"
         });
@@ -494,7 +494,8 @@ export default {
       const startTime = Date.now();
 
       this.$nuxt.$loading.start();
-      this.scrollInto("response");
+      this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED &&
+        this.scrollInto("response");
 
       try {
         let headers = {};
@@ -537,7 +538,8 @@ export default {
     async getSchema() {
       const startTime = Date.now();
       this.schemaString = this.$t("loading");
-      this.scrollInto("schema");
+      this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED &&
+        this.scrollInto("schema");
 
       // Start showing the loading bar as soon as possible.
       // The nuxt axios module will hide it when the request is made.

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2085,7 +2085,8 @@ export default {
       this.path = path;
       this.showPreRequestScript = usesScripts;
       this.preRequestScript = preRequestScript;
-      this.scrollInto("request");
+      this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED &&
+        this.scrollInto("request");
     },
     getVariablesFromPreRequestScript() {
       if (!this.preRequestScript) {
@@ -2132,7 +2133,8 @@ export default {
     },
     async sendRequest() {
       this.$toast.clear();
-      this.scrollInto("response");
+      this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED &&
+        this.scrollInto("response");
 
       if (!this.isValidURL) {
         this.$toast.error(this.$t("url_invalid_format"), {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -347,7 +347,11 @@ export default {
 
       settings: {
         SCROLL_INTO_ENABLED: 
-          this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED || true,
+          typeof this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED !==
+          "undefined"
+            ? this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED
+            : true,
+
         THEME_COLOR: "",
         THEME_TAB_COLOR: "",
         THEME_COLOR_VIBRANT: true,
@@ -360,6 +364,7 @@ export default {
           this.$store.state.postwoman.settings.PROXY_URL ||
           "https://postwoman.apollotv.xyz/",
         PROXY_KEY: this.$store.state.postwoman.settings.PROXY_KEY || "",
+        
         EXTENSIONS_ENABLED:
           typeof this.$store.state.postwoman.settings.EXTENSIONS_ENABLED !==
           "undefined"

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -347,7 +347,7 @@ export default {
 
       settings: {
         SCROLL_INTO_ENABLED: 
-          this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED || false,
+          this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED || true,
         THEME_COLOR: "",
         THEME_TAB_COLOR: "",
         THEME_COLOR_VIBRANT: true,

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -138,6 +138,21 @@
             </pw-toggle>
           </span>
         </li>
+        </ul>
+        <ul>
+        <li>
+          <span>
+            <pw-toggle
+              :on="settings.SCROLL_INTO_ENABLED"
+              @change="toggleSetting('SCROLL_INTO_ENABLED')"
+            >
+              {{ $t("scrollInto_use_toggle") }}
+              {{
+                settings.SCROLL_INTO_ENABLED ? $t("enabled") : $t("disabled")
+              }}
+            </pw-toggle>
+          </span>
+        </li>
       </ul>
     </pw-section>
 
@@ -331,7 +346,8 @@ export default {
       ],
 
       settings: {
-        THEME_CLASS: this.$store.state.postwoman.settings.THEME_CLASS || "",
+        SCROLL_INTO_ENABLED: 
+          this.$store.state.postwoman.settings.SCROLL_INTO_ENABLED || false,
         THEME_COLOR: "",
         THEME_TAB_COLOR: "",
         THEME_COLOR_VIBRANT: true,

--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -2,6 +2,12 @@ import Vue from "vue";
 
 export const SETTINGS_KEYS = [
   /**
+   * Whether or not to enable scrolling to a specified element, when certain
+   * actions are triggered.
+   */
+  "SCROLL_INTO_ENABLED",
+
+  /**
    * The CSS class that should be applied to the root element.
    * Essentially, the name of the background theme.
    */


### PR DESCRIPTION
Adds a toggle on the settings page (under the theme section) to enable and disable auto scroll (`scrollInto` functionality) on both graphql and index pages.

![image](https://user-images.githubusercontent.com/20114263/75168767-6fbf3680-56f5-11ea-8b3a-2342e5b6612e.png)
