### PR TITLE
Add --staged parameter to pretty-quick pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e": "cypress run",
     "e2e:open": "cypress open",
     "dev:e2e": "server-test dev :3000 e2e:open",
-    "pretty-quick": "pretty-quick --pattern \"**/*.*(html|js|json|vue)\"",
+    "pretty-quick": "pretty-quick --staged --pattern \"**/*.*(html|js|json|vue)\"",
     "test": "start-server-and-test start http-get://localhost:3000 e2e"
   },
   "husky": {


### PR DESCRIPTION
This adds a `--staged` parameter to the `pretty-quick` pre-commit script, which will make sure only staged files are formatted. Partially staged files will not be re-staged after formatting, and pretty-quick will exit with a non-zero exit code. The intent is to abort the git commit, and allow the user to amend their selective staging to include formatting fixes.