### PR TITLE
Ignore empty GQL Variable Strings

### DIFF
--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -503,7 +503,7 @@ export default {
           headers[header.key] = header.value
         })
 
-        let variables = JSON.parse(this.variableString)
+        let variables = JSON.parse(this.variableString || "{}")
 
         const gqlQueryString = this.gqlQueryString
 


### PR DESCRIPTION
This is a simple patch to ignore empty GraphQL variable strings.

That's about it. :sweat_smile: 