### PR TITLE
Minor GraphQL page improvements

### DIFF
--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -181,6 +181,8 @@ export default {
   loading: "Loading...",
   fetching: "Fetching...",
   waiting_send_req: "(waiting to send request)",
+  waiting_receive_response: "(waiting to receive response)",
+  waiting_receive_schema: "(waiting to receive schema)",
   cancel: "Cancel",
   save: "Save",
   dismiss: "Dismiss",

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -102,8 +102,8 @@
 
         <pw-section class="green" :label="$t('schema')" ref="schema">
           <div class="flex-wrap">
-            <label>{{ $t("response") }}</label>
-            <div>
+            <label>{{ $t("schema") }}</label>
+            <div v-if="schema">
               <button
                 class="icon"
                 @click="ToggleExpandResponse"
@@ -135,17 +135,28 @@
             </div>
           </div>
           <Editor
+            v-if="schema"
             :value="schema"
             :lang="'graphqlschema'"
             :options="{
               maxLines: responseBodyMaxLines,
-              minLines: '16',
+              minLines: 16,
               fontSize: '16px',
               autoScrollEditorIntoView: true,
               readOnly: true,
               showPrintMargin: false,
               useWorker: false,
             }"
+          />
+          <input
+            v-else
+            class="missing-data-response"
+            :value="$t('waiting_receive_schema')"
+            ref="status"
+            id="status"
+            name="status"
+            readonly
+            type="text"
           />
         </pw-section>
 
@@ -175,7 +186,7 @@
             :onRunGQLQuery="runQuery"
             :options="{
               maxLines: responseBodyMaxLines,
-              minLines: '16',
+              minLines: 10,
               fontSize: '16px',
               autoScrollEditorIntoView: true,
               showPrintMargin: false,
@@ -189,8 +200,8 @@
             v-model="variableString"
             :lang="'json'"
             :options="{
-              maxLines: responseBodyMaxLines,
-              minLines: '16',
+              maxLines: 10,
+              minLines: 5,
               fontSize: '16px',
               autoScrollEditorIntoView: true,
               showPrintMargin: false,
@@ -214,18 +225,29 @@
             </div>
           </div>
           <Editor
+            v-if="response"
             :value="response"
             :lang="'json'"
             :lint="false"
             :options="{
               maxLines: responseBodyMaxLines,
-              minLines: '16',
+              minLines: 10,
               fontSize: '16px',
               autoScrollEditorIntoView: true,
               readOnly: true,
               showPrintMargin: false,
               useWorker: false,
             }"
+          />
+          <input
+            v-else
+            class="missing-data-response"
+            :value="$t('waiting_receive_response')"
+            ref="status"
+            id="status"
+            name="status"
+            readonly
+            type="text"
           />
         </pw-section>
       </div>

--- a/store/state.js
+++ b/store/state.js
@@ -23,8 +23,8 @@ export default () => ({
     headers: [],
     schema: "",
     variablesJSONString: '{ "id": "1" }',
-    query: `query charcter {
-  character(id: 1) {
+    query: `query charcter($id: ID) {
+  character(id: $id) {
     id
     name
   }

--- a/store/state.js
+++ b/store/state.js
@@ -22,8 +22,13 @@ export default () => ({
     url: "https://rickandmortyapi.com/graphql",
     headers: [],
     schema: "",
-    variablesJSONString: "{}",
-    query: "",
+    variablesJSONString: '{ "id": "1" }',
+    query: `query charcter {
+  character(id: 1) {
+    id
+    name
+  }
+}`,
     response: "",
   },
   theme: {


### PR DESCRIPTION
- Schema will show `(waiting to receive schema)` until the schema is actually requested. (There's no point to show the editor box if there's no schema)
![image](https://user-images.githubusercontent.com/20114263/75611460-b7283700-5ae8-11ea-8a16-96a1750696f9.png)
- Added default values for the Query and Variables editors (Most people coming to this page might not even know what GraphQL is. So it's best to give them an example of a query and the correct variables to pass. They can go right to the GraphQL page and click the `runQuery` button)
![image](https://user-images.githubusercontent.com/20114263/75611626-23576a80-5aea-11ea-9f3c-fdbac971a436.png)

- Response will show `(waiting to receive response)` (Similar to reasoning above)
![image](https://user-images.githubusercontent.com/20114263/75611500-0706fe00-5ae9-11ea-9cb8-95d0effd773f.png)
- Decreased the `minLines` for variables to 10, `minLines` for variables to 5, and `minLines` for response to 10.

