### PR TITLE
Removed linting for the collection docs import editor

### DIFF
--- a/pages/doc.vue
+++ b/pages/doc.vue
@@ -29,6 +29,7 @@
           <Editor
             v-model="collectionJSON"
             :lang="'json'"
+            :lint="false"
             :options="{
               maxLines: '16',
               minLines: '8',


### PR DESCRIPTION
A pretty simple PR implementing a small fix to disable linting for the code editor in the docs page.