### PR TITLE
Add http/https support to socketio url valid

### DIFF
--- a/components/realtime/socketio.vue
+++ b/components/realtime/socketio.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script>
-import { wsValid } from "~/functions/utils/valid"
+import { socketioValid } from "~/functions/utils/valid"
 import io from "socket.io-client"
 import realtimeLog from "./log"
 
@@ -97,7 +97,7 @@ export default {
   },
   computed: {
     urlValid() {
-      return wsValid(this.url)
+      return socketioValid(this.url)
     },
   },
   methods: {

--- a/functions/utils/valid.js
+++ b/functions/utils/valid.js
@@ -1,14 +1,21 @@
+function generateIPRE(protocol) {
+  return new RegExp(
+    `${protocol}(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`
+  )
+}
+function generateHostnameRE(protocol) {
+  return new RegExp(
+    `${protocol}(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9/])$`
+  )
+}
+
 /**
  * valid url for ws/wss
  */
 export function wsValid(url) {
   const protocol = "^(wss?:\\/\\/)?"
-  const validIP = new RegExp(
-    `${protocol}(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`
-  )
-  const validHostname = new RegExp(
-    `${protocol}(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9/])$`
-  )
+  const validIP = generateIPRE(protocol)
+  const validHostname = generateHostnameRE(protocol)
   return validIP.test(url) || validHostname.test(url)
 }
 
@@ -17,11 +24,17 @@ export function wsValid(url) {
  */
 export function sseValid(url) {
   const protocol = "^(https?:\\/\\/)?"
-  const validIP = new RegExp(
-    `${protocol}(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`
-  )
-  const validHostname = new RegExp(
-    `${protocol}(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9/])$`
-  )
+  const validIP = generateIPRE(protocol)
+  const validHostname = generateHostnameRE(protocol)
+  return validIP.test(url) || validHostname.test(url)
+}
+
+/**
+ * valid url for ws/wss/http/https
+ */
+export function socketioValid(url) {
+  const protocol = "^((wss?:\\/\\/)|(https?:\\/\\/))?"
+  const validIP = generateIPRE(protocol)
+  const validHostname = generateHostnameRE(protocol)
   return validIP.test(url) || validHostname.test(url)
 }


### PR DESCRIPTION
Allow http/https protocols for Socket.io endpoints.

Next step i will append event listener(because of socketio looks like cant get all message, must be specify eventName).