### PR TITLE
Added the ability to prettify GraphQL queries

### DIFF
--- a/components/graphql/queryeditor.vue
+++ b/components/graphql/queryeditor.vue
@@ -151,8 +151,8 @@ export default {
       name: "prettifyGQLQuery",
       exec: () => this.prettifyQuery(),
       bindKey: {
-        mac: "cmd-g",
-        win: "ctrl-g",
+        mac: "cmd-p",
+        win: "ctrl-p",
       },
     })
 
@@ -168,7 +168,12 @@ export default {
 
   methods: {
     prettifyQuery() {
-      this.value = gql.print(gql.parse(this.editor.getValue()))
+      try {
+        this.value = gql.print(gql.parse(this.editor.getValue()))
+      } catch (e) {
+        // Catching the exception to avoid the event to be passed to the browser
+        // Prevents the print dialog from appearing
+      }
     },
 
     defineTheme() {

--- a/components/graphql/queryeditor.vue
+++ b/components/graphql/queryeditor.vue
@@ -171,8 +171,9 @@ export default {
       try {
         this.value = gql.print(gql.parse(this.editor.getValue()))
       } catch (e) {
-        // Catching the exception to avoid the event to be passed to the browser
-        // Prevents the print dialog from appearing
+        this.$toast.error(`${this.$t("gql_prettify_invalid_query")}`, {
+          icon: "error",
+        })
       }
     },
 

--- a/components/graphql/queryeditor.vue
+++ b/components/graphql/queryeditor.vue
@@ -147,6 +147,15 @@ export default {
       },
     })
 
+    editor.commands.addCommand({
+      name: "prettifyGQLQuery",
+      exec: () => this.prettifyQuery(),
+      bindKey: {
+        mac: "cmd-g",
+        win: "ctrl-g",
+      },
+    })
+
     editor.on("change", () => {
       const content = editor.getValue()
       this.$emit("input", content)
@@ -158,6 +167,10 @@ export default {
   },
 
   methods: {
+    prettifyQuery() {
+      this.value = gql.print(gql.parse(this.editor.getValue()))
+    },
+
     defineTheme() {
       if (this.theme) {
         return this.theme

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -184,6 +184,7 @@ export default {
   waiting_receive_schema: "(waiting to receive schema)",
   gql_prettify_invalid_query:
     "Couldn't prettify an invalid query, solve query syntax errors and try again",
+  prettify_query: "Prettify Query",
   cancel: "Cancel",
   save: "Save",
   dismiss: "Dismiss",

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -182,6 +182,8 @@ export default {
   waiting_send_req: "(waiting to send request)",
   waiting_receive_response: "(waiting to receive response)",
   waiting_receive_schema: "(waiting to receive schema)",
+  gql_prettify_invalid_query:
+    "Couldn't prettify an invalid query, solve query syntax errors and try again",
   cancel: "Cancel",
   save: "Save",
   dismiss: "Dismiss",

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -178,6 +178,13 @@
               >
                 <i class="material-icons">file_copy</i>
               </button>
+              <button
+                class="icon"
+                @click="doPrettifyQuery"
+                v-tooltip="`${$t('prettify_query')} (${getSpecialKey()}-P)`"
+              >
+                <i class="material-icons">photo_filter</i>
+              </button>
             </div>
           </div>
           <QueryEditor
@@ -452,6 +459,9 @@ export default {
   },
   methods: {
     getSpecialKey: getPlatformSpecialKey,
+    doPrettifyQuery() {
+      this.$refs.queryEditor.prettifyQuery()
+    },
     handleJumpToType(type) {
       const typesTab = document.getElementById("gqltypes-tab")
       typesTab.checked = true


### PR DESCRIPTION
This PR intends to add the ability to do GraphQL query prettification. It adds a editor shortcut (`cmd-p` or `ctrl-p`) and also a button above the query editor to do prettification.

I am not a pretty big fan of the icon for the prettify button, I had that auto-fix magic wand icon in my mind but I think it is removed from the material icons collection now. @liyasthomas it would be awesome if you could replace that with something more aesthetically pleasing.

**NOTE to Translators: Added new entries for i10n**