### PR TITLE
Fix setting default raw params

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1435,23 +1435,21 @@ export default {
     canListParameters(canToggleRaw) {
       this.rawInput = !canToggleRaw
     },
-    contentType(contentType) {
-      switch (contentType) {
-        case "application/json":
-        case "application/hal+json":
-          if (!(this.rawParams.charAt(0) in ['"', "{", "["])) {
-            this.rawParams = "{}"
-          }
-          break
-        case "application/xml":
-          if (this.rawParams.charAt(0) !== "<" || this.rawParams === "<!doctype html>") {
-            this.rawParams = "<?xml version='1.0' encoding='utf-8'?>"
-          }
-          break
-        case "text/html":
-          if (this.rawParams.charAt(0) !== "<" || this.rawParams.startsWith("<?xml")) {
-            this.rawParams = "<!doctype html>"
-          }
+    contentType(contentType, oldContentType) {
+      const getDefaultParams = contentType => {
+        switch (contentType) {
+          case "application/json":
+          case "application/hal+json":
+            return "{}"
+          case "application/xml":
+            return "<?xml version='1.0' encoding='utf-8'?>"
+          case "text/html":
+            return "<!doctype html>"
+        }
+        return ""
+      }
+      if (!this.rawParams || this.rawParams === getDefaultParams(oldContentType)) {
+        this.rawParams = getDefaultParams(contentType)
       }
       this.setRouteQueryState()
     },


### PR DESCRIPTION
My first PR comes with a minor bug here https://github.com/liyasthomas/postwoman/pull/678/files#diff-b19fa22add3de9cd0b98b05366479d92R1442 :disappointed: 
It's always true, so every time content type is changed to `application/json` body will be reset.

I'm fixing it here and also ensuring body is being reset to defaults only if it was not manually changed (empty or equals to default body for old content type).