### PR TITLE
Fix raw input (JSON)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1434,8 +1434,8 @@ export default {
     },
     canListParameters: {
       immediate: true,
-      handler (canToggleRaw) {
-        this.rawInput = !canToggleRaw
+      handler (canListParameters) {
+        this.rawInput = !canListParameters
       }
     },
     contentType(contentType, oldContentType) {
@@ -1764,7 +1764,7 @@ export default {
     },
     rawInput: {
       get() {
-        return this.canListParameter ? this.$store.state.request.rawInput : true
+        return this.canListParameters ? this.$store.state.request.rawInput : true
       },
       set(value) {
         this.$store.commit("setState", { value, attribute: "rawInput" })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1432,8 +1432,11 @@ export default {
         ])
       },
     },
-    canListParameters(canToggleRaw) {
-      this.rawInput = !canToggleRaw
+    canListParameters: {
+      immediate: true,
+      handler (canToggleRaw) {
+        this.rawInput = !canToggleRaw
+      }
     },
     contentType(contentType, oldContentType) {
       const getDefaultParams = contentType => {
@@ -1544,11 +1547,7 @@ export default {
       "text/plain",
     ],
     canListParameters() {
-      return [
-        "application/json",
-        "application/hal+json",
-        "application/x-www-form-urlencoded",
-      ].includes(this.contentType)
+      this.contentType === "application/x-www-form-urlencoded"
     },
     uri: {
       get() {
@@ -1765,7 +1764,7 @@ export default {
     },
     rawInput: {
       get() {
-        return this.$store.state.request.rawInput
+        return this.canListParameter ? this.$store.state.request.rawInput : true
       },
       set(value) {
         this.$store.commit("setState", { value, attribute: "rawInput" })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1435,7 +1435,13 @@ export default {
     canListParameters: {
       immediate: true,
       handler(canListParameters) {
-        this.rawInput = !canListParameters
+        if (canListParameters) {
+          this.$nextTick(() => {
+            this.rawInput = Boolean(this.rawParams && this.rawParams !== "{}")
+          })
+        } else {
+          this.rawInput = true
+        }
       },
     },
     contentType(contentType, oldContentType) {
@@ -1531,11 +1537,6 @@ export default {
   },
   computed: {
     /**
-     * These are content types that can be automatically
-     * serialized by postwoman.
-     */
-    knownContentTypes: () => ["application/json", "application/x-www-form-urlencoded"],
-    /**
      * These are a list of Content Types known to Postwoman.
      */
     validContentTypes: () => [
@@ -1546,8 +1547,12 @@ export default {
       "text/html",
       "text/plain",
     ],
+    /**
+     * Check content types that can be automatically
+     * serialized by postwoman.
+     */
     canListParameters() {
-      return this.contentType === "application/x-www-form-urlencoded"
+      return ["application/json", "application/x-www-form-urlencoded"].includes(this.contentType)
     },
     uri: {
       get() {
@@ -1764,7 +1769,7 @@ export default {
     },
     rawInput: {
       get() {
-        return this.canListParameters ? this.$store.state.request.rawInput : true
+        return this.$store.state.request.rawInput
       },
       set(value) {
         this.$store.commit("setState", { value, attribute: "rawInput" })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1547,7 +1547,7 @@ export default {
       "text/plain",
     ],
     canListParameters() {
-      this.contentType === "application/x-www-form-urlencoded"
+      return this.contentType === "application/x-www-form-urlencoded"
     },
     uri: {
       get() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1552,7 +1552,10 @@ export default {
      * serialized by postwoman.
      */
     canListParameters() {
-      return ["application/json", "application/x-www-form-urlencoded"].includes(this.contentType)
+      return (
+        this.contentType === "application/x-www-form-urlencoded" ||
+        this.contentType.endsWith("json")
+      )
     },
     uri: {
       get() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1845,7 +1845,7 @@ export default {
     },
     rawRequestBody() {
       const { bodyParams, contentType } = this
-      if (contentType === "application/json") {
+      if (contentType.endsWith("json")) {
         try {
           const obj = JSON.parse(
             `{${bodyParams

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1434,9 +1434,9 @@ export default {
     },
     canListParameters: {
       immediate: true,
-      handler (canListParameters) {
+      handler(canListParameters) {
         this.rawInput = !canListParameters
-      }
+      },
     },
     contentType(contentType, oldContentType) {
       const getDefaultParams = contentType => {


### PR DESCRIPTION
Related issue: https://github.com/liyasthomas/postwoman/issues/597

As I've commented on commit https://github.com/liyasthomas/postwoman/commit/b14adc29f521271306970e896c45ffe46ee04848, the problem with JSON body and raw input is happening again after this commit, maybe I've named things badly (`canListParameters`) and you misunderstood me, so I'm suggesting another fix :stuck_out_tongue: 

I've realized that it's getting `rawInput` original state from Vuex, and then it could happen to have JSON content with raw input disabled and without the toggle component, this way it would not be possible to enable raw input at all...

Now I'm making sure `rawInput` is true always `canListParameters` is false, and kept (revert) `canListParameters` to be true only with `application/x-www-form-urlencoded`.

> With immediate `canListParameters` wacther, https://github.com/liyasthomas/postwoman/compare/master...leomp12:fix/raw-input?expand=1#diff-b19fa22add3de9cd0b98b05366479d92R1767 may be unnecessary, just to be really sure