### PR TITLE
Fix postman import with empty url

### DIFF
--- a/components/collections/importExportCollections.vue
+++ b/components/collections/importExportCollections.vue
@@ -231,8 +231,10 @@ export default {
       let requestObjectUrl = requestObject.request.url.raw.match(
         /^(.+:\/\/[^\/]+|{[^\/]+})(\/[^\?]+|).*$/
       )
-      pwRequest.url = requestObjectUrl[1]
-      pwRequest.path = requestObjectUrl[2] ? requestObjectUrl[2] : ""
+      if (requestObjectUrl) {
+        pwRequest.url = requestObjectUrl[1]
+        pwRequest.path = requestObjectUrl[2] ? requestObjectUrl[2] : ""
+      }
       pwRequest.method = requestObject.request.method
       let itemAuth = requestObject.request.auth ? requestObject.request.auth : ""
       let authType = itemAuth ? itemAuth.type : ""


### PR DESCRIPTION
If you try importing a postman collection that contains an empty raw url, it silently fails.

Just needed a nullcheck. 
