### PR TITLE
Modify responseType by Object(json) or Array(json5)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1474,7 +1474,7 @@ export default {
           this.responseType === "application/vnd.api+json"
         ) {
           this.responseBodyText = JSON.stringify(this.response.body, null, 2)
-          this.responseBodyType = "json"
+          this.responseBodyType = this.response.body.constructor.name === "Object" ? "json" : "json5"
         } else if (this.responseType === "text/html") {
           this.responseBodyText = this.response.body
           this.responseBodyType = "html"


### PR DESCRIPTION
## Why?
[support response json array · Issue #805 · liyasthomas/postwoman](https://github.com/liyasthomas/postwoman/issues/805)

## How?

### Behavior
Editor component can't recognize json Array.
(It accepts json Object.)
If JSON Array, set this.responseBodyType 'json5'.

### Fixing
- When 'responseType` is `json/ etc`, responseBodyType will be set
  - `json` : response.body.type's constructor name is `Object`. (Usual case)
  - `json5` : response.body.type's constructor name is `Array`. (#805 's case)

## Screenshots

- JSON Array
![Screenshot from 2020-04-26 13-30-24](https://user-images.githubusercontent.com/2187465/80297966-4a1cdf00-87c3-11ea-84f4-1c6853408d44.png)
![Screenshot from 2020-04-26 13-30-51](https://user-images.githubusercontent.com/2187465/80297968-4db06600-87c3-11ea-8cc0-ad95f29ca236.png)

- JSON Object
![Screenshot from 2020-04-26 13-41-56](https://user-images.githubusercontent.com/2187465/80298070-c6afbd80-87c3-11ea-9002-6505bf9afec3.png)
![Screenshot from 2020-04-26 13-42-05](https://user-images.githubusercontent.com/2187465/80298072-cc0d0800-87c3-11ea-8e0d-02545da49284.png)




