### PR TITLE
chore(config): delete render option

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,13 +34,6 @@ export default {
   server: {
     host: "0.0.0.0", // default: localhost
   },
-  render: {
-    bundleRenderer: {
-      shouldPreload: (file, type) => {
-        return ["script", "style", "font"].includes(type)
-      },
-    },
-  },
   head: {
     title: `${options.name} \u2022 ${options.shortDescription}`,
     meta: [


### PR DESCRIPTION
delete render option in nuxt.config.js which is skipped for spa mode
![image](https://user-images.githubusercontent.com/43805318/80562248-bd1f9300-8a19-11ea-9d2f-98ba41eb60f4.png)
