### PR TITLE
Add format body option

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -184,6 +184,8 @@
   "waiting_receive_schema": "(waiting to receive schema)",
   "gql_prettify_invalid_query": "Couldn't prettify an invalid query, solve query syntax errors and try again",
   "prettify_query": "Prettify Query",
+  "json_prettify_invalid_body": "Couldn't prettify an invalid body, solve json syntax errors and try again",
+  "prettify_body": "Prettify body",
   "cancel": "Cancel",
   "save": "Save",
   "dismiss": "Dismiss",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -262,6 +262,13 @@
                       </button>
                     </label>
                     <input ref="payload" name="payload" type="file" @change="uploadPayload" />
+                    <button
+                        class="icon"
+                        @click="prettifyRequestBody()"
+                        v-tooltip="$t('prettify_body')"
+                      >
+                        <i class="material-icons">assistant</i>
+                      </button>
                   </div>
                 </div>
               </li>
@@ -2331,6 +2338,16 @@ export default {
           },
         },
       })
+    },
+    prettifyRequestBody() {
+      try {
+        const jsonObj = JSON.parse(this.rawParams)
+        this.rawParams = JSON.stringify(jsonObj, null, 2)
+      } catch (e) {
+        this.$toast.error(`${this.$t("json_prettify_invalid_body")}`, {
+          icon: "error",
+        })
+      }
     },
     copyRequest() {
       if (navigator.share) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -266,7 +266,7 @@
                         class="icon"
                         @click="prettifyRequestBody()"
                         v-tooltip="$t('prettify_body')"
-                        v-if="this.contentType.endsWith('json')"
+                        v-if="rawInput && this.contentType.endsWith('json')"
                       >
                         <i class="material-icons">assistant</i>
                       </button>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -266,6 +266,7 @@
                         class="icon"
                         @click="prettifyRequestBody()"
                         v-tooltip="$t('prettify_body')"
+                        v-if="this.contentType.endsWith('json')"
                       >
                         <i class="material-icons">assistant</i>
                       </button>


### PR DESCRIPTION
Adds a button to prettify the json request body.

[![Prettify](https://i.imgur.com/9JqMouv.png)](https://i.imgur.com/9JqMouv.png)

Shows a toast error if the body isn't a proper json string.

This PR fixes #767.