### PR TITLE
Environment variables in collections

### DIFF
--- a/functions/utils/uri.js
+++ b/functions/utils/uri.js
@@ -1,0 +1,13 @@
+export function parseUrlAndPath(value) {
+    let result = {}
+    try {
+        let url = new URL(value)
+        result.url = url.origin
+        result.path = url.pathname
+    } catch (error) {
+        let uriRegex = value.match(/^((http[s]?:\/\/)?(<<[^\/]+>>)?[^\/]*|)(\/?.*)$/)
+        result.url = uriRegex[1]
+        result.path = uriRegex[4]
+    }
+    return result;
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1330,6 +1330,7 @@ import { sendNetworkRequest } from "../functions/network"
 import { fb } from "../functions/fb"
 import { getEditorLangForMimeType } from "~/functions/editorutils"
 import { hasPathParams, addPathParamsToVariables, getQueryParams } from "../functions/requestParams.js"
+import { parseUrlAndPath } from "../functions/utils/uri.js"
 const statusCategories = [
   {
     name: "informational",
@@ -1603,16 +1604,9 @@ export default {
           environmentVariables = addPathParamsToVariables(this.params, environmentVariables)
           url = parseTemplateString(value, environmentVariables)
         }
-        try {
-          url = new URL(url)
-          this.url = url.origin
-          this.path = url.pathname
-        } catch (error) {
-          console.log(error)
-          let uriRegex = value.match(/^((http[s]?:\/\/)?(<<[^\/]+>>)?[^\/]*|)(\/?.*)$/)
-          this.url = uriRegex[1]
-          this.path = uriRegex[4]
-        }
+        let result = parseUrlAndPath(url)
+        this.url = result.url
+        this.path = result.path
       },
     },
     url: {
@@ -2633,6 +2627,9 @@ export default {
       if (this.selectedRequest.url) {
         this.editRequest = Object.assign({}, this.selectedRequest, this.editRequest)
       }
+      let result = parseUrlAndPath(this.uri)
+      this.url = result.url
+      this.path = result.path
       this.showRequestModal = true
     },
     hideRequestModal() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2182,6 +2182,7 @@ export default {
             let environmentVariables = getEnvironmentVariablesFromScript(this.preRequestScript)
             environmentVariables = addPathParamsToVariables(this.params, environmentVariables)
             entry.path = parseTemplateString(entry.path, environmentVariables)
+            entry.url = parseTemplateString(entry.url, environmentVariables)
           }
 
           this.$refs.historyComponent.addEntry(entry)
@@ -2214,6 +2215,7 @@ export default {
             let environmentVariables = getEnvironmentVariablesFromScript(this.preRequestScript)
             environmentVariables = addPathParamsToVariables(this.params, environmentVariables)
             entry.path = parseTemplateString(entry.path, environmentVariables)
+            entry.url = parseTemplateString(entry.url, environmentVariables)
           }
 
           this.$refs.historyComponent.addEntry(entry)
@@ -2605,9 +2607,10 @@ export default {
         })
         return
       }
+      let urlAndPath = parseUrlAndPath(this.uri)
       this.editRequest = {
-        url: this.url,
-        path: this.path,
+        url: urlAndPath.url,
+        path: urlAndPath.path,
         method: this.method,
         auth: this.auth,
         httpUser: this.httpUser,
@@ -2627,9 +2630,6 @@ export default {
       if (this.selectedRequest.url) {
         this.editRequest = Object.assign({}, this.selectedRequest, this.editRequest)
       }
-      let result = parseUrlAndPath(this.uri)
-      this.url = result.url
-      this.path = result.path
       this.showRequestModal = true
     },
     hideRequestModal() {


### PR DESCRIPTION
Fixes saving a request when using environment variables.

url and path variables get overwritten with replaced values, so before saving we reconstruct them using the original uri variable.

This PR intends to fix #642.