### PR TITLE
Allow importing environment variables via Postman environment json files

### DIFF
--- a/components/environments/importExportEnvironment.vue
+++ b/components/environments/importExportEnvironment.vue
@@ -119,14 +119,27 @@ export default {
       let reader = new FileReader()
       reader.onload = event => {
         let content = event.target.result
-        let environments = JSON.parse(content)
-        let confirmation = this.$t("file_imported")
-        this.$store.commit("postwoman/importAddEnvironments", {
-          environments,
-          confirmation,
-        })
+        let importFileObj = JSON.parse(content)
+        if (importFileObj["_postman_variable_scope"] === "environment") {
+          this.importFromPostman(importFileObj)
+        } else {
+          this.importFromPostwoman(importFileObj)
+        }
       }
       reader.readAsText(this.$refs.inputChooseFileToImportFrom.files[0])
+    },
+    importFromPostwoman(environments) {
+      let confirmation = this.$t("file_imported")
+      this.$store.commit("postwoman/importAddEnvironments", {
+        environments,
+        confirmation,
+      })
+    },
+    importFromPostman(importFileObj) {
+      let environment = { name: importFileObj.name, variables: [] }
+      importFileObj.values.forEach(element => environment.variables.push({ key: element.key, value: element.value }));
+      let environments = [ environment ]
+      this.importFromPostwoman(environments)
     },
     exportJSON() {
       let text = this.environmentJson


### PR DESCRIPTION
When importing a JSON file during the environment import we check for the Postman specific field `_postman_variable_scope` which should be set to `environment`.

If so, we re-format the JSON to the Postwoman structure and call the existing import function.
If not, we assume it is a Postwoman file and import it as usual.

This PR intends to add the feature discussed in #759