### PR TITLE
Fixed Axios parsing JSON for non-JSON content-types

### DIFF
--- a/functions/strategies/AxiosStrategy.js
+++ b/functions/strategies/AxiosStrategy.js
@@ -9,7 +9,29 @@ const axiosWithProxy = async (req, { state }) => {
 }
 
 const axiosWithoutProxy = async (req, _store) => {
-  const res = await axios(req)
+  const res = await axios({
+    ...req,
+    transformResponse: [
+      (data, headers) => {
+        // If the response has a JSON content type, try parsing it
+        if (
+          headers["content-type"].startsWith("application/json") ||
+          headers["content-type"].startsWith("application/vnd.api+json") ||
+          headers["content-type"].startsWith("application/hal+json")
+        ) {
+          try {
+            const jsonData = JSON.parse(data)
+            return jsonData
+          } catch (e) {
+            return data
+          }
+        }
+
+        // Else return the string itself without any transformations
+        return data
+      },
+    ],
+  })
   return res
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "postwoman",
-    "version": "1.9.5",
+    "version": "1.9.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This PR intends to update the axios default behaviour of parsing JSON strings to JSON objects even if the content-type is not JSON type.

This PR fixes #869 