### PR TITLE
Added check if content-type header is present for transformResponse

### DIFF
--- a/functions/strategies/AxiosStrategy.js
+++ b/functions/strategies/AxiosStrategy.js
@@ -15,9 +15,10 @@ const axiosWithoutProxy = async (req, _store) => {
       (data, headers) => {
         // If the response has a JSON content type, try parsing it
         if (
-          headers["content-type"].startsWith("application/json") ||
-          headers["content-type"].startsWith("application/vnd.api+json") ||
-          headers["content-type"].startsWith("application/hal+json")
+          headers["content-type"] &&
+          (headers["content-type"].startsWith("application/json") ||
+            headers["content-type"].startsWith("application/vnd.api+json") ||
+            headers["content-type"].startsWith("application/hal+json"))
         ) {
           try {
             const jsonData = JSON.parse(data)


### PR DESCRIPTION
This PR adds a small check for the `content-type` header in the transformResponse override in the AxiosStrategy file.

This PR fixes #894 