### PR TITLE
Cancel Request from the Keyboard

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -15,7 +15,7 @@
   "subscribe": "Subscribe",
   "choose_language": "Choose Language",
   "shortcuts": "Shortcuts",
-  "send_request": "Send Request",
+  "send_request": "Send/Cancel Request",
   "save_to_collections": "Save to Collections",
   "copy_request_link": "Copy Request Link",
   "reset_request": "Reset Request",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2828,7 +2828,12 @@ export default {
     this._keyListener = function (e) {
       if (e.key === "g" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
-        this.sendRequest()
+        console.log(this.runningRequest)
+        if (!this.runningRequest) {
+          this.sendRequest()
+        } else {
+          this.cancelRequest()
+        }
       } else if (e.key === "s" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
         this.saveRequest()


### PR DESCRIPTION
This PR intends to add the ability to use `Ctrl+G` key combo to cancel running requests.

Also there is a update to the language entry for `send_request`