### PR TITLE
GraphQL response options only visible when a response is shown

### DIFF
--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -225,6 +225,7 @@
                 class="icon"
                 @click="downloadResponse"
                 ref="downloadResponse"
+                v-if="response"
                 v-tooltip="$t('download_file')"
               >
                 <i class="material-icons">get_app</i>
@@ -233,6 +234,7 @@
                 class="icon"
                 @click="copyResponse"
                 ref="copyResponseButton"
+                v-if="response"
                 v-tooltip="$t('copy_response')"
               >
                 <i class="material-icons">file_copy</i>


### PR DESCRIPTION
GraphQL response options (copy response and download response JSON) is only visible when a response is available.