### PR TITLE
Hide download response button for non-JSON responses

### DIFF
--- a/functions/utils/contenttypes.js
+++ b/functions/utils/contenttypes.js
@@ -9,9 +9,19 @@ export const knownContentTypes = [
 ]
 
 export function isJSONContentType(contentType) {
-  return (
-    contentType === "application/json" ||
-    contentType === "application/vnd.api+json" ||
-    contentType === "application/hal+json"
-  )
+  if (contentType.includes(";")) {
+    const [justContentType] = contentType.split(";")
+
+    return (
+      justContentType === "application/json" ||
+      justContentType === "application/vnd.api+json" ||
+      justContentType === "application/hal+json"
+    )
+  } else {
+    return (
+      contentType === "application/json" ||
+      contentType === "application/vnd.api+json" ||
+      contentType === "application/hal+json"
+    )
+  }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -973,7 +973,7 @@
                     class="icon"
                     @click="downloadResponse"
                     ref="downloadResponse"
-                    v-if="response.body"
+                    v-if="response.body && canDownloadResponse"
                     v-tooltip="$t('download_file')"
                   >
                     <i class="material-icons">get_app</i>
@@ -1610,6 +1610,14 @@ export default {
       return (
         this.contentType === "application/x-www-form-urlencoded" ||
         isJSONContentType(this.contentType)
+      )
+    },
+    canDownloadResponse() {
+      return (
+        this.response &&
+        this.response.headers &&
+        this.response.headers["content-type"] &&
+        isJSONContentType(this.response.headers["content-type"])
       )
     },
     uri: {


### PR DESCRIPTION
This PR intends to introduce the behaviour of the download response button above the response view to be hidden when the response is not a JSON response (detected from content-type).

This is a temporary fix for until the solution for #929 is implemented.