### PR TITLE
chore: add json file extension

### DIFF
--- a/packages/hoppscotch-app/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-app/components/collections/ImportExport.vue
@@ -412,7 +412,7 @@ export default defineComponent({
       const url = URL.createObjectURL(file)
       a.href = url
       // TODO get uri from meta
-      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}`
+      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}.json`
       document.body.appendChild(a)
       a.click()
       this.$toast.success(this.$t("state.download_started"), {

--- a/packages/hoppscotch-app/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/ImportExport.vue
@@ -249,7 +249,7 @@ export default defineComponent({
       const url = URL.createObjectURL(file)
       a.href = url
       // TODO get uri from meta
-      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}`
+      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}.json`
       document.body.appendChild(a)
       a.click()
       this.$toast.success(this.$t("state.download_started"), {

--- a/packages/hoppscotch-app/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-app/components/environments/ImportExport.vue
@@ -227,7 +227,7 @@ export default defineComponent({
       const url = URL.createObjectURL(file)
       a.href = url
       // TODO get uri from meta
-      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}`
+      a.download = `${url.split("/").pop().split("#")[0].split("?")[0]}.json`
       document.body.appendChild(a)
       a.click()
       this.$toast.success(this.$t("state.download_started"), {


### PR DESCRIPTION
I can not import the exported JSON without `.json` file extension intuitively.