### PR TITLE
feat: allow azure tenant to be specified for microsoft auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ MICROSOFT_CLIENT_ID="************************************************"
 MICROSOFT_CLIENT_SECRET="************************************************"
 MICROSOFT_CALLBACK_URL="http://localhost:3170/v1/auth/microsoft/callback"
 MICROSOFT_SCOPE="user.read"
+MICROSOFT_TENANT="common"
 
 # Mailer config
 MAILER_SMTP_URL="smtps://user@domain.com:pass@smtp.domain.com"

--- a/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
@@ -17,6 +17,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
       clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
       callbackURL: process.env.MICROSOFT_CALLBACK_URL,
       scope: [process.env.MICROSOFT_SCOPE],
+      tenant: process.env.MICROSOFT_TENANT,
       passReqToCallback: true,
       store: true,
     });


### PR DESCRIPTION
closes #3139

### Description
Many orgs using Azure AD will be running on their own "tenants" rather than the "common" tenant, and therefore need to be able to specify a tenant ID to allow oauth2 url's to be correctly generated by passport-microsoft.

passportjs.org/packages/passport-microsoft

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
