### PR TITLE
[bug]: Setting body type to none sets the content type in the request to application/x-www-form-urlencoded #3685

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Body.vue
+++ b/packages/hoppscotch-common/src/components/http/Body.vue
@@ -185,11 +185,7 @@ const isContentTypeAlreadyExist = () => {
 
 const updateContentType = (contentTypeItem, hide) => {
   if (contentTypeItem === 'none') {
-      body.contentType = null
-      body.contentType = null
-      // And remove the 'Content-Type' header
     body.contentType = null
-      // And remove the 'Content-Type' header
     headers.value = headers.value.filter(header => header.key.toLowerCase() !== 'content-type');
   } else {
     body.contentType = contentTypeItem


### PR DESCRIPTION
This PR addresses an issue where the 'Content-Type' header was incorrectly set to 'application/x-www-form-urlencoded' when the body type was set to 'none'. The changes ensure that the 'Content-Type' header is removed as expected in this scenario.

I would appreciate if you could review the changes and provide your valuable feedback. Thank you!