### PR TITLE
fix(common): preserve large number precision

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/contentParser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/contentParser.ts
@@ -160,7 +160,7 @@ const getXMLBody = (rawData: string) =>
   )
 
 const getFormattedJSON = flow(
-  safeParseJSON,
+  (str: string) => safeParseJSON(str, false, true),
   O.map((parsedJSON) => JSON.stringify(parsedJSON, null, 2)),
   O.getOrElse(() => "{ }")
 )

--- a/packages/hoppscotch-common/src/helpers/functional/json.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/json.ts
@@ -1,6 +1,7 @@
 import * as O from "fp-ts/Option"
 import * as E from "fp-ts/Either"
 import { pipe, flow } from "fp-ts/function"
+import * as LosslessJSON from "lossless-json"
 
 import { MediaType, RelayResponseBody } from "@hoppscotch/kernel"
 
@@ -8,23 +9,44 @@ import { decodeToString } from "~/helpers/functional/parse"
 import { safeParseJSONOrYAML } from "./yaml"
 
 type SafeParseJSON = {
-  (str: string, convertToArray: true): O.Option<Array<unknown>>
-  (str: string, convertToArray?: false): O.Option<Record<string, unknown>>
+  (
+    str: string,
+    convertToArray: true,
+    lossless?: boolean
+  ): O.Option<Array<unknown>>
+  (
+    str: string,
+    convertToArray?: false,
+    lossless?: boolean
+  ): O.Option<Record<string, unknown>>
 }
+
+const losslessReviver = (_key: string, value: any) =>
+  value && value.isLosslessNumber ? value.toString() : value
+
+const parseWith = (lossless: boolean) => (str: string) =>
+  lossless ? LosslessJSON.parse(str, losslessReviver) : JSON.parse(str)
+
+const maybeConvertToArray = (convertToArray: boolean) => (data: any) =>
+  convertToArray ? (Array.isArray(data) ? data : [data]) : data
 
 /**
  * Checks and Parses JSON string
  * @param str Raw JSON data to be parsed
+ * @param convertToArray Whether to convert non-array results to array
+ * @param lossless Whether to use lossless parsing for floating point precision
  * @returns Option type with some(JSON data) or none
  */
-export const safeParseJSON: SafeParseJSON = (str, convertToArray = false) =>
-  O.tryCatch(() => {
-    const data = JSON.parse(str)
-    if (convertToArray) {
-      return Array.isArray(data) ? data : [data]
-    }
-    return data
-  })
+export const safeParseJSON: SafeParseJSON = (
+  str,
+  convertToArray = false,
+  lossless = false
+) =>
+  pipe(
+    str,
+    (s) => O.tryCatch(() => parseWith(lossless)(s)),
+    O.map(maybeConvertToArray(convertToArray))
+  )
 
 /**
  * Checks if given string is a JSON string
@@ -41,8 +63,11 @@ export const parseBytesToJSON = <T>(content: Uint8Array): O.Option<T> =>
     E.fold(() => O.none, O.some)
   )
 
-export const parseJSONAs = <T>(str: string): E.Either<Error, T> =>
-  E.tryCatch(() => JSON.parse(str) as T, E.toError)
+export const parseJSONAs = <T>(
+  str: string,
+  lossless = false
+): E.Either<Error, T> =>
+  E.tryCatch(() => parseWith(lossless)(str) as T, E.toError)
 
 export const parseBodyAsJSON = <T>(body: RelayResponseBody): O.Option<T> =>
   pipe(

--- a/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
@@ -11,8 +11,12 @@ const Processors = {
   json: {
     process: (body: unknown): E.Either<Error, ContentType> =>
       pipe(
-        typeof body === "string" ? parseJSONAs<unknown>(body) : E.right(body),
-        E.map(() => content.json(body, MediaType.APPLICATION_JSON)),
+        typeof body === "string"
+          ? parseJSONAs<unknown>(body, true)
+          : E.right(body),
+        E.map((parsedBody) =>
+          content.json(parsedBody, MediaType.APPLICATION_JSON)
+        ),
         E.orElse(() => E.right(content.text(body, MediaType.TEXT_PLAIN)))
       ),
   },


### PR DESCRIPTION
This fixes an issue in kernel processors where large integers in JSON request bodies lose precision during processing. Basically we were hitting the JavaScript's floating-point precision limitations affecting large integers.

Closes #5155
Closes HFE-899

When users input large numbers like `"dsid": 990000000262240065` in JSON request bodies, the value gets converted to `990000000262240100` due to precision loss during JSON processing. (See [Number.MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER))

The cause was the JSON processor was unnecessarily loss-y parsing JSON objects.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/a532e17b-8516-419d-99c1-90e4c73f98ac) | ![image](https://github.com/user-attachments/assets/de562d08-b206-4835-a729-b7f74c66fc1d) |
| ![image](https://github.com/user-attachments/assets/daa90382-964a-4aa2-9ab2-d41b90665954) | ![image](https://github.com/user-attachments/assets/86fee0b2-28f6-4fc2-9106-81a0fb62dd63) |

### Testing

Use 
```
{ "dsid": 990000000262240065 }
```
with `application/json` content-type on any echo server such as `https://echo.hoppscotch.io` or use `nc -l 8080` with `localhost:8080` on the desktop app

| Request sent | Request received |
|---|---|
| ![image](https://github.com/user-attachments/assets/17d32459-acd6-46ca-952d-476ab7e59f04) | ![image](https://github.com/user-attachments/assets/86fee0b2-28f6-4fc2-9106-81a0fb62dd63) |