### PR TITLE
chore: security patches for the dependency chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
       "@babel/runtime@<7.26.10": "7.26.10",
       "apiconnect-wsdl": "2.0.36",
       "@xmldom/xmldom": "0.8.10",
-      "multer@1.4.5-lts.2": "2.0.0"
+      "multer@1.4.5-lts.2": "2.0.1",
+      "brace-expansion@2.0.1": "2.0.2",
+      "brace-expansion@1.1.11": "1.1.12"
     },
     "packageExtensions": {
       "@hoppscotch/httpsnippet": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,9 @@ overrides:
   '@babel/runtime@<7.26.10': 7.26.10
   apiconnect-wsdl: 2.0.36
   '@xmldom/xmldom': 0.8.10
-  multer@1.4.5-lts.2: 2.0.0
+  multer@1.4.5-lts.2: 2.0.1
+  brace-expansion@2.0.1: 2.0.2
+  brace-expansion@1.1.11: 1.1.12
 
 packageExtensionsChecksum: sha256-Qhsch/G1LLagBL1kRb8nf11C5HcyCWi8Px3h3uWxYUw=
 
@@ -7341,11 +7343,11 @@ packages:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -7726,9 +7728,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concat-stream@1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
@@ -10948,8 +10950,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  multer@2.0.0:
-    resolution: {integrity: sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==}
+  multer@2.0.1:
+    resolution: {integrity: sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==}
     engines: {node: '>= 10.16.0'}
 
   mute-stream@0.0.8:
@@ -19456,7 +19458,7 @@ snapshots:
       '@nestjs/core': 11.1.1(@nestjs/common@11.1.1(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.5
       express: 5.1.0
-      multer: 2.0.0
+      multer: 2.0.1
       path-to-regexp: 8.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -22045,12 +22047,12 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -22480,11 +22482,11 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concat-stream@1.6.2:
+  concat-stream@2.0.0:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 3.6.2
       typedarray: 0.0.6
 
   confbox@0.1.7: {}
@@ -26312,27 +26314,27 @@ snapshots:
 
   minimatch@10.0.1:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@4.2.1:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@4.2.3:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@5.1.6:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 
@@ -26939,11 +26941,11 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  multer@2.0.0:
+  multer@2.0.1:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
-      concat-stream: 1.6.2
+      concat-stream: 2.0.0
       mkdirp: 0.5.6
       object-assign: 4.1.1
       type-is: 1.6.18

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,7 +1,7 @@
 # This step is used to build a custom build of Caddy to prevent
 # vulnerable packages on the dependency chain
-FROM alpine:3.21.3 AS caddy_builder
-RUN apk add curl go
+FROM alpine:3.22.0 AS caddy_builder
+RUN apk add curl go git
 
 RUN mkdir -p /tmp/caddy-build
 
@@ -25,6 +25,8 @@ RUN go get github.com/go-jose/go-jose/v3@v3.0.4
 RUN go get golang.org/x/crypto@v0.35.0
 # Patch to resolve CVE-2025-22872 on net
 RUN go get golang.org/x/net@v0.38.0
+# Patch to resolve GHSA-vrw8-fxc6-2r93 on chi
+RUN go get github.com/go-chi/chi/v5@v5.2.2
 
 RUN go mod vendor
 
@@ -38,7 +40,7 @@ RUN apk add nodejs curl
 
 # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
 # TODO: Find a better method which is resistant to supply chain attacks
-RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh"
+RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.4.2 sh"
 
 WORKDIR /usr/src/app
 
@@ -47,7 +49,7 @@ ENV HOPP_ALLOW_RUNTIME_ENV=true
 # Required by @hoppscotch/js-sandbox to build `isolated-vm`
 RUN apk add python3 make g++ zlib-dev brotli-dev c-ares-dev nghttp2-dev openssl-dev icu-dev
 
-RUN npm install -g pnpm@10.2.1
+RUN npm install -g pnpm@10.12.3
 COPY pnpm-lock.yaml .
 RUN pnpm fetch
 
@@ -69,12 +71,12 @@ RUN apk add nodejs curl
 
 # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
 # TODO: Find a better method which is resistant to supply chain attacks
-RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh"
+RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.4.2 sh"
 
 # Install caddy
 COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
 
-RUN npm install -g pnpm@10.2.1
+RUN npm install -g pnpm@10.12.3
 
 COPY --from=base_builder  /usr/src/app/packages/hoppscotch-backend/backend.Caddyfile /etc/caddy/backend.Caddyfile
 COPY --from=backend_builder /dist/backend /dist/backend
@@ -112,7 +114,7 @@ RUN apk add nodejs curl
 
 # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
 # TODO: Find a better method which is resistant to supply chain attacks
-RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh"
+RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.4.2 sh"
 
 # Install caddy
 COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
@@ -155,7 +157,7 @@ RUN apk add nodejs curl
 
 # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
 # TODO: Find a better method which is resistant to supply chain attacks
-RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh"
+RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.4.2 sh"
 
 # Install caddy
 COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
@@ -182,7 +184,7 @@ RUN apk add nodejs curl
 
 # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
 # TODO: Find a better method which is resistant to supply chain attacks
-RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh"
+RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.4.2 sh"
 
 # Caddy install
 COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
@@ -199,7 +201,7 @@ LABEL org.opencontainers.image.source="https://github.com/hoppscotch/hoppscotch"
 
 RUN apk add tini
 
-RUN npm install -g pnpm@10.2.1
+RUN npm install -g pnpm@10.12.3
 
 # Copy necessary files
 # Backend files


### PR DESCRIPTION
This PR intends to update dependencies that are vulnerable in the dependency chain.

### What's changed
- Add version pinning for `brace-expansion@2.0.1` and `brace-expansion@1.1.11` independently to their respective patch releases that fix their vulnerabilities.
- Bump `caddy_builder` container build step's Alpine version to `3.22.0` to get a newer version of Go that resolves a vulnerability in the Go stdlib.
- Patch `caddy`'s dependency `chi` to use a version that fixes GHSA-vrw8-fxc6-2r93
- Bump `npm` versions in all containers to be `11.4.2` to remove usage of a vulnerable version of `brace-expansion`
- Bump `pnpm` versions in all containers to be `10.12.3` to remove usage of a vulnerable version of `brace-expansion`

### Notes to reviewers
Make sure the containers boot and function properly.
