### PR TITLE
docs: add Linux installation instructions (#5135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 - Web : [hoppscotch.io](https://hoppscotch.io)
 - Windows/Linux/macOS : [Desktop Apps](https://docs.hoppscotch.io/documentation/clients/desktop#download-hoppscotch-desktop-app)
 
+## **Installation**
+
+### **Linux**
+
+Install Hoppscotch desktop app on Linux with a single command:
+
+```bash
+sudo curl -fsSL https://gist.githubusercontent.com/mrKarton/2ba5bbc6d9ab894afa56752094714611/raw/598a89a5faf6e150c548c9fe2b3926a7e4785b0d/hoppscotch-installer.bash | bash
+```
+
+This script will automatically download and install the Hoppscotch desktop application with a desktop entry for easy access from your applications menu.
+
 ## **Usage**
 
 1. Provide your API endpoint in the URL field


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5135

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

This PR adds a simple one-line installation command for Linux users to easily install the Hoppscotch desktop application. The installation script automatically downloads the latest AppImage, sets up the application in `/opt/hoppscotch`, and creates a desktop entry for easy access from the applications menu.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

- [x] Added new "Installation" section to README.md
- [x] Added Linux subsection with one-line installation command
- [x] Included clear description of what the installation script does
- [x] Used the community-provided script from @mrKarton's gist

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

- The installation script referenced is hosted on GitHub Gist by @mrKarton (https://gist.github.com/mrKarton/2ba5bbc6d9ab894afa56752094714611)
- The script downloads the latest Hoppscotch Linux AppImage and creates a proper desktop entry
- This addresses a community request to make Linux installation easier without overengineering the solution
- The installation command requires sudo privileges as it installs system-wide in `/opt/` and `/usr/share/applications/`
- Script has been tested on Arch Linux as mentioned in the original issue