### PR TITLE
feat(common): enhance URL parsing to use environment variables on openapi import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -756,9 +756,9 @@ const parseOpenAPIUrl = (
   if (objectHasProperty(doc, "swagger")) {
     // TODO: dynamically add doc.host, doc.basePath value as variables in the environment if available. or notify user to add it.
     // add base url variable to each request
-    const hostVar = "<<baseUrl>>"
-    const basePathVar = doc.basePath ? "<<basePath>>" : ""
-    return `${hostVar}${basePathVar}`
+    const host = doc.host?.trim() || "<<baseUrl>>"
+    const basePath = doc.basePath?.trim() || ""
+    return `${host}${basePath}`
   }
 
   /**


### PR DESCRIPTION
Closes FE-914 #5177

Improve URL parsing to utilize environment variables for host and base path, allowing for more dynamic configurations. Clean up code for better readability.