### PR TITLE
chore: hide advanced configuration for non-authCode grant types

### DIFF
--- a/packages/hoppscotch-common/src/components/http/authorization/OAuth2.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/OAuth2.vue
@@ -172,7 +172,7 @@
       </span>
     </div>
 
-    <div class="flex flex-col">
+    <div v-if="selectedGrantTypeID === 'authCode'" class="flex flex-col">
       <div
         class="flex cursor-pointer items-center justify-between py-2 pl-4 text-secondaryLight transition hover:text-secondary"
         @click="toggleAdvancedConfig"


### PR DESCRIPTION
Restrict the display of advanced configuration options to only the authCode grant type.