### PR TITLE
fix: correctly resolve request variables during collection runs

### DIFF
--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -589,11 +589,11 @@ export function runTestRunnerRequest(
 
     const finalRequestVariables = pipe(
       request.requestVariables,
-      A.filter((v): v is HoppRESTRequestVariable => v.active),
-      A.map((v) => ({
-        key: v.key,
-        initialValue: v.value,
-        currentValue: v.value,
+      A.filter(({ active }) => active),
+      A.map(({ key, value }) => ({
+        key,
+        initialValue: value,
+        currentValue: value,
         secret: false,
       }))
     )


### PR DESCRIPTION
Closes FE-958

This PR fixes the issue in collection runner flow where the request variable was not getting resolved while running.