### PR TITLE
fix: update masked secret environment value after replace action

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -177,6 +177,19 @@ watch(
   }
 )
 
+//update secretText when modelValue changes
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    if (secretText.value !== newVal) {
+      secretText.value = newVal
+    }
+  },
+  {
+    immediate: true,
+  }
+)
+
 onClickOutside(autoCompleteWrapper, () => {
   showSuggestionPopover.value = false
 })


### PR DESCRIPTION
Closes FE-982 #5317 

This PR fixes the issue with the secret environment UI, where the masked environment value was not getting updated when copying the initial value to the current value and vice versa.
