### PR TITLE
fix: `orderIndex` update to scope by collection ID

### DIFF
--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -119,7 +119,10 @@ export class TeamRequestService {
           await this.prisma.lockTableExclusive(tx, 'TeamRequest');
 
           await tx.teamRequest.updateMany({
-            where: { orderIndex: { gte: dbTeamReq.orderIndex } },
+            where: {
+              collectionID: dbTeamReq.collectionID,
+              orderIndex: { gte: dbTeamReq.orderIndex },
+            },
             data: { orderIndex: { decrement: 1 } },
           });
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

This pull request makes a targeted change to the logic for updating the `orderIndex` of team requests in the `TeamRequestService`. The update ensures that only requests within the same collection are affected when decrementing `orderIndex` values.

Closes #5364.

* Restricts the scope of the `updateMany` operation in `TeamRequestService` to only affect requests with the same `collectionID` as the current team request, preventing unintended changes across collections.


### Reproduce the issue
In the team workspace, create two collections. Create three requests in each collection.
Now try to delete 2nd (middle) team request from any one collection.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Simulate [Reproduce the issue] section and see if the issue resolved.


