### PR TITLE
docs(cli): add workspace dependency build requirements to README

### DIFF
--- a/packages/hoppscotch-cli/README.md
+++ b/packages/hoppscotch-cli/README.md
@@ -133,8 +133,10 @@ The Hoppscotch CLI follows **pre-1.0 semantic versioning** conventions while in 
 
 1. Clone the repository, make sure you've installed latest [pnpm](https://pnpm.io).
 2. `pnpm install`
-3. Build required workspace dependencies:
+3. Build required workspace dependencies (if needed):
    ```bash
+   # These auto-build via postinstall hooks during 'pnpm install'
+   # Rebuild manually only when you make changes to these packages:
    pnpm --filter @hoppscotch/data run build
    pnpm --filter @hoppscotch/js-sandbox run build
    ```
@@ -167,11 +169,13 @@ Please note we have a code of conduct, please follow it in all your interactions
 
    ```bash
    pnpm install
-   # Build required workspace dependencies first
+   # Build required workspace dependencies (if needed)
+   # These auto-build via postinstall hooks during 'pnpm install'
+   # Rebuild manually only when you make changes to these packages:
    pnpm --filter @hoppscotch/data run build
    pnpm --filter @hoppscotch/js-sandbox run build
    # Then build the CLI
-   pnpm run build
+   cd packages/hoppscotch-cli && pnpm run build
    ```
 
 2. In order to test locally, you can use two types of package linking:


### PR DESCRIPTION
Add instructions to build `@hoppscotch/data` and `@hoppscotch/js-sandbox` packages before building the CLI to resolve dependency resolution issues.

The CLI depends on these workspace packages, which need to be built locally before the CLI can be compiled successfully.

### What's changed
- [x] Updated "Developing" section in CLI README with workspace dependencies build steps
- [x] Updated "Set Up The Development Environment" section with the same build instructions
- [x] Added explanatory comments about postinstall hooks and when manual rebuilds are needed
- [x] Clarified that manual rebuilds are primarily needed when making changes to dependency packages
- [x] Fixed working directory context for CLI build command in "Set Up The Development Environment" section
- [x] Maintained proper step numbering after adding new build steps

### Notes to reviewers
This is a documentation-only change that adds missing build instructions for workspace dependencies. I tried to use CLI on my machine, and the CLI build was failing because it depends on `@hoppscotch/data` and `@hoppscotch/js-sandbox` packages that need to be built locally before the CLI can be compiled.

The documentation now clarifies that:
- These packages auto-build via postinstall hooks during `pnpm install`
- Manual builds are primarily needed when making changes to these packages during development
- The CLI build command must be run from the `packages/hoppscotch-cli` directory

The changes are minimal and focused - only adding the necessary build commands with clear comments explaining the order of operations and when rebuilds are needed.