### PR TITLE
  Add missing 'as const' assertions in error constants[HacktoberFest]

### DIFF
--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -22,19 +22,19 @@ export const ADMIN_CAN_NOT_BE_DELETED =
  * Token Authorization failed (Check 'Authorization' Header)
  * (GqlAuthGuard)
  */
-export const AUTH_FAIL = 'auth/fail';
+export const AUTH_FAIL = 'auth/fail' as const;
 
 /**
  * Invalid JSON
  * (Utils)
  */
-export const JSON_INVALID = 'json_invalid';
+export const JSON_INVALID = 'json_invalid' as const;
 
 /**
  * Auth Provider not specified
  * (Auth)
  */
-export const AUTH_PROVIDER_NOT_SPECIFIED = 'auth/provider_not_specified';
+export const AUTH_PROVIDER_NOT_SPECIFIED = 'auth/provider_not_specified' as const;
 
 /**
  * Email not provided by OAuth provider
@@ -168,7 +168,7 @@ export const TEAM_NOT_REQUIRED_ROLE = 'team/not_required_role' as const;
  * Team name validation failure
  * (TeamService)
  */
-export const TEAM_NAME_INVALID = 'team/name_invalid';
+export const TEAM_NAME_INVALID = 'team/name_invalid' as const;
 
 /**
  * Couldn't find the sync data from the user


### PR DESCRIPTION
 ## Summary
  - Add missing `as const` type assertions to error constant declarations
  - Improve type safety and consistency across all error constants
  - Ensure TypeScript treats these as literal types rather than general strings

  ## Test plan
  - [x] Verify TypeScript compilation succeeds
  - [x] Confirm error constants maintain proper typing
  - [x] Check that error handling functionality remains unchanged
