### PR TITLE
  Improve import organization and quote consistency in agent main.ts[HacktoberFest]

### DIFF
--- a/packages/hoppscotch-agent/src/main.ts
+++ b/packages/hoppscotch-agent/src/main.ts
@@ -2,11 +2,9 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import './index.css'
 
-import { plugin as HoppUI } from "@hoppscotch/ui"
-
-import "@hoppscotch/ui/themes.css"
-
-import "@hoppscotch/ui/style.css"
+import { plugin as HoppUI } from '@hoppscotch/ui'
+import '@hoppscotch/ui/themes.css'
+import '@hoppscotch/ui/style.css'
 
 createApp(App)
   .use(HoppUI)


### PR DESCRIPTION
 ## Summary
  - Group related HoppUI imports together for better organization
  - Standardize quote usage from double quotes to single quotes
  - Remove unnecessary spacing between related imports

  ## Test plan
  - [x] Verify application builds and runs correctly
  - [x] Confirm import statements work as expected
  - [x] Check that HoppUI plugin loads properly
