### PR TITLE
  Add missing type annotations to setupSwagger function[HacktoberFest]

### DIFF
--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -12,7 +12,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { InfraTokenModule } from './infra-token/infra-token.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
-function setupSwagger(app, isProduction: boolean) {
+function setupSwagger(app: NestExpressApplication, isProduction: boolean): void {
   const swaggerDocPath = '/api-docs';
 
   const config = new DocumentBuilder()


### PR DESCRIPTION
 ## Summary
  - Add missing type annotation for `app` parameter as `NestExpressApplication`
  - Add explicit `void` return type annotation
  - Improve type safety and code documentation

  ## Test plan
  - [x] Verify TypeScript compilation succeeds without errors
  - [x] Confirm Swagger setup functionality remains unchanged
  - [x] Check that application starts and serves API documentation correctly