### PR TITLE
feat: add `$randomCompanyName` predefined variable

### DIFF
--- a/packages/hoppscotch-data/src/predefinedVariables.ts
+++ b/packages/hoppscotch-data/src/predefinedVariables.ts
@@ -289,33 +289,33 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
     },
   },
 
-  // company Name
+  // Company names
   {
     key: "$randomCompanyName",
-    description: "A random company name",
-    getValue: () : string => {
+    description: "A random company name.",
+    getValue: () => {
       const companyNames = [
-        'Nexora',
-        'CodeLoom',
-        'BitHaven',
-        'SynapseWorks',
-        'VoltEdge',
-        'Elevoria',
-        'Bridgent',
-        'Verniq',
-        'Corevia',
-        'Stratigen',
-        'Lunova Studio',
-        'Pixelora',
-        'MuseMind',
-        'BrightNest',
-        'Auralis',
-        'VerdaFlow',
-        'BloomShift',
-        'PureTrek',
-        'EcoVerse',
-        'ReLeaf Labs',
-      ];
+        "Nexora",
+        "CodeLoom",
+        "BitHaven",
+        "SynapseWorks",
+        "VoltEdge",
+        "Elevoria",
+        "Bridgent",
+        "Verniq",
+        "Corevia",
+        "Stratigen",
+        "Lunova Studio",
+        "Pixelora",
+        "MuseMind",
+        "BrightNest",
+        "Auralis",
+        "VerdaFlow",
+        "BloomShift",
+        "PureTrek",
+        "EcoVerse",
+        "ReLeaf Labs",
+      ]
 
       return companyNames[Math.floor(Math.random() * companyNames.length)]
     },


### PR DESCRIPTION
### What's changed
Hello, this PR adds a new predefined variable for generating random company names in the Hoppscotch data package.

- Adds `$randomCompanyName` predefined variable with 20 sample company names
- Implements random selection logic using `Math.random()` and `Math.floor()`

