### PR TITLE
chore: mock server name validation and prevent duplicates

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
@@ -19,7 +19,6 @@ import {
   MOCK_SERVER_DELETION_FAILED,
   MOCK_SERVER_LOG_NOT_FOUND,
   MOCK_SERVER_LOG_DELETION_FAILED,
-  MOCK_SERVER_ALREADY_EXISTS,
 } from 'src/errors';
 import { randomBytes } from 'crypto';
 import { WorkspaceType } from 'src/types/WorkspaceTypes';
@@ -310,17 +309,6 @@ export class MockServerService {
       const collectionValidation = await this.validateCollection(user, input);
       if (E.isLeft(collectionValidation)) {
         return E.left(collectionValidation.left);
-      }
-
-      // Check if already exists a mock server with the same collection
-      const existingMockServer = await this.prisma.mockServer.findFirst({
-        where: {
-          collectionID: input.collectionID,
-          deletedAt: null,
-        },
-      });
-      if (existingMockServer) {
-        return E.left(MOCK_SERVER_ALREADY_EXISTS);
       }
 
       // Create mock server


### PR DESCRIPTION

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->


This pull request introduces improved validation and error handling for mock server creation and updates in the backend. The most significant changes are the relaxed name validation rules for mock servers and the addition of a check to prevent duplicate mock servers for the same collection.

**Validation improvements:**

* Relaxed the validation for the `name` field in both `CreateMockServerInput` and `UpdateMockServerInput` classes: replaced `@IsAlphanumeric()` with `@Matches(/^[a-zA-Z0-9 ._-]+$/)` to allow spaces, dots, underscores, and hyphens, and added `@IsString()` for type safety. [[1]](diffhunk://#diff-93cc9f5dc50179e0fc4d1e7f4f3ab8a5e42a49ded6adb276524b9620a82c8d8fL10-R13) [[2]](diffhunk://#diff-93cc9f5dc50179e0fc4d1e7f4f3ab8a5e42a49ded6adb276524b9620a82c8d8fR106-R112) [[3]](diffhunk://#diff-93cc9f5dc50179e0fc4d1e7f4f3ab8a5e42a49ded6adb276524b9620a82c8d8fR157-R164)

**Error handling enhancements:**

* Added a check in `MockServerService` to prevent creating a mock server with a collection ID that already exists and is not deleted, returning a `MOCK_SERVER_ALREADY_EXISTS` error if found. [[1]](diffhunk://#diff-c8edfb7c8a3b0950506b59351c3ce1a89ec044d548f2ab0d1f81f43d97f65d4aR22) [[2]](diffhunk://#diff-c8edfb7c8a3b0950506b59351c3ce1a89ec044d548f2ab0d1f81f43d97f65d4aR315-R325)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil