### PR TITLE
feat(ci): desktop workflow with platform jobs

### DIFF
--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -11,7 +11,7 @@ on:
         default: "hoppscotch/hoppscotch"
       branch:
         description: Branch to checkout
-        required: false
+        required: true
         default: "main"
       tag:
         description: Tag to checkout (takes precedence over branch if provided)
@@ -26,6 +26,26 @@ on:
         required: false
         type: boolean
         default: false
+      build_linux:
+        description: Build for Linux
+        type: boolean
+        required: false
+        default: true
+      build_windows:
+        description: Build for Windows
+        type: boolean
+        required: false
+        default: true
+      build_macos_x64:
+        description: Build for macOS x64
+        type: boolean
+        required: false
+        default: true
+      build_macos_arm64:
+        description: Build for macOS ARM64
+        type: boolean
+        required: false
+        default: true
 env:
   CARGO_TERM_COLOR: always
   WORKSPACE_PATH: ${{ github.workspace }}
@@ -35,18 +55,19 @@ env:
 jobs:
   build-linux:
     runs-on: ubuntu-24.04
+    if: ${{ inputs.build_linux }}
     steps:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
-          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+          token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.2.1
+          version: 10.18.3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -131,16 +152,17 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux
+          name: selfhost-desktop-linux
           path: dist/*
   build-windows:
     runs-on: windows-latest
+    if: ${{ inputs.build_windows }}
     steps:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
-          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+          token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Set Perl environment variables
         shell: pwsh
         run: |
@@ -151,7 +173,7 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.2.1
+          version: 10.18.3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -161,7 +183,7 @@ jobs:
         shell: pwsh
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://github.com/Levminer/trusted-signing-cli/releases/download/0.5.0/trusted-signing-cli.exe" -OutFile "trusted-signing-cli.exe"
+          Invoke-WebRequest -Uri "https://github.com/Levminer/trusted-signing-cli/releases/download/0.8.0/trusted-signing-cli.exe" -OutFile "trusted-signing-cli.exe"
           Move-Item -Path "trusted-signing-cli.exe" -Destination "$env:GITHUB_WORKSPACE\trusted-signing-cli.exe"
           echo "$env:GITHUB_WORKSPACE" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
       - name: Setting up Windows Signing Environment
@@ -238,22 +260,23 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windows
+          name: selfhost-desktop-windows
           path: dist/*
   build-macos-x64:
     runs-on: macos-latest
+    if: ${{ inputs.build_macos_x64 }}
     steps:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
-          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+          token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.2.1
+          version: 10.18.3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -271,8 +294,8 @@ jobs:
       - uses: apple-actions/import-codesign-certs@v3
         if: ${{ inputs.disable_signing != true }}
         with:
-          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
-          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - uses: actions/cache@v4
         with:
@@ -310,10 +333,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.HOPPSCOTCH_APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.HOPPSCOTCH_APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.HOPPSCOTCH_APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.HOPPSCOTCH_APPLE_SIGNING_IDENTITY }}
           RUST_LOG: debug
         run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target x86_64-apple-darwin
       - name: Build Tauri app without Apple signing
@@ -334,22 +357,23 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: macos-x64
+          name: selfhost-desktop-macos-x64
           path: dist/*
   build-macos-arm64:
     runs-on: macos-latest
+    if: ${{ inputs.build_macos_arm64 }}
     steps:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
-          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+          token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.2.1
+          version: 10.18.3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -367,8 +391,8 @@ jobs:
       - uses: apple-actions/import-codesign-certs@v3
         if: ${{ inputs.disable_signing != true }}
         with:
-          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
-          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - uses: actions/cache@v4
         with:
@@ -406,10 +430,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.HOPPSCOTCH_APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.HOPPSCOTCH_APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.HOPPSCOTCH_APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.HOPPSCOTCH_APPLE_SIGNING_IDENTITY }}
           RUST_LOG: debug
         run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target aarch64-apple-darwin
       - name: Build Tauri app without Apple signing
@@ -430,11 +454,12 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: macos-aarch64
+          name: selfhost-desktop-macos-aarch64
           path: dist/*
   create-update-manifest:
     needs: [build-linux, build-windows, build-macos-x64, build-macos-arm64]
     runs-on: ubuntu-latest
+    if: ${{ inputs.build_linux && inputs.build_windows && inputs.build_macos_x64 && inputs.build_macos_arm64 }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -452,19 +477,19 @@ jobs:
             "pub_date": "${CURRENT_DATE}",
             "platforms": {
               "linux-x86_64": {
-                "signature": "$(cat artifacts/linux/Hoppscotch_SelfHost_linux_x64.AppImage.sig)",
+                "signature": "$(cat artifacts/selfhost-desktop-linux/Hoppscotch_SelfHost_linux_x64.AppImage.sig)",
                 "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_linux_x64.AppImage"
               },
               "windows-x86_64": {
-                "signature": "$(cat artifacts/windows/Hoppscotch_SelfHost_win_x64.msi.sig)",
+                "signature": "$(cat artifacts/selfhost-desktop-windows/Hoppscotch_SelfHost_win_x64.msi.sig)",
                 "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_win_x64.msi"
               },
               "darwin-x86_64": {
-                "signature": "$(cat artifacts/macos-x64/Hoppscotch_SelfHost_mac_x64.tar.gz.sig)",
+                "signature": "$(cat artifacts/selfhost-desktop-macos-x64/Hoppscotch_SelfHost_mac_x64.tar.gz.sig)",
                 "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_mac_x64.tar.gz"
               },
               "darwin-aarch64": {
-                "signature": "$(cat artifacts/macos-aarch64/Hoppscotch_SelfHost_mac_aarch64.tar.gz.sig)",
+                "signature": "$(cat artifacts/selfhost-desktop-macos-aarch64/Hoppscotch_SelfHost_mac_aarch64.tar.gz.sig)",
                 "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_mac_aarch64.tar.gz"
               }
             }
@@ -473,5 +498,5 @@ jobs:
       - name: Upload manifest
         uses: actions/upload-artifact@v4
         with:
-          name: update-manifest
+          name: selfhost-desktop-update-manifest
           path: artifacts/hoppscotch-selfhost-desktop.json


### PR DESCRIPTION
 Plus inputs and other standardizations

 This updates the Desktop Self Host workflow with selective platform builds,
 standardized secret naming, and artifact organization, synchronizing with
 the CI workflow patterns and completing the Nov's CI/CD updation cycle.

 Closes FE-993
 Closes FE-995
 Closes FE-1038
 Closes FE-1039
 Closes FE-1040

 The Desktop workflow lacked selective platform build controls and used
 inconsistent secret naming compared to the Agent workflow. This created
 issues with unnecessary builds and made cross-workflow maintenance
 difficult, especially with different prod/dev secrets and certificates.

 ## Changes

 Added individual boolean inputs for selective platform builds:
 `build_linux`, `build_windows`, `build_macos_x64`, and `build_macos_arm64`.

 Each input defaults to `true` to maintain existing behavior where all
 platforms build by default. Jobs use conditional execution based on
 corresponding inputs, allowing users to trigger specific platform
 builds without running the entire workflow.

 ```yaml
 on:
   workflow_dispatch: inputs: build_linux: 
   description: Build for Linux
   type: boolean
   required: false
   default: true
 ```

 The manifest generation job runs only when all required
 platforms (Linux, Windows, macOS x64/ARM64) are built, strictly
 preventing incomplete update manifests.

 ### Secret Naming Standardization

 Updated Apple signing secrets to use `HOPPSCOTCH_` prefix matching the
 Agent workflow: `APPLE_CERTIFICATE` to
 `HOPPSCOTCH_APPLE_CERTIFICATE`, `APPLE_ID` to `HOPPSCOTCH_APPLE_ID`,
 `APPLE_PASSWORD` to `HOPPSCOTCH_APPLE_PASSWORD`, `APPLE_TEAM_ID` to
 `HOPPSCOTCH_APPLE_TEAM_ID`, and `APPLE_SIGNING_IDENTITY` to
 `HOPPSCOTCH_APPLE_SIGNING_IDENTITY`.

 This provides more granular control of which specific set of certs are
 being used for the run (swapping out prefixes).

 Also updated repository checkout token to 
 `HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN` 
 for overall consistency with agent + sh-desktop.

 ```yaml
 env:
   APPLE_ID: ${{ secrets.HOPPSCOTCH_APPLE_ID }} 
   APPLE_PASSWORD: ${{ secrets.HOPPSCOTCH_APPLE_PASSWORD }} 
   APPLE_TEAM_ID: ${{ secrets.HOPPSCOTCH_APPLE_TEAM_ID }}
  ```

 ### Tool Version Updates

 Updated pnpm from version `10.2.1` to `10.18.3` for consistency across
 workflows. Updated Windows signing to use trusted-signing-cli `0.8.0`
 downloaded directly instead of `0.5.0`.

 ```yaml
 - name: Setup pnpm 
   uses: pnpm/action-setup@v4 
   with: version: 10.18.3
 ```

 ### Artifacts

 Standardized artifact naming using pattern
 `selfhost-desktop-{platform}` for workflow artifacts to distinguish from
 Agent artifacts and improve organization.

 Updated manifest generation to reference new artifact paths:
 `selfhost-desktop-linux`, `selfhost-desktop-windows`,
 `selfhost-desktop-macos-x64`, `selfhost-desktop-macos-aarch64`.

 ### Branch Input Requirement

 Made `branch` input required (changed from `required: false` to
 `required: true`) to make sure there's explicit branch specification
 for builds.

 ## Backward Compatibility

 Default behavior maintains building all platforms when triggered
 without explicit input overrides. Existing release processes continue
 to work unchanged since all platform inputs default to `true`.

 Secret naming changes require repository secret updates but maintain
 identical functionality. Artifact paths change but manifest generation
 updates preserve update system compatibility.

 ## Notes to reviewers

 This refactor is part of FE-993, the larger epic for updating native
 CI/CD workflows across all repository groups.

 This also completes the Desktop workflow updates following the Agent
 workflow patterns established in the previous PR #5514.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds platform-selective jobs to the Desktop Self Host workflow, standardizes secrets and artifacts, and bumps tooling to match Agent CI. Manifests generate only when all platforms build. Aligns with Linear FE-993, FE-995, FE-1038–FE-1040.

- **Refactors**
  - Add boolean inputs for Linux, Windows, macOS x64, and macOS ARM64; gate jobs and manifest on these.
  - Require branch input; use HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN.
  - Rename Apple secrets to HOPPSCOTCH_* and standardize artifact names to selfhost-desktop-{platform}.
  - Update pnpm to 10.18.3 and trusted-signing-cli to 0.8.0.

- **Migration**
  - Update repository secrets to HOPPSCOTCH_* and adjust any references to new artifact names.
  - Provide a branch when dispatching the workflow.

<sup>Written for commit 2811e7f1edae4bd28428fd340e86e07d4f566247. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

