### PR TITLE
fix: missing Sec-WebSocket-Protocol header in websocket request when App reopened

### DIFF
--- a/packages/hoppscotch-common/src/pages/realtime/websocket.vue
+++ b/packages/hoppscotch-common/src/pages/realtime/websocket.vue
@@ -276,13 +276,9 @@ const workerResponseHandler = ({
   if (data.url === url.value) isUrlValid.value = data.result
 }
 
-const getActiveProtocols = (protocolList) => {
+const getActiveProtocols = (protocolList: HoppWSProtocol[]): string[] => {
   return protocolList
-    .filter((item) =>
-      Object.prototype.hasOwnProperty.call(item, "active")
-        ? item.active === true
-        : true
-    )
+    .filter((item) => Object.hasOwn(item, "active"))
     .map(({ value }) => value)
 }
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #[3909](https://github.com/hoppscotch/hoppscotch/issues/3909)

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
When Hoppscotch is reopened, previously set protocols in Websocket requests are not sent in the `Sec-WebSocket-Protocol` header. This happens because the activeProtocols is not a session variable and needs to be calculated in onMounted event.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- Extracted the callback method in watchers for reuse
- Used the extracted method during onMounted to get the current active protocols
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- ### Notes to reviewers -->
<!-- Any information you feel the reviewer should know about when reviewing your PR -->




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Sec-WebSocket-Protocol header on WebSocket requests after reopening the app. We now recalculate active protocols on mount using a shared helper, so selected protocols are always sent.

<sup>Written for commit c83eb3ed51cf1c902d37862e249612eb8fe1be81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



