### PR TITLE
fix: preserve request id after curl import

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-common/src/components/http/ImportCurl.vue
@@ -149,11 +149,12 @@ const handleImport = () => {
 
     if (tabs.currentActiveTab.value.document.type === "example-response") return
 
-    // Preserve the existing request name when importing cURL
+    // Preserve the existing request id and name when importing cURL
     const currentRequest = tabs.currentActiveTab.value.document.request
+    const reqID = currentRequest?.id ?? req.id
     const reqName = currentRequest?.name ?? req.name
 
-    tabs.currentActiveTab.value.document.request = { ...req, name: reqName }
+    tabs.currentActiveTab.value.document.request = { ...req, id: reqID, name: reqName }
   } catch (e) {
     console.error(e)
     toast.error(`${t("error.curl_invalid_format")}`)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
Problem (observed in desktop and web): Importing a cURL request then saving did not save the request to the db properly - it would save only to the local storage, so closing the browser tab / desktop app and coming back meant the cURL data we imported did not get saved.

Cause: cURL imports did not properly preserve the id of the existing request. Since it was overriding the tab prop completely, the id disappeared, and backend sync was not running because id did not exist in the request object.

Fix: make sure the existing request id is not overriden

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the existing request id (and name) when importing a cURL request. This ensures the request syncs to the backend DB instead of only local storage, fixing lost persistence after closing the app on web and desktop.

<sup>Written for commit 4bd926805027069dc3e4425bfdf1042b70f93f70. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

