### PR TITLE
feat: add fetch support in pre-request scripts #5410,#3305

### DIFF
--- a/packages/hoppscotch-common/src/helpers/preRequestScriptSnippets.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequestScriptSnippets.ts
@@ -18,4 +18,60 @@ const max = 1000
 const randomArbitrary = Math.random() * (max - min) + min
 pw.env.set("randomNumber", randomArbitrary.toString());`,
   },
+  {
+    name: "HTTP: Fetch API call to set authentication token",
+    script: `(async () => {
+  try {
+    console.log("Fetching authentication token...");
+    
+    const authResponse = await fetch("https://api.example.com/auth", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "your_username",
+        password: "your_password"
+      })
+    });
+
+    console.log("Auth response status:", authResponse.status);
+
+    if (authResponse.ok) {
+      const authData = await authResponse.json();
+      console.log("Authentication successful");
+      pw.env.set("auth_token", authData.token);
+    } else {
+      console.error("Authentication failed:", authResponse.status);
+    }
+  } catch (err) {
+    console.error("Authentication request failed:", err);
+  }
+})();`,
+  },
+  {
+    name: "HTTP: Fetch data and set environment variable",
+    script: `(async () => {
+  try {
+    console.log("Fetching data from API...");
+    
+    const response = await fetch("https://api.example.com/data");
+    console.log("API response status:", response.status);
+
+    if (response.ok) {
+      const data = await response.json();
+      console.log("Data received:", data);
+      
+      pw.env.set("api_data", JSON.stringify(data));
+      pw.env.set("user_id", data.userId || "");
+      
+      console.log("Environment variables set successfully");
+    } else {
+      console.error("API call failed:", response.status);
+    }
+  } catch (err) {
+    console.error("Fetch failed:", err);
+  }
+})();`,
+  },
 ]

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -156,6 +156,7 @@ export type TestResult = {
   envs: {
     global: EnvironmentVariable[]
     selected: EnvironmentVariable[]
+    temp?: EnvironmentVariable[]
   }
 }
 

--- a/packages/hoppscotch-js-sandbox/src/web/pre-request/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/web/pre-request/index.ts
@@ -15,15 +15,29 @@ import Worker from "./worker?worker&inline"
 
 const runPreRequestScriptWithWebWorker = (
   preRequestScript: string,
-  envs: TestResult["envs"]
+  envs: TestResult["envs"],
 ): Promise<E.Either<string, SandboxPreRequestResult>> => {
   return new Promise((resolve) => {
     const worker = new Worker()
 
-    // Listen for the results from the web worker
+    // Listen for messages from the web worker
     worker.addEventListener("message", (event: MessageEvent) => {
-      worker.terminate()
-      return resolve(event.data.results)
+      const { type, results, level, args } = event.data
+
+      if (type === "console") {
+        // Forward console messages to the main thread console
+        const logMethod = level as keyof typeof console
+        if (typeof console[logMethod] === "function") {
+          ;(console[logMethod] as any)(
+            `[Pre-request Script ${level.toUpperCase()}]:`,
+            ...args,
+          )
+        }
+      } else if (results) {
+        // This is the final result message
+        worker.terminate()
+        return resolve(results)
+      }
     })
 
     // Send the script to the web worker
@@ -36,61 +50,115 @@ const runPreRequestScriptWithWebWorker = (
 
 const runPreRequestScriptWithFaradayCage = async (
   preRequestScript: string,
-  envs: TestResult["envs"],
+  envs: TestResult["envs"] & {
+    temp?: Array<{
+      key: string
+      currentValue: string
+      initialValue: string
+      secret: boolean
+    }>
+  },
   request: HoppRESTRequest,
-  cookies: Cookie[] | null
+  cookies: Cookie[] | null,
 ): Promise<E.Either<string, SandboxPreRequestResult>> => {
   const consoleEntries: ConsoleEntry[] = []
+  const tempEnvs = envs.temp || []
   let finalEnvs = envs
   let finalRequest = request
   let finalCookies = cookies
 
-  const cage = await FaradayCage.create()
+  let cage: any = null
 
-  const result = await cage.runCode(preRequestScript, [
-    ...defaultModules({
-      handleConsoleEntry: (consoleEntry) => consoleEntries.push(consoleEntry),
-    }),
+  try {
+    cage = await FaradayCage.create()
 
-    preRequestModule({
-      envs: cloneDeep(envs),
-      request: cloneDeep(request),
-      cookies: cookies ? cloneDeep(cookies) : null,
-      handleSandboxResults: ({ envs, request, cookies }) => {
-        finalEnvs = envs
-        finalRequest = request
-        finalCookies = cookies
-      },
-    }),
-  ])
+    // Set up a timeout to prevent hanging async operations
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error("Script execution timeout (10 seconds)"))
+      }, 10000)
+    })
 
-  if (result.type === "error") {
-    if (
-      result.err !== null &&
-      typeof result.err === "object" &&
-      "message" in result.err
-    ) {
-      return E.left(`Script execution failed: ${result.err.message}`)
+    const executePromise = cage.runCode(preRequestScript, [
+      ...defaultModules({
+        handleConsoleEntry: (consoleEntry) => consoleEntries.push(consoleEntry),
+      }),
+
+      preRequestModule({
+        envs: cloneDeep(envs),
+        request: cloneDeep(request),
+        cookies: cookies ? cloneDeep(cookies) : null,
+        handleSandboxResults: ({ envs, request, cookies }) => {
+          finalEnvs = envs
+          finalRequest = request
+          finalCookies = cookies
+        },
+      }),
+    ])
+
+    // Race between execution and timeout
+    const result = await Promise.race([executePromise, timeoutPromise])
+
+    if (result.type === "error") {
+      if (
+        result.err !== null &&
+        typeof result.err === "object" &&
+        "message" in result.err
+      ) {
+        return E.left(`Script execution failed: ${result.err.message}`)
+      }
+
+      return E.left(`Script execution failed: ${String(result.err)}`)
     }
 
-    return E.left(`Script execution failed: ${String(result.err)}`)
-  }
+    return E.right({
+      updatedEnvs: {
+        ...finalEnvs,
+        temp: tempEnvs, // Preserve the temp array
+      },
+      consoleEntries,
+      updatedRequest: finalRequest,
+      updatedCookies: finalCookies,
+    } satisfies SandboxPreRequestResult)
+  } catch (error) {
+    // Handle any errors that occur during execution
+    if (error instanceof Error) {
+      return E.left(`Sandbox execution failed: ${error.message}`)
+    }
+    return E.left(`Sandbox execution failed: ${String(error)}`)
+  } finally {
+    // Ensure cage is cleaned up even if there's an error
+    if (cage) {
+      try {
+        // Give more time for any pending async operations to complete
+        // This is especially important for fetch promises that might still be resolving
+        await new Promise((resolve) => setTimeout(resolve, 1000))
 
-  return E.right({
-    updatedEnvs: finalEnvs,
-    consoleEntries,
-    updatedRequest: finalRequest,
-    updatedCookies: finalCookies,
-  } satisfies SandboxPreRequestResult)
+        // Try to clean up the cage if it has cleanup methods
+        if (typeof cage.destroy === "function") {
+          cage.destroy()
+        } else if (typeof cage.dispose === "function") {
+          cage.dispose()
+        } else if (typeof cage.close === "function") {
+          cage.close()
+        }
+      } catch (cleanupError) {
+        console.warn("Failed to cleanup FaradayCage:", cleanupError)
+      }
+    }
+  }
 }
 
 export const runPreRequestScript = (
   preRequestScript: string,
-  options: RunPreRequestScriptOptions
+  options: RunPreRequestScriptOptions,
 ): Promise<E.Either<string, SandboxPreRequestResult>> => {
   const { envs, experimentalScriptingSandbox = true } = options
 
-  if (experimentalScriptingSandbox) {
+  // Check if script uses fetch - if so, use web worker to avoid QuickJS lifetime issues
+  const usesFetch = preRequestScript.includes("fetch(")
+
+  if (experimentalScriptingSandbox && !usesFetch) {
     const { request, cookies } = options as Extract<
       RunPreRequestScriptOptions,
       { experimentalScriptingSandbox: true }
@@ -100,9 +168,10 @@ export const runPreRequestScript = (
       preRequestScript,
       envs,
       request,
-      cookies
+      cookies,
     )
   }
 
+  // Use web worker for fetch operations or when experimental sandbox is disabled
   return runPreRequestScriptWithWebWorker(preRequestScript, envs)
 }

--- a/packages/hoppscotch-js-sandbox/src/web/test-runner/worker.ts
+++ b/packages/hoppscotch-js-sandbox/src/web/test-runner/worker.ts
@@ -10,29 +10,108 @@ import {
 const executeScriptInContext = (
   testScript: string,
   envs: TestResult["envs"],
-  response: TestResponse
+  response: TestResponse,
 ): TE.TaskEither<string, SandboxTestResult> => {
-  try {
-    const responseObjHandle = preventCyclicObjects(response)
-    if (E.isLeft(responseObjHandle)) {
-      return TE.left(`Response marshalling failed: ${responseObjHandle.left}`)
-    }
+  return TE.tryCatch(
+    async () => {
+      const responseObjHandle = preventCyclicObjects(response)
+      if (E.isLeft(responseObjHandle)) {
+        throw new Error(
+          `Response marshalling failed: ${responseObjHandle.left}`,
+        )
+      }
 
-    const { pw, testRunStack, updatedEnvs } = getTestRunnerScriptMethods(envs)
+      const { pw, testRunStack, updatedEnvs } = getTestRunnerScriptMethods(envs)
 
-    // Create a function from the test script using the `Function` constructor
-    const executeScript = new Function("pw", testScript)
+      // Create a console proxy that forwards logs to the main thread
+      const proxyConsole = {
+        log: (...args: any[]) => {
+          self.postMessage({
+            type: "console",
+            level: "log",
+            args,
+          })
+        },
+        info: (...args: any[]) => {
+          self.postMessage({
+            type: "console",
+            level: "info",
+            args,
+          })
+        },
+        warn: (...args: any[]) => {
+          self.postMessage({
+            type: "console",
+            level: "warn",
+            args,
+          })
+        },
+        error: (...args: any[]) => {
+          self.postMessage({
+            type: "console",
+            level: "error",
+            args,
+          })
+        },
+        debug: (...args: any[]) => {
+          self.postMessage({
+            type: "console",
+            level: "debug",
+            args,
+          })
+        },
+      }
 
-    // Execute the script
-    executeScript({ ...pw, response: responseObjHandle.right })
+      // Clean the script to remove any export/import statements
+      const cleanedScript = testScript
+        .replace(/^\s*export\s+.*$/gm, "") // Remove export statements
+        .replace(/^\s*import\s+.*$/gm, "") // Remove import statements
+        .trim()
 
-    return TE.right(<SandboxTestResult>{
-      tests: testRunStack[0],
-      envs: updatedEnvs,
-    })
-  } catch (error) {
-    return TE.left(`Script execution failed: ${(error as Error).message}`)
-  }
+      // Set up globals BEFORE executing the user's script
+      ;(globalThis as any).pw = { ...pw, response: responseObjHandle.right }
+      ;(globalThis as any).console = proxyConsole
+      ;(globalThis as any).fetch = self.fetch
+        ? self.fetch.bind(self)
+        : globalThis.fetch
+
+      // Also set on self for redundancy
+      ;(self as any).pw = { ...pw, response: responseObjHandle.right }
+      ;(self as any).console = proxyConsole
+      ;(self as any).fetch = self.fetch
+        ? self.fetch.bind(self)
+        : globalThis.fetch
+
+      // Execute the user's script using Function constructor
+      // Remove trailing semicolon to avoid syntax errors when using 'return'
+      const scriptToExecute = cleanedScript.trim().replace(/;$/, "")
+      const scriptFunction = new Function(`return ${scriptToExecute}`)
+      const scriptResult = scriptFunction()
+
+      // If the script returns a promise (e.g., from an async IIFE), wait for it
+      if (scriptResult && typeof scriptResult.then === "function") {
+        await scriptResult
+      }
+
+      return <SandboxTestResult>{
+        tests: testRunStack[0],
+        envs: updatedEnvs,
+      }
+    },
+    (error) => {
+      const errorMessage = (error as Error).message
+
+      // Provide more helpful error messages for common issues
+      if (errorMessage.includes("export")) {
+        return `Script execution failed: ES6 module syntax (export/import) is not supported in test scripts. Please use regular JavaScript.`
+      }
+      if (errorMessage.includes("import")) {
+        return `Script execution failed: ES6 module syntax (export/import) is not supported in test scripts. Please use regular JavaScript.`
+      }
+
+      return `Script execution failed: ${errorMessage}`
+    },
+  )
 }
 
 // Listen for messages from the main thread


### PR DESCRIPTION
- Bind fetch API to web worker context
- Add fetch to both globalThis and self objects
- Ensures fetch is available in pre-request scripts

Closes #5410 #3305


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fetch support in pre-request and test scripts by running scripts that call fetch inside a web worker and binding fetch to both globalThis and self. This enables reliable HTTP calls in scripts with cleaner logging.

- **New Features**
  - Auto-detect fetch usage and execute scripts in a web worker.
  - Bind fetch to globalThis and self; forward console logs to the main thread.
  - Add pre-request script snippets showing auth token fetch and data fetch.

- **Refactors**
  - Preserve temp environment variables across sandbox contexts.
  - Add timeout and cleanup to FaradayCage to avoid hanging executions.
  - Improve error messages for unsupported import/export syntax in scripts.

<sup>Written for commit 9bd264c7232a817547cfa116bc33b0ae51b94635. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

