### PR TITLE
fix(common): prevent duplicate requests from showing active indicator simultaneously

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -183,7 +183,6 @@ import { useService } from "dioc/vue"
 import { GQLTabService } from "~/services/tab/graphql"
 import { computed } from "vue"
 import {
-  generateUniqueRefId,
   getDefaultGQLRequest,
   HoppCollection,
   HoppGQLRequest,
@@ -515,8 +514,6 @@ const duplicateRequest = async ({
   if (!isValidToken) return
   saveGraphqlRequestAs(folderPath, {
     ...cloneDeep(request),
-    id: undefined,
-    _ref_id: generateUniqueRefId("req"),
     name: `${request.name} - ${t("action.duplicate")}`,
   })
 }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1478,7 +1478,6 @@ const duplicateRequest = async (payload: {
 
   const newRequest = {
     ...cloneDeep(request),
-    id: undefined,
     _ref_id: generateUniqueRefId("req"),
     name: `${request.name} - ${t("action.duplicate")}`,
   }

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -282,7 +282,6 @@ const duplicateTab = (tabID: string) => {
       type: "request",
       request: {
         ...cloneDeep(tab.value.document.request),
-        id: undefined,
         _ref_id: generateUniqueRefId("req"),
       },
       isDirty: true,


### PR DESCRIPTION
Closes #5604 

This PR fixes a bug where both the original request and its duplicate would incorrectly display the green "active" indicator dot simultaneously in the collections sidebar, even though only one tab was actually open. This issue occurred in both personal and team workspaces when duplicating requests via either the collection sidebar context menu or the tab context menu.

### What's changed
- [x] Ensures only requests with valid, non-empty IDs can be identified as the active request

**Testing:**
To verify the fix:
1. Create a request in a personal collection
2. Right-click → "Duplicate" from the sidebar
3. Click on the original request in the sidebar
4. Verify only the clicked request shows the green dot (not both)
5. Repeat with "Duplicate Tab" from the tab context menu
6. Test in both personal workspace and team workspace

**No Breaking Changes:**
This is a pure bug fix with no API or behavior changes beyond correcting the active indicator display.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents both the original and duplicated requests from showing the green “active” dot at the same time in the collections sidebar. Applies to duplicates from the sidebar and tab context menus in personal and team workspaces.

- **Bug Fixes**
  - When duplicating a request, assign a new _ref_id via generateUniqueRefId("req") so the duplicate is treated separately.
  - When duplicating a tab, clone the request, add a new _ref_id, mark it dirty, and activate the new tab.

<sup>Written for commit 9658230d148c4dc4d2ae29f608ee00e266957d08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



