### PR TITLE
fix: improve save request handling and optimize history mapping

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -312,7 +312,7 @@ const onSelect = (pickedVal: Picked | null) => {
   picked.value = pickedVal
 }
 
-const saveRequestAs = async () => {
+const handleSaveRequestAs = async () => {
   const isValidToken = await handleTokenValidation()
   if (!isValidToken) return
 
@@ -588,6 +588,14 @@ const saveRequestAs = async () => {
 
     requestSaved("GQL")
   }
+}
+
+const saveRequestAs = async () => {
+  // Avoids UI jank, freezing
+  setTimeout(() => {
+    handleSaveRequestAs()
+  }, 0)
+  return
 }
 
 /**

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -329,7 +329,7 @@ const saveRequestAction = ref<any | null>(null)
 const history = useReadonlyStream<RESTHistoryEntry[]>(restHistory$, [])
 
 const userHistories = computed(() => {
-  return history.value.map((history) => history.request.endpoint).slice(0, 10)
+  return history.value.slice(0, 10).map((history) => history.request.endpoint)
 })
 
 const inspectionService = useService(InspectionService)


### PR DESCRIPTION
This pull request focuses on improving the user experience and code clarity in the request saving workflow, as well as optimizing how recent endpoints are displayed. The main changes include refactoring the save request logic to prevent UI freezing and adjusting the order of operations when displaying recent request endpoints.

**Request Saving Workflow Improvements:**

* Refactored the save request logic in `SaveRequest.vue` by introducing a new `handleSaveRequestAs` function and updating `saveRequestAs` to use `setTimeout`, which helps avoid UI jank and freezing when saving requests. [[1]](diffhunk://#diff-acc963c13cb775925158e0e84da309b65d76d26e48ab66e5033f389fe933064eL315-R315) [[2]](diffhunk://#diff-acc963c13cb775925158e0e84da309b65d76d26e48ab66e5033f389fe933064eR593-R600)

**Recent Endpoints Display Optimization:**

* Modified the computation of recent endpoints in `Request.vue` to first slice the history and then map to endpoints, ensuring the correct order and limiting to the 10 most recent requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved save request handling to avoid UI freezing. Optimized recent endpoints mapping so the list shows the latest 10 in the right order.

- **Bug Fixes**
  - Deferred save action with setTimeout(0) and moved logic to handleSaveRequestAs in SaveRequest.vue to prevent UI jank.
  - In Request.vue, slice history before mapping endpoints to keep correct order and limit to 10.

<sup>Written for commit 00a7be78e79b436026920786888f66d783f8503c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

