### PR TITLE
chore(agent): bump agent and dependency chain

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -33,7 +33,7 @@ in {
     # NOTE: In case there's `Cannot find module: ... bcrypt ...` error, try `npm rebuild bcrypt`
     # See: https://github.com/kelektiv/node.bcrypt.js/issues/800
     # See: https://github.com/kelektiv/node.bcrypt.js/issues/1055
-    nodejs_20
+    nodejs_22
     nodePackages.typescript-language-server
     nodePackages."@volar/vue-language-server"
     nodePackages.prisma
@@ -167,7 +167,7 @@ in {
       enable = true;
     };
     javascript = {
-      package = pkgs.nodejs_20;
+      package = pkgs.nodejs_22;
       enable = true;
       npm.enable = true;
       pnpm.enable = true;

--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,26 +12,26 @@
   "dependencies": {
     "@hoppscotch/ui": "0.2.5",
     "@tauri-apps/api": "2.1.1",
-    "@tauri-apps/plugin-shell": "^2.2.1",
-    "@vueuse/core": "13.7.0",
-    "axios": "1.12.2",
+    "@tauri-apps/plugin-shell": "2.3.3",
+    "@vueuse/core": "14.0.0",
+    "axios": "1.13.2",
     "fp-ts": "2.16.11",
     "lodash-es": "4.17.21",
     "vue": "3.5.22"
   },
   "devDependencies": {
-    "@iconify-json/lucide": "1.2.68",
-    "@tauri-apps/cli": "^2.0.3",
+    "@iconify-json/lucide": "1.2.73",
+    "@tauri-apps/cli": "2.9.3",
     "@types/lodash-es": "4.17.12",
-    "@types/node": "24.9.1",
-    "@vitejs/plugin-vue": "5.1.4",
+    "@types/node": "24.10.1",
+    "@vitejs/plugin-vue": "6.0.2",
     "autoprefixer": "10.4.21",
     "postcss": "8.5.6",
     "tailwindcss": "3.4.16",
     "typescript": "5.9.3",
-    "unplugin-icons": "22.2.0",
-    "unplugin-vue-components": "29.0.0",
-    "vite": "6.3.6",
+    "unplugin-icons": "22.5.0",
+    "unplugin-vue-components": "30.0.0",
+    "vite": "7.2.4",
     "vue-tsc": "2.2.0"
   }
 }

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-agent"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -5094,9 +5094,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bceb52453e507c505b330afe3398510e87f428ea42b6e76ecb6bd63b15965b5"
+checksum = "9e492485dd390b35f7497401f67694f46161a2a00ffd800938d5dd3c898fb9d8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5146,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a924b6c50fe83193f0f8b14072afa7c25b7a72752a2a73d9549b463f5fe91a38"
+checksum = "87d6f8cafe6a75514ce5333f115b7b1866e8e68d9672bf4ca89fc0f35697ea9d"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5168,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1fe64c74cc40f90848281a90058a6db931eb400b60205840e09801ee30f190"
+checksum = "b7ef707148f0755110ca54377560ab891d722de4d53297595380a748026f139f"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -5195,9 +5195,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260c5d2eb036b76206b9fca20b7be3614cfd21046c5396f7959e0e64a4b07f2f"
+checksum = "71664fd715ee6e382c05345ad258d6d1d50f90cf1b58c0aa726638b33c2a075d"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5656,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-agent"
-version = "0.1.15"
+version = "0.1.16"
 description = "A cross-platform HTTP request agent for Hoppscotch for advanced request handling including custom headers, certificates, proxies, and local system integration."
 authors = ["AndrewBastin", "CuriousCorrelation"]
 edition = "2021"
@@ -12,44 +12,44 @@ name = "hoppscotch_agent_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.0.1", features = [] }
+tauri-build = { version = "2.5.2", features = [] }
 
 [dependencies]
-tauri = { version = "2.0.4", features = ["tray-icon", "image-png"] }
-tauri-plugin-shell = "2.2.1"
-tauri-plugin-autostart = { version = "2.0.1", optional = true }
+tauri = { version = "2.9.3", features = ["tray-icon", "image-png"] }
+tauri-plugin-shell = "2.3.3"
+tauri-plugin-autostart = { version = "2.5.1", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1.40.0", features = ["full"] }
+tokio = { version = "1.48.0", features = ["full"] }
 dashmap = { version = "6.1.0", features = ["serde"] }
-axum = { version = "0.7.7" }
-axum-extra = { version = "0.9.4", features = ["typed-header"] }
-tower-http = { version = "0.6.1", features = ["cors"] }
-tokio-util = "0.7.12"
-uuid = { version = "1.11.0", features = [ "v4", "fast-rng" ] }
+axum = { version = "0.7.9" }
+axum-extra = { version = "0.9.6", features = ["typed-header"] }
+tower-http = { version = "0.6.6", features = ["cors"] }
+tokio-util = "0.7.17"
+uuid = { version = "1.18.1", features = [ "v4", "fast-rng" ] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8.5"
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "fmt", "std", "time"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json", "fmt", "std", "time"] }
 tracing-appender = "0.2.3"
 relay = { git = "https://github.com/CuriousCorrelation/relay.git" }
-thiserror = "1.0.64"
-tauri-plugin-store = "2.1.0"
+thiserror = "1.0.69"
+tauri-plugin-store = "2.4.1"
 x25519-dalek = { version = "2.0.1", features = ["getrandom"] }
 base16 = "0.2.1"
 aes-gcm = { version = "0.10.3", features = ["aes"] }
-tauri-plugin-updater = "2.0.2"
-tauri-plugin-dialog = "2.0.1"
+tauri-plugin-updater = "2.9.0"
+tauri-plugin-dialog = "2.4.2"
 lazy_static = "1.5.0"
-tauri-plugin-single-instance = "2.0.1"
-tauri-plugin-http = { version = "2.0.1", features = ["gzip"] }
+tauri-plugin-single-instance = "2.3.6"
+tauri-plugin-http = { version = "2.5.4", features = ["gzip"] }
 native-dialog = "0.7.0"
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 file-rotate = "0.8.0"
 dirs = "6.0.0"
 
 [target.'cfg(windows)'.dependencies]
-tempfile = { version = "3.13.0" }
+tempfile = { version = "3.23.0" }
 winreg = { version = "0.52.0" }
 
 [features]

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,19 +79,19 @@ importers:
     dependencies:
       '@hoppscotch/ui':
         specifier: 0.2.5
-        version: 0.2.5(eslint@9.39.1(jiti@2.6.1))(terser@5.44.1)(typescript@5.9.3)(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+        version: 0.2.5(eslint@9.39.1(jiti@2.6.1))(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       '@tauri-apps/api':
         specifier: 2.1.1
         version: 2.1.1
       '@tauri-apps/plugin-shell':
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: 2.3.3
+        version: 2.3.3
       '@vueuse/core':
-        specifier: 13.7.0
-        version: 13.7.0(vue@3.5.22(typescript@5.9.3))
+        specifier: 14.0.0
+        version: 14.0.0(vue@3.5.22(typescript@5.9.3))
       axios:
-        specifier: 1.12.2
-        version: 1.12.2
+        specifier: 1.13.2
+        version: 1.13.2
       fp-ts:
         specifier: 2.16.11
         version: 2.16.11
@@ -103,20 +103,20 @@ importers:
         version: 3.5.22(typescript@5.9.3)
     devDependencies:
       '@iconify-json/lucide':
-        specifier: 1.2.68
-        version: 1.2.68
+        specifier: 1.2.73
+        version: 1.2.73
       '@tauri-apps/cli':
-        specifier: ^2.0.3
-        version: 2.9.4
+        specifier: 2.9.3
+        version: 2.9.3
       '@types/lodash-es':
         specifier: 4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: 24.9.1
-        version: 24.9.1
+        specifier: 24.10.1
+        version: 24.10.1
       '@vitejs/plugin-vue':
-        specifier: 5.1.4
-        version: 5.1.4(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
+        specifier: 6.0.2
+        version: 6.0.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))
       autoprefixer:
         specifier: 10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -125,19 +125,19 @@ importers:
         version: 8.5.6
       tailwindcss:
         specifier: 3.4.16
-        version: 3.4.16(ts-node@10.9.2(@types/node@24.9.1)(typescript@5.9.3))
+        version: 3.4.16(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       unplugin-icons:
-        specifier: 22.2.0
-        version: 22.2.0(@vue/compiler-sfc@3.5.24)(svelte@3.59.2)(vue-template-compiler@2.7.16)
+        specifier: 22.5.0
+        version: 22.5.0(@vue/compiler-sfc@3.5.24)(svelte@3.59.2)(vue-template-compiler@2.7.16)
       unplugin-vue-components:
-        specifier: 29.0.0
-        version: 29.0.0(@babel/parser@7.28.5)(vue@3.5.22(typescript@5.9.3))
+        specifier: 30.0.0
+        version: 30.0.0(@babel/parser@7.28.5)(vue@3.5.22(typescript@5.9.3))
       vite:
-        specifier: 6.3.6
-        version: 6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
+        specifier: 7.2.4
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
       vue-tsc:
         specifier: 2.2.0
         version: 2.2.0(typescript@5.9.3)
@@ -5852,8 +5852,17 @@ packages:
   '@tauri-apps/api@2.1.1':
     resolution: {integrity: sha512-fzUfFFKo4lknXGJq8qrCidkUcKcH2UHhfaaCNt4GzgzGaW2iS26uFOg4tS3H4P8D6ZEeUxtiD5z0nwFF0UN30A==}
 
+  '@tauri-apps/api@2.9.0':
+    resolution: {integrity: sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw==}
+
   '@tauri-apps/cli-darwin-arm64@1.5.6':
     resolution: {integrity: sha512-NNvG3XLtciCMsBahbDNUEvq184VZmOveTGOuy0So2R33b/6FDkuWaSgWZsR1mISpOuP034htQYW0VITCLelfqg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-arm64@2.9.3':
+    resolution: {integrity: sha512-W8FQXZXQmQ0Fmj9UJXNrm2mLdIaLLriKVY7o/FzmizyIKTPIvHjfZALTNybbpTQRbJvKoGHLrW1DNzAWVDWJYg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -5870,6 +5879,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@tauri-apps/cli-darwin-x64@2.9.3':
+    resolution: {integrity: sha512-zDwu40rlshijt3TU6aRvzPUyVpapsx1sNfOlreDMTaMelQLHl6YoQzSRpLHYwrHrhimxyX2uDqnKIiuGel0Lhg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@tauri-apps/cli-darwin-x64@2.9.4':
     resolution: {integrity: sha512-VT9ymNuT06f5TLjCZW2hfSxbVtZDhORk7CDUDYiq5TiSYQdxkl8MVBy0CCFFcOk4QAkUmqmVUA9r3YZ/N/vPRQ==}
     engines: {node: '>= 10'}
@@ -5878,6 +5893,12 @@ packages:
 
   '@tauri-apps/cli-linux-arm-gnueabihf@1.5.6':
     resolution: {integrity: sha512-z6SPx+axZexmWXTIVPNs4Tg7FtvdJl9EKxYN6JPjOmDZcqA13iyqWBQal2DA/GMZ1Xqo3vyJf6EoEaKaliymPQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.9.3':
+    resolution: {integrity: sha512-+Oc2OfcTRwYtW93VJqd/HOk77buORwC9IToj/qsEvM7bTMq6Kda4alpZprzwrCHYANSw+zD8PgjJdljTpe4p+g==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -5894,6 +5915,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-arm64-gnu@2.9.3':
+    resolution: {integrity: sha512-59GqU/J1n9wFyAtleoQOaU0oVIo+kwQynEw4meFDoKRXszKGor6lTsbsS3r0QKLSPbc0o/yYGJhqqCtkYjb/eg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@tauri-apps/cli-linux-arm64-gnu@2.9.4':
     resolution: {integrity: sha512-ql6vJ611qoqRYHxkKPnb2vHa27U+YRKRmIpLMMBeZnfFtZ938eao7402AQCH1mO2+/8ioUhbpy9R/ZcLTXVmkg==}
     engines: {node: '>= 10'}
@@ -5906,10 +5933,22 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-arm64-musl@2.9.3':
+    resolution: {integrity: sha512-fzvG+jEn5/iYGNH6Z2IRMheYFC4pJdXa19BR9fFm6Bdn2cuajRLDKdUcEME/DCtwqclphXtFZTrT4oezY5vI/A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@tauri-apps/cli-linux-arm64-musl@2.9.4':
     resolution: {integrity: sha512-vg7yNn7ICTi6hRrcA/6ff2UpZQP7un3xe3SEld5QM0prgridbKAiXGaCKr3BnUBx/rGXegQlD/wiLcWdiiraSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.9.3':
+    resolution: {integrity: sha512-qV8DZXI/fZwawk6T3Th1g6smiNC2KeQTk7XFgKvqZ6btC01z3UTsQmNGvI602zwm3Ld1TBZb4+rEWu2QmQimmw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
     os: [linux]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.9.4':
@@ -5920,6 +5959,12 @@ packages:
 
   '@tauri-apps/cli-linux-x64-gnu@1.5.6':
     resolution: {integrity: sha512-gbFHYHfdEGW0ffk8SigDsoXks6USpilF6wR0nqB/JbWzbzFR/sBuLVNQlJl1RKNakyJHu+lsFxGy0fcTdoX8xA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.9.3':
+    resolution: {integrity: sha512-tquyEONCNRfqEBWEe4eAHnxFN5yY5lFkCuD4w79XLIovUxVftQ684+xLp7zkhntkt4y20SMj2AgJa/+MOlx4Kg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5936,6 +5981,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-x64-musl@2.9.3':
+    resolution: {integrity: sha512-v2cBIB/6ji8DL+aiL5QUykU3ZO8OoJGyx50/qv2HQVzkf85KdaYSis3D/oVRemN/pcDz+vyCnnL3XnzFnDl4JQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@tauri-apps/cli-linux-x64-musl@2.9.4':
     resolution: {integrity: sha512-zcd1QVffh5tZs1u1SCKUV/V7RRynebgYUNWHuV0FsIF1MjnULUChEXhAhug7usCDq4GZReMJOoXa6rukEozWIw==}
     engines: {node: '>= 10'}
@@ -5944,6 +5995,12 @@ packages:
 
   '@tauri-apps/cli-win32-arm64-msvc@1.5.6':
     resolution: {integrity: sha512-DRNDXFNZb6y5IZrw+lhTTA9l4wbzO4TNRBAlHAiXUrH+pRFZ/ZJtv5WEuAj9ocVSahVw2NaK5Yaold4NPAxHog==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.9.3':
+    resolution: {integrity: sha512-ZGvBy7nvrHPbE0HeKp/ioaiw8bNgAHxWnb7JRZ4/G0A+oFj0SeSFxl9k5uU6FKnM7bHM23Gd1oeaDex9g5Fceg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -5960,6 +6017,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@tauri-apps/cli-win32-ia32-msvc@2.9.3':
+    resolution: {integrity: sha512-UsgIwOnpCoY9NK9/65QiwgmWVIE80LE7SwRYVblGtmlY9RYfsYvpbItwsovA/AcHMTiO+OCvS/q9yLeqS3m6Sg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@tauri-apps/cli-win32-ia32-msvc@2.9.4':
     resolution: {integrity: sha512-1LmAfaC4Cq+3O1Ir1ksdhczhdtFSTIV51tbAGtbV/mr348O+M52A/xwCCXQank0OcdBxy5BctqkMtuZnQvA8uQ==}
     engines: {node: '>= 10'}
@@ -5972,6 +6035,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tauri-apps/cli-win32-x64-msvc@2.9.3':
+    resolution: {integrity: sha512-fmw7NrrHE5m49idCvJAx9T9bsupjdJ0a3p3DPCNCZRGANU6R1tA1L+KTlVuUtdAldX2NqU/9UPo2SCslYKgJHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@tauri-apps/cli-win32-x64-msvc@2.9.4':
     resolution: {integrity: sha512-EdYd4c9wGvtPB95kqtEyY+bUR+k4kRw3IA30mAQ1jPH6z57AftT8q84qwv0RDp6kkEqOBKxeInKfqi4BESYuqg==}
     engines: {node: '>= 10'}
@@ -5980,6 +6049,11 @@ packages:
 
   '@tauri-apps/cli@1.5.6':
     resolution: {integrity: sha512-k4Y19oVCnt7WZb2TnDzLqfs7o98Jq0tUoVMv+JQSzuRDJqaVu2xMBZ8dYplEn+EccdR5SOMyzaLBJWu38TVK1A==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@tauri-apps/cli@2.9.3':
+    resolution: {integrity: sha512-BQ7iLUXTQcyG1PpzLWeVSmBCedYDpnA/6Cm/kRFGtqjTf/eVUlyYO5S2ee07tLum3nWwDBWTGFZeruO8yEukfA==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -5999,6 +6073,9 @@ packages:
 
   '@tauri-apps/plugin-shell@2.2.1':
     resolution: {integrity: sha512-G1GFYyWe/KlCsymuLiNImUgC8zGY0tI0Y3p8JgBCWduR5IEXlIJS+JuG1qtveitwYXlfJrsExt3enhv5l2/yhA==}
+
+  '@tauri-apps/plugin-shell@2.3.3':
+    resolution: {integrity: sha512-Xod+pRcFxmOWFWEnqH5yZcA7qwAMuaaDkMR1Sply+F8VfBj++CGnj2xf5UoialmjZ2Cvd8qrvSCbU+7GgNVsKQ==}
 
   '@tauri-apps/plugin-store@2.2.0':
     resolution: {integrity: sha512-hJTRtuJis4w5fW1dkcgftsYxKXK0+DbAqurZ3CURHG5WkAyyZgbxpeYctw12bbzF9ZbZREXZklPq8mocCC3Sgg==}
@@ -13672,46 +13749,6 @@ packages:
       yaml:
         optional: true
 
-  vite@6.3.6:
-    resolution: {integrity: sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.2.4:
     resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -17619,30 +17656,6 @@ snapshots:
       - typescript
       - vite
 
-  '@hoppscotch/ui@0.2.5(eslint@9.39.1(jiti@2.6.1))(terser@5.44.1)(typescript@5.9.3)(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
-    dependencies:
-      '@boringer-avatars/vue3': 0.2.1(vue@3.5.22(typescript@5.9.3))
-      '@fontsource-variable/inter': 5.2.8
-      '@fontsource-variable/material-symbols-rounded': 5.2.24
-      '@fontsource-variable/roboto-mono': 5.2.8
-      '@hoppscotch/vue-sonner': 1.2.3
-      '@hoppscotch/vue-toasted': 0.1.0(vue@3.5.22(typescript@5.9.3))
-      '@vitejs/plugin-legacy': 2.3.0(terser@5.44.1)(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))
-      '@vueuse/core': 8.9.4(vue@3.5.22(typescript@5.9.3))
-      fp-ts: 2.16.11
-      lodash-es: 4.17.21
-      path: 0.12.7
-      vite-plugin-eslint: 1.8.1(eslint@9.39.1(jiti@2.6.1))(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))
-      vue: 3.5.22(typescript@5.9.3)
-      vue-promise-modals: 0.1.0(typescript@5.9.3)
-      vuedraggable-es: 4.1.1(vue@3.5.22(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - eslint
-      - terser
-      - typescript
-      - vite
-
   '@hoppscotch/ui@0.2.5(eslint@9.39.1(jiti@2.6.1))(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@boringer-avatars/vue3': 0.2.1(vue@3.5.22(typescript@5.9.3))
@@ -19399,7 +19412,12 @@ snapshots:
 
   '@tauri-apps/api@2.1.1': {}
 
+  '@tauri-apps/api@2.9.0': {}
+
   '@tauri-apps/cli-darwin-arm64@1.5.6':
+    optional: true
+
+  '@tauri-apps/cli-darwin-arm64@2.9.3':
     optional: true
 
   '@tauri-apps/cli-darwin-arm64@2.9.4':
@@ -19408,10 +19426,16 @@ snapshots:
   '@tauri-apps/cli-darwin-x64@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-darwin-x64@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-darwin-x64@2.9.4':
     optional: true
 
   '@tauri-apps/cli-linux-arm-gnueabihf@1.5.6':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.9.3':
     optional: true
 
   '@tauri-apps/cli-linux-arm-gnueabihf@2.9.4':
@@ -19420,13 +19444,22 @@ snapshots:
   '@tauri-apps/cli-linux-arm64-gnu@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-linux-arm64-gnu@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-linux-arm64-gnu@2.9.4':
     optional: true
 
   '@tauri-apps/cli-linux-arm64-musl@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-linux-arm64-musl@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-linux-arm64-musl@2.9.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.9.3':
     optional: true
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.9.4':
@@ -19435,10 +19468,16 @@ snapshots:
   '@tauri-apps/cli-linux-x64-gnu@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-linux-x64-gnu@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-linux-x64-gnu@2.9.4':
     optional: true
 
   '@tauri-apps/cli-linux-x64-musl@1.5.6':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.9.3':
     optional: true
 
   '@tauri-apps/cli-linux-x64-musl@2.9.4':
@@ -19447,16 +19486,25 @@ snapshots:
   '@tauri-apps/cli-win32-arm64-msvc@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-win32-arm64-msvc@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-win32-arm64-msvc@2.9.4':
     optional: true
 
   '@tauri-apps/cli-win32-ia32-msvc@1.5.6':
     optional: true
 
+  '@tauri-apps/cli-win32-ia32-msvc@2.9.3':
+    optional: true
+
   '@tauri-apps/cli-win32-ia32-msvc@2.9.4':
     optional: true
 
   '@tauri-apps/cli-win32-x64-msvc@1.5.6':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.9.3':
     optional: true
 
   '@tauri-apps/cli-win32-x64-msvc@2.9.4':
@@ -19474,6 +19522,20 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 1.5.6
       '@tauri-apps/cli-win32-ia32-msvc': 1.5.6
       '@tauri-apps/cli-win32-x64-msvc': 1.5.6
+
+  '@tauri-apps/cli@2.9.3':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.9.3
+      '@tauri-apps/cli-darwin-x64': 2.9.3
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.9.3
+      '@tauri-apps/cli-linux-arm64-gnu': 2.9.3
+      '@tauri-apps/cli-linux-arm64-musl': 2.9.3
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.9.3
+      '@tauri-apps/cli-linux-x64-gnu': 2.9.3
+      '@tauri-apps/cli-linux-x64-musl': 2.9.3
+      '@tauri-apps/cli-win32-arm64-msvc': 2.9.3
+      '@tauri-apps/cli-win32-ia32-msvc': 2.9.3
+      '@tauri-apps/cli-win32-x64-msvc': 2.9.3
 
   '@tauri-apps/cli@2.9.4':
     optionalDependencies:
@@ -19504,6 +19566,10 @@ snapshots:
   '@tauri-apps/plugin-shell@2.2.1':
     dependencies:
       '@tauri-apps/api': 2.1.1
+
+  '@tauri-apps/plugin-shell@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.9.0
 
   '@tauri-apps/plugin-store@2.2.0':
     dependencies:
@@ -20467,16 +20533,6 @@ snapshots:
       terser: 5.44.1
       vite: 6.3.5(@types/node@24.10.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.1)(yaml@2.8.1)
 
-  '@vitejs/plugin-legacy@2.3.0(terser@5.44.1)(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))':
-    dependencies:
-      '@babel/standalone': 7.28.5
-      core-js: 3.47.0
-      magic-string: 0.26.7
-      regenerator-runtime: 0.13.11
-      systemjs: 6.15.1
-      terser: 5.44.1
-      vite: 6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
-
   '@vitejs/plugin-legacy@2.3.0(terser@5.44.1)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))':
     dependencies:
       '@babel/standalone': 7.28.5
@@ -20514,11 +20570,6 @@ snapshots:
   '@vitejs/plugin-vue@5.1.4(vite@6.3.5(@types/node@24.10.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       vite: 6.3.5(@types/node@24.10.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.1)(yaml@2.8.1)
-      vue: 3.5.22(typescript@5.9.3)
-
-  '@vitejs/plugin-vue@5.1.4(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
-    dependencies:
-      vite: 6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
       vue: 3.5.22(typescript@5.9.3)
 
   '@vitejs/plugin-vue@6.0.2(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.3))':
@@ -28049,33 +28100,6 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@24.9.1)(typescript@5.9.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@24.9.1)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.11
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - ts-node
-
   tapable@0.2.9: {}
 
   tapable@2.3.0: {}
@@ -28881,14 +28905,6 @@ snapshots:
       rollup: 2.79.2
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
 
-  vite-plugin-eslint@1.8.1(eslint@9.39.1(jiti@2.6.1))(vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@types/eslint': 8.56.12
-      eslint: 9.39.1(jiti@2.6.1)
-      rollup: 2.79.2
-      vite: 6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)
-
   vite-plugin-eslint@1.8.1(eslint@9.39.1(jiti@2.6.1))(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
@@ -29082,22 +29098,6 @@ snapshots:
       yaml: 2.8.1
 
   vite@6.3.5(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      sass: 1.94.2
-      terser: 5.44.1
-      yaml: 2.8.1
-
-  vite@6.3.6(@types/node@24.9.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)


### PR DESCRIPTION
 This updates Hoppscotch Agent dependencies to align with
 v2025.11.0 security patch and other dependency chain.

 Closes FE-1056

 ## What's changed

 | Package | Old Version | New Version |
 |---------|-------------|-------------|
 | tauri-build | 2.0.1 | 2.5.2 |
 | tauri | 2.0.4 | 2.9.3 |
 | tauri-plugin-shell | 2.2.1 | 2.3.3 |
 | tauri-plugin-autostart | 2.0.1 | 2.5.1 |
 | tokio | 1.40.0 | 1.48.0 |
 | axum | 0.7.7 | 0.7.9 |
 | axum-extra | 0.9.4 | 0.9.6 |
 | tower-http | 0.6.1 | 0.6.6 |
 | tokio-util | 0.7.12 | 0.7.17 |
 | uuid | 1.11.0 | 1.18.1 |
 | tracing | 0.1.40 | 0.1.41 |
 | tracing-subscriber | 0.3.18 | 0.3.20 |
 | thiserror | 1.0.64 | 1.0.69 |
 | tauri-plugin-store | 2.1.0 | 2.4.1 |
 | tauri-plugin-updater | 2.0.2 | 2.9.0 |
 | tauri-plugin-dialog | 2.0.1 | 2.4.2 |
 | tauri-plugin-single-instance | 2.0.1 | 2.3.6 |
 | tauri-plugin-http | 2.0.1 | 2.5.4 |
 | sha2 | 0.10.8 | 0.10.9 |
 | tempfile (Windows) | 3.13.0 | 3.23.0 |

 | Package | Old Version | New Version |
 |---------|-------------|-------------|
 | @vueuse/core | 13.7.0 | 14.0.0 |
 | axios | 1.12.2 | 1.13.2 |
 | @iconify-json/lucide | 1.2.68 | 1.2.73 |
 | @types/node | 24.9.1 | 24.10.1 |
 | @vitejs/plugin-vue | 5.1.4 | 6.0.2 |
 | unplugin-icons | 22.2.0 | 22.5.0 |
 | unplugin-vue-components | 29.0.0 | 30.0.0 |
 | vite | 6.3.6 | 7.2.4 |

 Updated Node.js version in `devenv.nix` from 20 to 22 to align with the
 Node.js 22 requirement introduced in the dependency chain update.
 This affects both the package declaration and the js lang config.

 Updated Rust dependencies to their latest versions including security
 patches. Updated (possible) frontend dependencies in `package.json`
 for compatibility. Version bump from 0.1.15 to 0.1.16.

 NOTE: Removed caret prefixes from Tauri dependencies for more
 consistent version pinning.

 Updated `Cargo.lock` with transitive dependency changes. All Tauri
 plugin versions synchronized for compatibility.

 Verified on Windows 10/11, macOS (latest), NixOS (stable/unstable),
 Ubuntu 24.04.1 LTS, Debian (latest stable), and RHEL-based
 distributions. Tested AppImage, .deb packages, Windows executables,
 macOS .dmg, and custom Nix packages.

 No breaking changes in existing functionality.
 Tauri IPC features working as expected.

 Node.js 22 is now required for development environments. See the main
 dependency chain PR (#5590) for details on the Node.js version
 requirement change.

 ## Testing

 Verify core functionality including agent registration, request
 proxying, tray icon, autostart, store persistence, dialog interactions,
 single instance enforcement, and HTTP client with gzip.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps Hoppscotch Agent to the v2025.11.0 dependency chain, adopts Node.js 22, and pins Tauri versions for stable builds. Closes FE-1056; no functional changes.

- **Dependencies**
  - Pinned Tauri core/plugins to exact 2.x versions; removed caret prefixes.
  - Updated Rust stack (tokio, axum/+extra, tower-http, tokio-util, uuid, tracing, thiserror, sha2, tempfile); refreshed Cargo.lock.
  - Updated agent frontend/tooling (VueUse 14, Axios 1.13, Vite 7, @vitejs/plugin-vue 6, unplugin updates); pinned @tauri-apps/cli to 2.9.3.

- **Migration**
  - Use Node.js 22 for development and CI (devenv.nix updated).
  - No breaking changes; agent IPC and core features verified across Windows, macOS, and Linux builds.

<sup>Written for commit 3bd29c0b82a3e6ac87c926ce8f91e547e9eed727. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





