### PR TITLE
fix(common): agent interceptor dependency compat

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/store.ts
@@ -323,7 +323,6 @@ export class KernelInterceptorAgentStore extends Service {
     const sharedSecretKeyBytes = new Uint8Array(
       base16.decode(this.sharedSecretB16.value!.toUpperCase())
     )
-
     const sharedSecretKey = await window.crypto.subtle.importKey(
       "raw",
       sharedSecretKeyBytes,


### PR DESCRIPTION
 Fixes agent interceptor registration broken by dependency update

 Closes FE-1059

 ### What's changed

 Updated `KernelInterceptorAgentStore` to work with @noble/curves v2.0
 and @scure/base v2.0 breaking changes.

 Applied `Uint8Array` wrapper to all `base16.decode()` calls used with
 Web Crypto API for type compat.

 ### Testing

 Verify agent registration flow.

 ### Notes to reviewers

 The switch from `x25519.utils.randomPrivateKey()` to
 `crypto.getRandomValues()` uses browser-native cryptographically secure
 random generation, which is appropriate for this context and removes
 dependency on @noble/hashes.

 The `.js` extension in imports is required by @noble/curves v2.0's
 ESM-only distribution.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores agent interceptor registration after dependency upgrades (FE-1059). Updates crypto usage to work with @noble/curves v2.0 and @scure/base v2.0.

- **Bug Fixes**
  - Use crypto.getRandomValues for x25519 private key generation.
  - Wrap base16.decode outputs in Uint8Array for Web Crypto compatibility (nonce, keys).
  - Fix types for watcher change event and completeRequest parameter.

<sup>Written for commit f605e85821a9aed81e4be2bc53872bb19fdbf323. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







