### PR TITLE
fix: detect trailing comma and report error at correct position

### DIFF
--- a/packages/hoppscotch-common/src/helpers/jsoncParse.ts
+++ b/packages/hoppscotch-common/src/helpers/jsoncParse.ts
@@ -140,7 +140,6 @@ function parseObj(): JSONObjectValue {
 
       // After consuming ",", if the next token is "}", this is a trailing comma
       if (kind === "}") {
-        // After consuming ",", if the next token is "}", this is a trailing comma
         throw {
           message: "Trailing comma in object is not allowed in JSON.",
           start: commaStart,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5502

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

This PR fixes an issue where trailing commas in JSON objects or arrays were not detected as invalid JSON in the request body editor. The server rejected such bodies, but the editor did not highlight the error. This change updates the parser to properly detect and report trailing commas with accurate error positions.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

- Added explicit trailing comma detection in `parseObj` and `parseArr`.
- Store the comma token range before consuming it with `expect(",")`.
- When the next token after the comma is a closing `}` or `]`, report a `SyntaxError` pointing to the comma token rather than the closing bracket/brace.
- Ensures that invalid JSON with trailing commas is now surfaced correctly in the UI.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

- The fix is strictly scoped to JSON trailing comma handling.
- No existing behavior for valid JSON structures is affected.
- The error reporting position now aligns with VSCode-like behavior, improving the editor’s feedback accuracy.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects trailing commas in JSON objects/arrays and highlights the comma as the error in the request body editor. Aligns UI validation with server behavior for clearer feedback.

- **Bug Fixes**
  - Added trailing comma checks in parseObj/parseArr and throw with the comma token range.
  - Store comma start/end before consuming "," to report the exact error position.
  - Unified root parsing via parseVal + EOF, replacing the object/array try-catch flow.

<sup>Written for commit ecd614e875bc69703e8e0aa47b26e225cb450fa1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



