### PR TITLE
feat(common): adjust layout for created server info display in mock server

### DIFF
--- a/packages/hoppscotch-common/src/components/mockServer/MockServerCreatedInfo.vue
+++ b/packages/hoppscotch-common/src/components/mockServer/MockServerCreatedInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Display created server info -->
-    <div v-if="mockServer" class="flex flex-col mb-4">
+    <div v-if="mockServer" class="flex flex-col mb-4 space-y-4">
       <div v-if="mockServer.serverUrlPathBased" class="flex flex-col space-y-2">
         <label class="text-sm font-semibold text-secondaryDark">
           {{ t("mock_server.path_based_url") }}


### PR DESCRIPTION
Modify the layout of the created server information to improve visual organization and clarity.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the created mock server info layout to improve readability and consistency. The path-based URL now shows only when applicable, and extra spacing is removed.

- **Bug Fixes**
  - Render the path-based URL section only if the server is path-based.
  - Replace vertical spacing with a bottom margin to eliminate unnecessary gaps.

<sup>Written for commit de92643488ac9ffe9f89040e5a71b0d0f87836cd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





