### PR TITLE
feat(desktop): atomic write for registry persistence

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -40,7 +40,7 @@
     "@hoppscotch/httpsnippet": "3.0.9",
     "@hoppscotch/js-sandbox": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35",
     "@hoppscotch/ui": "0.2.5",
     "@hoppscotch/vue-toasted": "0.1.0",
     "@lezer/highlight": "1.2.1",

--- a/packages/hoppscotch-desktop/package.json
+++ b/packages/hoppscotch-desktop/package.json
@@ -24,7 +24,7 @@
     "@fontsource-variable/roboto-mono": "5.2.8",
     "@hoppscotch/common": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35",
     "@hoppscotch/ui": "0.2.5",
     "@tauri-apps/api": "2.1.1",
     "@tauri-apps/plugin-fs": "2.0.2",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -2426,7 +2426,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2446,7 +2446,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3719,7 +3719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4180,7 +4180,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4217,7 +4217,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=e05861959938b57479a1a81fa796735ebbd08c7c#e05861959938b57479a1a81fa796735ebbd08c7c"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=52744a8f35bf81b039410522efd4168bd06d4f35#52744a8f35bf81b039410522efd4168bd06d4f35"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6903,7 +6903,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-store = "2.4.1"
 tauri-plugin-dialog = "2.4.2"
 tauri-plugin-fs = "2.4.4"
 tauri-plugin-deep-link = "2.4.5"
-tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "e05861959938b57479a1a81fa796735ebbd08c7c" }
+tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "52744a8f35bf81b039410522efd4168bd06d4f35" }
 tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "7cf09c1ad31e228758738c2f4e1c8fe9cc141291" }
 axum = "0.8.7"
 tower-http = { version = "0.6.6", features = ["cors"] }

--- a/packages/hoppscotch-selfhost-web/package.json
+++ b/packages/hoppscotch-selfhost-web/package.json
@@ -29,7 +29,7 @@
     "@hoppscotch/common": "workspace:^",
     "@hoppscotch/data": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35",
     "@hoppscotch/ui": "0.2.5",
     "@import-meta-env/unplugin": "0.6.3",
     "@tauri-apps/api": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,8 +534,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35'
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@8.57.0)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.3))
@@ -1022,8 +1022,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35'
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@8.57.0)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.3))
@@ -1325,8 +1325,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#e05861959938b57479a1a81fa796735ebbd08c7c
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#52744a8f35bf81b039410522efd4168bd06d4f35
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35'
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@8.57.0)(terser@5.44.1)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(sass@1.94.2)(terser@5.44.1)(yaml@2.8.1))(vue@3.5.25(typescript@5.9.3))
@@ -1691,8 +1691,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/7cf09c1ad31e228758738c2f4e1c8fe9cc141291':
@@ -13239,7 +13239,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.12.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e05861959938b57479a1a81fa796735ebbd08c7c':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/52744a8f35bf81b039410522efd4168bd06d4f35':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
 This implements atomic writes for registry.json using temp file plus
 rename to prevent file corruption on Windows 11.

 Closes FE-1078
 Closes #5632
 Closes #5599

 The `Registry::save` method previously wrote directly to registry.json.
 On Windows 11, several factors can interrupt or interfere with writes
 and when interrupted, the file can end up with partial new content plus
 remnants of old content, resulting in malformed JSON like trailing `}}}`
 characters.

 Users report "failed to initialize plugin appload:
 Configuration error: Serialization error: trailing characters at line 11
 column 2" preventing application startup.

 ### What's changed

 Updated `Registry::save` in `tauri-plugin-appload/src/storage/registry.rs`
 to write to a temporary file first, then atomically rename:

 ```rust
 pub async fn save(&self, layout: &StorageLayout) -> Result<()> {
     let content = serde_json::to_string_pretty(self)?;
     let path = layout.registry_path();
     let temp_path = path.with_extension("json.tmp");

     // this is where that swap happens,
     // essentially this writes to a tmp file
     tokio::fs::write(&temp_path, &content).await?;
     // and this atomically "swaps" them
     tokio::fs::rename(&temp_path, &path).await?;

     Ok(())
 }
 ```

 This pattern is already used in `store_bundle` in `manager.rs`. NTFS
 rename is atomic within the same volume, so if the write is interrupted
 the original file remains intact.

 ### Notes to reviewers

 This is **defensive programming rather than a confirmed fix** for the
 reported issues. **The exact root cause of the Windows 11 corruption
 is still uncertain**, but atomic writes via temp file plus rename is
 standard practice for config file persistence and protects against
 the identified failure modes.

 Testing should verify on all platform and Windows 11 that normal
 save/load cycles work correctly and no leftover `.json.tmp` files
 remain after successful saves.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make registry.json writes atomic to prevent Windows 11 file corruption and startup failures in the desktop appload plugin. Addresses Linear FE-1078 by saving via a temp file and atomic rename.

- **Bug Fixes**
  - Save to .json.tmp and atomically rename to registry.json to avoid partial writes.
  - Prevents malformed JSON and the “Serialization error: trailing characters” on startup.

- **Dependencies**
  - Bumped tauri-plugin-appload across desktop/common/selfhost packages to include the atomic write change.
  - Cargo lock updated accordingly.

<sup>Written for commit 180f919f6d34daff0c2b3d7964dbe11ddccaa53a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

