### PR TITLE
chore(common): `Czech` translation updates

### DIFF
--- a/packages/hoppscotch-common/locales/cs.json
+++ b/packages/hoppscotch-common/locales/cs.json
@@ -179,7 +179,7 @@
     "edit": "Upravit sbírku",
     "import_or_create": "Importovat nebo vytvořit sbírku",
     "import_collection": "Importovat sbírku",
-    "invalid_name": "Uveďte platný název sbírky",
+    "invalid_name": "Uveďte prosím název sbírky",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
     "my_collections": "Moje sbírky",


### PR DESCRIPTION
Some new translations and fixes of Czech localization.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Czech localization across the app. Translated remaining English strings and corrected terms to make wording consistent and clearer for Czech users (e.g., “Status” → “Stav”, “Options” → “Možnosti”).

- **Bug Fixes**
  - Fixed mistranslations and improved wording in collection actions and properties, import/create flows, saving, and helper texts.
  - Localized confirmation dialogs and modal labels, including unsaved tabs, customize/import/export, and team/environment messages.
  - Standardized UI labels in context menus, response view, and run actions.

<sup>Written for commit af92e088141bfd7abf1c2f007e95168912dc300f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



