### PR TITLE
fix(desktop): align vendored instance version

### DIFF
--- a/packages/hoppscotch-common/src/platform/instance.ts
+++ b/packages/hoppscotch-common/src/platform/instance.ts
@@ -18,7 +18,7 @@ export const VENDORED_INSTANCE_CONFIG: Instance = {
   kind: "vendored" as const,
   serverUrl: "app://hoppscotch",
   displayName: "Hoppscotch Desktop",
-  version: "25.9.0",
+  version: "25.12.0",
   lastUsed: new Date().toISOString(),
   bundleName: "Hoppscotch",
 }


### PR DESCRIPTION
 This fixes the stale vendored display version.

 `VENDORED_INSTANCE_CONFIG` currently stores old instance version
 `25.9.0` and while other components do override this correctly, it'd be
 better to keep this consistent per release.

 Closes FE-1102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the vendored desktop instance version to 25.12.0 so the app shows the correct release version across components. Closes FE-1102.

<sup>Written for commit b3c6c2b42764469489e31fa46a9ca9556c45ab68. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

