### PR TITLE
fix(collection): error when opened imported collection

### DIFF
--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -793,7 +793,7 @@ export default class NewTeamCollectionAdapter {
       this.updateRequest({
         id: result.right.teamRequestUpdated.id,
         collectionID: result.right.teamRequestUpdated.collectionID,
-        request: JSON.parse(result.right.teamRequestUpdated.request),
+        request: translateToNewRequest(JSON.parse(result.right.teamRequestUpdated.request)),
         title: result.right.teamRequestUpdated.title,
       })
     })


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #5674 #5670 #5690

Fix team request selection error after updates and Postman Collection v2.1 imports. The problem is:
* Imported Postman Collection v2.1 requests appear in sidebar but fail to load in editor when clicked
* Browser console shows: `TypeError: Cannot create property 'auth' on string`
* Error occurs because request object is stored as JSON string but not properly parsed

Root cause of this problem is Missing `translateToNewRequest()` call in the `teamRequestUpdated$` subscription handler (line 796 of TeamCollectionAdapter.ts). When team requests are updated, the request data is parsed from JSON but not translated to ensure schema compatibility.

### What's changed

Solution:
* Wrap `JSON.parse()` with `translateToNewRequest()` to match the pattern used in other handlers (add, move, initial load) on file `packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts`

```typescript
  // Before
  request: JSON.parse(result.right.teamRequestUpdated.request)

  // After
  request:
  translateToNewRequest(JSON.parse(result.right.teamRequestUpdated.request))
```

Impact

  - ✅ Imported Postman collections now load correctly in editor
  - ✅ Updated team requests can be selected without errors
  - ✅ Ensures backward compatibility with older request schema versions

  Files Changed

  - `packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
  (line 796)`

Evidence before changes reproduced on Hoppscotch cloud version at https://hoppscotch.io:

<img width="1278" height="828" alt="image" src="https://github.com/user-attachments/assets/7bb01818-ec7c-4544-8082-240a788d1562" />

Evidence step after the changes:

1. Import the collection from OpenAPI format file

<img width="1305" height="740" alt="image" src="https://github.com/user-attachments/assets/f84fe256-7cd0-4456-864c-239742c7268a" />

<img width="1276" height="790" alt="image" src="https://github.com/user-attachments/assets/fb8d4bc0-e556-4f96-b4df-51483a0d4440" />

2. Open the one of endpoint imported (success)

<img width="1300" height="792" alt="image" src="https://github.com/user-attachments/assets/b533245c-a1d6-4eba-abaa-784966882e1e" />

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes errors when opening imported collections by normalizing updated team requests to the new request format. OpenAPI-imported endpoints now open reliably.

- **Bug Fixes**
  - Translate parsed teamRequestUpdated.request with translateToNewRequest(...) before updating to align legacy/imported payloads with the current schema.

<sup>Written for commit 9e6c599c68b1ba9b6d4d793f227d36e7cd85d485. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

