### PR TITLE
fix(common): restore scrolling on settings and profile pages

### DIFF
--- a/packages/hoppscotch-common/src/layouts/default.vue
+++ b/packages/hoppscotch-common/src/layouts/default.vue
@@ -23,7 +23,7 @@
               horizontal
             >
               <Pane class="flex flex-1 !overflow-hidden">
-                <main class="flex w-full flex-1" role="main">
+                <main class="flex w-full flex-1 overflow-auto" role="main">
                   <RouterView
                     v-slot="{ Component }"
                     class="flex min-w-0 flex-1"


### PR DESCRIPTION
Closes #5693 

This PR fixes a regression introduced by #5665, where the Settings and Profile pages became unscrollable. While #5665 successfully fixed the double scrollbar issue (#5545), it inadvertently removed scrolling capability from full-page layouts by setting all parent Panes to `overflow-hidden` without providing a scroll container for pages that don't use split panes.

### What's changed
- Updated the main element to allow overflow, enabling better handling of content that exceeds the available space.