### PR TITLE
fix(common): resolve Postman API key authorization header import mapping

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -299,7 +299,7 @@ const getHoppReqAuth = (
         getVariableValue(auth.apikey, "value") ?? ""
       ),
       addTo:
-        (getVariableValue(auth.apikey, "in") ?? "query") === "query"
+        getVariableValue(auth.apikey, "in") === "query"
           ? "QUERY_PARAMS"
           : "HEADERS",
     }


### PR DESCRIPTION
Closes #5688

Previously, when importing Postman collections with API key authentication, if the `"in"` field was missing or undefined in the auth configuration, the code would incorrectly default to passing the API key via query parameters (with `?? "query"` fallback). As seen in the issue [#5688](https://github.com/hoppscotch/hoppscotch/issues/5688), this caused the Authentication method to always be set as `"QUERY_PARAMS"` incorrectly.

### What's changed

Now there is no default fallback for the API key authentication when importing Postman collections, which correctly maps the `"HEADERS"` configuration from the collection being imported. The `"QUERY_PARAMS"` behaviour keeps working as expected.
