### PR TITLE
fix(desktop): prevent white screen when URI handler fails

### DIFF
--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/lib.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/lib.rs
@@ -157,6 +157,14 @@ pub fn init<R: Runtime>(config: Config) -> TauriPlugin<R> {
                 Err(e) => {
                     tracing::error!(error = %e, "URI handler failed, returning fallback error page");
 
+                    // Escape HTML special characters to prevent XSS
+                    let escaped_error = e.to_string()
+                        .replace('&', "&amp;")
+                        .replace('<', "&lt;")
+                        .replace('>', "&gt;")
+                        .replace('"', "&quot;")
+                        .replace('\'', "&#39;");
+
                     let error_html = format!(
                         r#"<!DOCTYPE html>
 <html>
@@ -198,7 +206,7 @@ pub fn init<R: Runtime>(config: Config) -> TauriPlugin<R> {
     </div>
 </body>
 </html>"#,
-                        e
+                        escaped_error
                     );
 
                     tauri::http::Response::builder()

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/uri/handler.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/uri/handler.rs
@@ -86,6 +86,19 @@ impl UriHandler {
                     "Failed to retrieve file content"
                 );
 
+                // Escape HTML special characters to prevent XSS
+                let escape_html = |s: &str| -> String {
+                    s.replace('&', "&amp;")
+                        .replace('<', "&lt;")
+                        .replace('>', "&gt;")
+                        .replace('"', "&quot;")
+                        .replace('\'', "&#39;")
+                };
+
+                let escaped_host = escape_html(host);
+                let escaped_path = escape_html(if path.is_empty() { "index.html" } else { path });
+                let escaped_error = escape_html(&e.to_string());
+
                 // Return a user-friendly error page instead of an empty response
                 // This prevents the white screen issue when cache lookup fails
                 let error_html = format!(
@@ -146,9 +159,9 @@ impl UriHandler {
     </div>
 </body>
 </html>"#,
-                    host = host,
-                    path = if path.is_empty() { "index.html" } else { path },
-                    error = e
+                    host = escaped_host,
+                    path = escaped_path,
+                    error = escaped_error
                 );
 
                 Response::builder()


### PR DESCRIPTION
## Summary

This PR fixes the white screen issue reported in #5722.

### Root Cause

The white screen occurs due to two issues in the `tauri-plugin-appload` module:

1. **`lib.rs:153`**: Used `.unwrap()` on the URI handler result, which could panic and crash the webview when the handler fails
2. **`handler.rs`**: Returned an empty 404 response when cache lookup fails, causing the webview to display a blank page

### Changes

- **`lib.rs`**: Replaced `.unwrap()` with a `match` statement that catches errors and returns a user-friendly error page with a reload button
- **`handler.rs`**: Added comprehensive error handling that displays a styled error page with technical details instead of an empty response

### Before

When the cache lookup fails or URI handler encounters an error, the app shows a blank white screen with no indication of what went wrong.

### After

Users now see a helpful error page with:
- Clear error message explaining what happened
- A "Reload" button to retry
- Technical details for debugging

## Test Plan

- [ ] Build the desktop app with these changes
- [ ] Simulate cache failures to verify error pages display correctly
- [ ] Verify normal operation is not affected
- [ ] Test on macOS/Windows/Linux

Closes #5722



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the desktop app from turning into a white screen when the URI handler fails by serving a helpful error page and avoiding panics; also escapes error details to prevent XSS. Fixes #5722 and #5716.

- **Bug Fixes**
  - lib.rs: replaced unwrap with error handling; returns a 500 HTML error page with a reload button and logs the error.
  - uri/handler.rs: replaced empty 404 with a styled 500 HTML error page showing host, path, and error details.

<sup>Written for commit 98511fca1bec7275a0eb12472b3ed86a64029113. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



