### PR TITLE
fix(common): correct typo in repo `French` locale

### DIFF
--- a/packages/hoppscotch-common/locales/fr.json
+++ b/packages/hoppscotch-common/locales/fr.json
@@ -927,7 +927,7 @@
   },
   "response": {
     "audio": "Audio",
-    "body": "Coprs de la réponse",
+    "body": "Corps de la réponse",
     "duplicated": "Réponse dupliquée",
     "duplicate_name_error": "Une réponse avec le même nom existe déjà",
     "filter_response_body": "Filtrer le corps de la réponse JSON (utilise la syntaxe JSONPath)",


### PR DESCRIPTION
Introduction
This pull request fixes a typo in the French locale file. Fixes #5675

What's changed
Changed "body": "Coprs de la réponse" to "body": "Corps de la réponse" in https://github.com/hoppscotch/hoppscotch/blob/main/packages/hoppscotch-common/locales/fr.json.

Notes to reviewers
This is a minor typo fix for the French translation. No other changes were made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the French locale, changing "Coprs de la réponse" to "Corps de la réponse" for the response body label. Resolves #5675.

<sup>Written for commit 7b7382f4369b62523aec0967c550059df2147f29. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

