### PR TITLE
feat(common): add copy functionality to console output entries

### DIFF
--- a/packages/hoppscotch-common/src/components/console/Value.vue
+++ b/packages/hoppscotch-common/src/components/console/Value.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="whitespace-pre-wrap font-mono text-[12px]">
+  <div class="whitespace-pre-wrap font-mono text-[12px] select-text">
     <VueJsonPretty
       v-if="isObjectOrArray"
       :data="parsedValue"
@@ -7,16 +7,16 @@
       :show-line="false"
       :show-line-numbers="true"
       :deep="2"
-      class="p-4 bg-primary text-secondaryDark border !border-dividerLight !text-[12px] rounded !font-mono"
+      class="p-4 bg-primary text-secondaryDark border !border-dividerLight !text-[12px] rounded !font-mono select-text"
     />
 
     <pre
       v-else-if="parsedJSON"
-      class="overflow-auto max-h-96 p-4 bg-primary text-secondaryDark border !border-dividerLight rounded"
+      class="overflow-auto max-h-96 p-4 bg-primary text-secondaryDark border !border-dividerLight rounded select-text"
       >{{ formattedJSONString }}
     </pre>
 
-    <pre v-else class="truncate"
+    <pre v-else class="truncate select-text"
       >{{ formattedPrimitive }}
     </pre>
   </div>
@@ -110,5 +110,31 @@ const treeViewTheme = computed(() => (isDarkTheme.value ? "dark" : "light"))
 .vjs-tree-node:hover {
   background-color: var(--primary-light-color) !important;
   color: var(--secondary-dark-color) !important;
+}
+</style>
+
+<style scoped>
+/* Force scrollbars to always be visible (override macOS auto-hide) */
+pre {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: var(--divider-color) transparent; /* Firefox: thumb track */
+}
+
+pre::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+pre::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+pre::-webkit-scrollbar-thumb {
+  background: var(--divider-color);
+  border-radius: 4px;
+}
+
+pre::-webkit-scrollbar-thumb:hover {
+  background: var(--secondary-light-color);
 }
 </style>


### PR DESCRIPTION
When debugging post-request scripts, developers often need to copy console output to share with teammates or save for later analysis. There was no easy way to copy values from the console panel. This PR addresses the same by adding a copy button to each console entry.

Closes #5700, FE-1106.

### What's changed

- Added hover-activated copy button to each console entry.
- Uses group-hover pattern with opacity transition (hidden by default, visible on hover).
- Icon animation: copy → checkmark for 1 second using `refAutoReset` from VueUse.
- Toast notification for copy confirmation using the existing i18n key.
- Copy output format: `[LOG_LEVEL] timestamp\narguments...`.
- Handles all JavaScript types:
  - Primitives → direct string conversion.
  - BigInt → formatted with `n` suffix (e.g., `12345n`).
  - Objects/arrays → pretty-printed JSON with 2-space indent.
  - null/undefined → string representations.
  - Unserializable values → `[Unserializable]` label.
- Copy button positioned outside scrollable content area to stay visible on hover.
- Added `aria-label` for screen reader accessibility.
- Enabled text selection across all console value types via the `select-text` class.
- Conditional hover backgrounds: `hover:bg-primaryLight` applied only to log/debug entries to preserve semantic colours (red for error, orange for warn, blue for info).

> Implementation notes

- The copy functionality uses the same patterns as response body copying (`useCopyResponse` composable) and the existing `copyToClipboard` utility for browser compatibility (`navigator.clipboard` API with fallback to `execCommand`).
- The conditional hover implementation evolved from initially using hover borders on all entries, which created double borders on JSON/object displays. The final approach checks `props.entry.type in bgColors` to determine if an entry has semantic background colours and only applies hover backgrounds to entries without them.

### Preview

<img width="1000" height="708" alt="image" src="https://github.com/user-attachments/assets/719068b1-dd05-4c25-a313-d60d848998bd" />

<img width="951" height="759" alt="image" src="https://github.com/user-attachments/assets/8fc75177-8988-4575-8aa1-9bbecc48074c" />


> JSON stringified contents

  <img width="994" height="789" alt="image" src="https://github.com/user-attachments/assets/3c97eada-f54b-4012-899c-ba80e6eedf03" />

<img width="923" height="267" alt="image" src="https://github.com/user-attachments/assets/cc49960b-342e-437b-9f5a-daafc5fc74f6" />

<img width="928" height="258" alt="image" src="https://github.com/user-attachments/assets/bee5bf71-a846-4773-b549-d84100eb1556" />

<img width="1742" height="333" alt="image" src="https://github.com/user-attachments/assets/1383a251-81bd-44e9-a42f-9b9f8b35455b" />

### Note to reviewers

Observe the console entries displayed after inserting the snippets below into the post-request script.

```js
console.log(hopp)
console.log(JSON.stringify(pw, null, 2))


console.log("Simple string")
console.log(42)
console.log(true)
console.log(null)
console.log(undefined)
// 2. BigInt:

console.log(9007199254740991n)
// 3. Objects and Arrays:

console.log({ name: "test", value: 123 })
console.log([1, 2, 3, 4, 5])
console.log({ nested: { deep: { value: "test" } } })
// 4. Multiple Arguments:

console.log("Message:", { status: 200 }, "completed")
console.log("Value1", "Value2", "Value3", 123, true, null)
// 5. Different Log Levels:

console.log("Regular log")
console.info("Info message")
console.warn("Warning message")
console.error("Error message")
console.debug("Debug message")
// 6. Very Long Strings (Scrolling Test):

console.log(JSON.stringify({ data: Array(100).fill({ key: "value", nested: { deep: true } }) }))
console.log("A".repeat(1000))
// 7. Circular References (Unserializable):

const obj = { a: 1 }
obj.self = obj
console.log(obj)
// 8. Special Characters:

console.log("String with\nnewlines\nand\ttabs")
console.log("Emoji: 🚀 ✨ 🎉")
console.log("Quotes: 'single' \"double\" `backtick`")
// 9. JSON Strings:

console.log('{"valid":"json","number":123}')
console.log('{"formatted": "json string with spaces"}')
// 10. Mixed Complex Case:

console.log("Request failed:", { 
  error: "Network timeout",
  statusCode: 408,
  timestamp: new Date().toISOString(),
  retries: 3,
  config: { url: "https://api.example.com", method: "POST" }
}, "Will retry in 5s")
```