### PR TITLE
chore: apply ThrottlerBehindProxyGuard across controllers

### DIFF
--- a/packages/hoppscotch-backend/src/app.controller.ts
+++ b/packages/hoppscotch-backend/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ThrottlerBehindProxyGuard } from './guards/throttler-behind-proxy.guard';
 
 @Controller('ping')
+@UseGuards(ThrottlerBehindProxyGuard)
 export class AppController {
   @Get()
   ping(): string {

--- a/packages/hoppscotch-backend/src/health/health.controller.ts
+++ b/packages/hoppscotch-backend/src/health/health.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
   PrismaHealthIndicator,
 } from '@nestjs/terminus';
+import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Controller('health')
+@UseGuards(ThrottlerBehindProxyGuard)
 export class HealthController {
   constructor(
     private health: HealthCheckService,

--- a/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, HttpStatus, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { InfraConfigService } from './infra-config.service';
 import { RESTError } from 'src/types/RESTError';
 import { throwHTTPErr } from 'src/utils';
@@ -11,8 +19,10 @@ import {
 } from './dto/onboarding.dto';
 import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
+import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 
 @Controller({ path: 'onboarding', version: '1' })
+@UseGuards(ThrottlerBehindProxyGuard)
 export class OnboardingController {
   constructor(private infraConfigService: InfraConfigService) {}
 

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.controller.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.controller.ts
@@ -5,6 +5,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { PublishedDocsService } from './published-docs.service';
@@ -12,9 +13,11 @@ import { GetPublishedDocsQueryDto } from './published-docs.dto';
 import * as E from 'fp-ts/Either';
 import { throwHTTPErr } from 'src/utils';
 import { PublishedDocs } from './published-docs.model';
+import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 
 @ApiTags('Published Docs')
 @Controller({ version: '1', path: 'published-docs' })
+@UseGuards(ThrottlerBehindProxyGuard)
 export class PublishedDocsController {
   constructor(private readonly publishedDocsService: PublishedDocsService) {}
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes BE-700

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR addresses missing rate-limit coverage in a few backend endpoints to ensure consistent protection across the API surface.

1. Added rate-limiting to health check APIs.
2. Applied rate-limiting to additional controllers that were previously missed.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
No additional notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied ThrottlerBehindProxyGuard across ping, health, onboarding (v1), and published-docs (v1) controllers to enforce proxy-aware rate limiting and fix missing coverage on the health route. This addresses BE-700 and ensures consistent protection on public endpoints.

- **Bug Fixes**
  - Health and ping routes are now rate-limited to prevent abuse and excessive polling.
  - Guard added at controller level so all child routes inherit the limit.

<sup>Written for commit 711cd6c601486810c1bdcf29b765952aaebda83e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

