### PR TITLE
feat(common): show full request path in tab tooltip

### DIFF
--- a/packages/hoppscotch-common/src/components/http/TabHead.vue
+++ b/packages/hoppscotch-common/src/components/http/TabHead.vue
@@ -164,9 +164,7 @@ const requestPath = computed(() => {
     ctx.folderPath
   ) {
     try {
-      const folderIndices = ctx.folderPath
-        .split("/")
-        .map((x: string) => parseInt(x))
+      const folderIndices = ctx.folderPath.split("/").map((x) => parseInt(x))
       const pathItems: string[] = []
 
       let currentFolder =
@@ -203,11 +201,17 @@ const escapeHtml = (text: string) => {
 
 const tabTooltip = computed(() => {
   if (requestPath.value) {
-    return `<div class="text-left font-normal">
-      ${escapeHtml(tabState.value.name)}<br>
-      ${escapeHtml(requestPath.value)}<br>
-      ${escapeHtml(tabState.value.request?.endpoint || "")}
-    </div>`
+    const lines: string[] = [
+      escapeHtml(tabState.value.name),
+      escapeHtml(requestPath.value),
+    ]
+
+    const endpoint = tabState.value.request?.endpoint
+    if (endpoint) {
+      lines.push(escapeHtml(endpoint))
+    }
+
+    return `<div class="text-left font-normal">${lines.join("<br>")}</div>`
   }
   return escapeHtml(tabState.value.name)
 })


### PR DESCRIPTION
Closes #5732

### What's changed

This PR implements the feature to display the full request path in the tab tooltip, making it easier for users to identify requests that have the same name but exist in different folders.

-   **Modified [packages/hoppscotch-common/src/components/http/TabHead.vue](cci:7://file:///Users/abhibarkade/Development/OpenSource/hoppscotch/packages/hoppscotch-common/src/components/http/TabHead.vue:0:0-0:0)**:
    -   Added `restCollectionStore` and [HoppCollection](cci:2://file:///Users/abhibarkade/Development/OpenSource/hoppscotch/packages/hoppscotch-common/src/helpers/rest/document.ts:66:0-95:8) imports.
    -   Implemented a `requestPath` computed property that resolves the folder path using the request's `saveContext`.
    -   Updated the tooltip `title` binding to display the format `Collection / Folder / Subfolder / Request Name` when available.
    -   Added error handling to ensure invalid paths degrade gracefully to just showing the request name.

### Notes to reviewers

-   This logic primarily targets requests originating from **User Collections** (`originLocation: "user-collection"`) as they provide a reliable `folderPath` in their save context.
-   The path resolution logic is consistent with how other components (like Spotlight) reconstruct folder paths.

**Screenshots**
Tooltip showing full path:
<img width="1440" height="822" alt="Screenshot 2026-01-05 at 9 39 15 PM" src="https://github.com/user-attachments/assets/a9d2411b-03c3-4b10-b70f-032e74f1adfe" />
<img width="361" height="142" alt="Screenshot 2026-01-05 at 9 40 04 PM" src="https://github.com/user-attachments/assets/a2e3abd0-4acc-464f-beb6-989c6c527d1f" />


