### PR TITLE
fix: name username input validation

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -132,6 +132,7 @@ const emit = defineEmits<{
 }>()
 
 const editingName = useVModel(props, "modelValue")
+const REQUEST_NAME_REGEX = /^[A-Za-z0-9 _-]{1,50}$/
 
 const {
   generateRequestName,
@@ -139,6 +140,9 @@ const {
   isGenerateRequestNamePending,
   lastTraceID,
 } = useRequestNameGeneration(editingName)
+
+const submittedFeedback = ref(false)
+const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
 
 watch(
   () => props.show,
@@ -150,20 +154,17 @@ watch(
   }
 )
 
-const submittedFeedback = ref(false)
-const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
-
 const editRequest = () => {
-  if (props.loadingState) {
-    return
-  }
+  if (props.loadingState) return
 
-  if (editingName.value.trim() === "") {
+  const name = editingName.value.trim()
+
+  if (!REQUEST_NAME_REGEX.test(name)) {
     toast.error(t("request.invalid_name"))
     return
   }
 
-  emit("submit", editingName.value)
+  emit("submit", name)
 }
 
 const hideModal = () => {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #<insert-issue-number-if-any>

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR adds proper validation for usernames in the request modal. It ensures that only valid characters are allowed and prevents users from submitting invalid names.

### What's changed
- Added a regex for username validation:
  - Allows letters (a–z, A–Z), numbers (0–9), underscores (_), and hyphens (-)
  - Minimum length: 1, Maximum length: 50 characters
- Shows a toast error message if the username is invalid
- Prevents form submission when the username does not meet the criteria

- [x] Username input now validated
- [x] Toast error implemented for invalid usernames
- [x] Submission blocked on invalid input

### Notes to reviewers
- Tested locally in the Hoppscotch dev environment
- Regex used: `/^[a-zA-Z0-9_-]{1,50}$/`
- Only affects the request modal input field


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict validation to the Request Name field in Edit Request. Trims input, blocks invalid names, and shows an error toast.

- **Bug Fixes**
  - Validate with /^[A-Za-z0-9 _-]{1,50}$/ (letters, numbers, spaces, underscores, hyphens).
  - Submit the trimmed name; block submit and show an error toast when invalid.

<sup>Written for commit 96bdb8d98543726cc2ae871f3d92ee53253c409b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

