### PR TITLE
fix(cli): inherit collection variables in folders without own variables

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -160,6 +160,16 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
       expect(result.error).toBeNull();
     });
 
+    test("Successfully inherits collection variables into folders without their own variables", async () => {
+      const args = `test ${getTestJsonFilePath(
+        "collection-with-variables.json",
+        "collection"
+      )}`;
+      const result = await runCLIWithNetworkRetry(args);
+      if (result === null) return;
+      expect(result.error).toBeNull();
+    });
+
     test("Persists environment variables set in the pre-request script for consumption in the test script", async () => {
       const args = `test ${getTestJsonFilePath(
         "pre-req-script-env-var-persistence-coll.json",

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/collection-with-variables.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/collection-with-variables.json
@@ -45,7 +45,7 @@
           ],
           "headers": [],
           "preRequestScript": "",
-          "testScript": "export {};\npw.test('Correctly inherits collection variables from the parent collection and folder', () =>\n{\n\n    pw.expect([\n        \"collection-var-1-initial-value\",\n        \"collection-var-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"collection-var-1\"])\n\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"collection-var-2\"])\n\n    pw.expect([\n        \"folder-variable-1-initial-value\",\n        \"folder-variable-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"folder-var-1\"])\n\n    pw.expect([\n        \"folder-variable-2-initial-value\",\n        \"folder-variable-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"folder-var-2\"])\n\n});",
+          "testScript": "pw.test('Correctly inherits collection variables from the parent collection and folder', () => {\n    pw.expect([\n        \"collection-var-1-initial-value\",\n        \"collection-var-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"collection-var-1\"]);\n\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"collection-var-2\"]);\n\n    pw.expect([\n        \"folder-variable-1-initial-value\",\n        \"folder-variable-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"folder-var-1\"]);\n\n    pw.expect([\n        \"folder-variable-2-initial-value\",\n        \"folder-variable-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"folder-var-2\"]);\n});",
           "auth": {
             "authType": "inherit",
             "authActive": true
@@ -77,9 +77,233 @@
           "initialValue": "folder-variable-2-initial-value"
         }
       ]
+    },
+    {
+      "id": "empty_folder_test",
+      "_ref_id": "coll_empty_folder",
+      "v": 10,
+      "name": "folder-without-variables",
+      "folders": [
+        {
+          "id": "nested_folder_test",
+          "_ref_id": "coll_nested_folder",
+          "v": 10,
+          "name": "nested-folder",
+          "folders": [],
+          "requests": [
+            {
+              "v": "15",
+              "id": "nested_request",
+              "name": "deeply-nested-request",
+              "method": "GET",
+              "endpoint": "https://echo.hoppscotch.io",
+              "params": [
+                {
+                  "key": "nested-var-1",
+                  "value": "<<collection-variable-1>>",
+                  "active": true,
+                  "description": ""
+                },
+                {
+                  "key": "nested-var-2",
+                  "value": "<<collection-variable-2>>",
+                  "active": true,
+                  "description": ""
+                }
+              ],
+              "headers": [],
+              "preRequestScript": "",
+              "testScript": "pw.test('Nested folder should inherit variables from root collection through parent', () => {\n    pw.expect([\n        \"collection-var-1-initial-value\",\n        \"collection-var-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"nested-var-1\"]);\n\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"nested-var-2\"]);\n});",
+              "auth": {
+                "authType": "inherit",
+                "authActive": true
+              },
+              "body": {
+                "contentType": null,
+                "body": null
+              },
+              "requestVariables": [],
+              "responses": {}
+            }
+          ],
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "headers": [],
+          "variables": []
+        }
+      ],
+      "requests": [
+        {
+          "v": "15",
+          "id": "request_in_empty_folder",
+          "name": "request-inheriting-collection-vars",
+          "method": "GET",
+          "endpoint": "https://echo.hoppscotch.io",
+          "params": [
+            {
+              "key": "inherited-var-1",
+              "value": "<<collection-variable-1>>",
+              "active": true,
+              "description": ""
+            },
+            {
+              "key": "inherited-var-2",
+              "value": "<<collection-variable-2>>",
+              "active": true,
+              "description": ""
+            }
+          ],
+          "headers": [],
+          "preRequestScript": "",
+          "testScript": "pw.test('Folder without variables should inherit from parent collection', () => {\n    pw.expect([\n        \"collection-var-1-initial-value\",\n        \"collection-var-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"inherited-var-1\"]);\n\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"inherited-var-2\"]);\n});",
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "body": {
+            "contentType": null,
+            "body": null
+          },
+          "requestVariables": [],
+          "responses": {}
+        }
+      ],
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "headers": [],
+      "variables": []
+    },
+    {
+      "id": "precedence_test_folder",
+      "_ref_id": "coll_precedence_folder",
+      "v": 10,
+      "name": "folder-with-override",
+      "folders": [],
+      "requests": [
+        {
+          "v": "15",
+          "id": "request_with_override",
+          "name": "request-with-folder-override",
+          "method": "GET",
+          "endpoint": "https://echo.hoppscotch.io",
+          "params": [
+            {
+              "key": "overridden-var",
+              "value": "<<collection-variable-1>>",
+              "active": true,
+              "description": ""
+            },
+            {
+              "key": "non-overridden-var",
+              "value": "<<collection-variable-2>>",
+              "active": true,
+              "description": ""
+            }
+          ],
+          "headers": [],
+          "preRequestScript": "",
+          "testScript": "pw.test('Folder variable should take precedence over collection variable with same key', () => {\n    // collection-variable-1 is overridden by folder, should be 'folder-override-value'\n    pw.expect(pw.response.body.args[\"overridden-var\"]).toBe(\"folder-override-value\");\n\n    // collection-variable-2 is NOT overridden, should be from collection\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"non-overridden-var\"]);\n});",
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "body": {
+            "contentType": null,
+            "body": null
+          },
+          "requestVariables": [],
+          "responses": {}
+        }
+      ],
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "headers": [],
+      "variables": [
+        {
+          "key": "collection-variable-1",
+          "secret": false,
+          "currentValue": "",
+          "initialValue": "folder-override-value"
+        }
+      ]
     }
   ],
-  "requests": [],
+  "requests": [
+    {
+      "v": "15",
+      "id": "root_level_request",
+      "name": "root-level-request",
+      "method": "GET",
+      "endpoint": "https://echo.hoppscotch.io",
+      "params": [
+        {
+          "key": "root-var-1",
+          "value": "<<collection-variable-1>>",
+          "active": true,
+          "description": ""
+        },
+        {
+          "key": "root-var-2",
+          "value": "<<collection-variable-2>>",
+          "active": true,
+          "description": ""
+        }
+      ],
+      "headers": [],
+      "preRequestScript": "",
+      "testScript": "pw.test('Root-level request should access collection variables directly', () => {\n    pw.expect([\n        \"collection-var-1-initial-value\",\n        \"collection-var-1-current-value\"\n    ]).toInclude(pw.response.body.args[\"root-var-1\"]);\n\n    pw.expect([\n        \"collection-var-2-initial-value\",\n        \"collection-var-2-current-value\"\n    ]).toInclude(pw.response.body.args[\"root-var-2\"]);\n});",
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "body": {
+        "contentType": null,
+        "body": null
+      },
+      "requestVariables": [],
+      "responses": {}
+    },
+    {
+      "v": "15",
+      "id": "root_level_request_with_precedence",
+      "name": "root-request-variable-precedence",
+      "method": "GET",
+      "endpoint": "https://echo.hoppscotch.io",
+      "params": [
+        {
+          "key": "precedence-test",
+          "value": "<<collection-variable-1>>",
+          "active": true,
+          "description": ""
+        }
+      ],
+      "headers": [],
+      "preRequestScript": "",
+      "testScript": "pw.test('Request variable takes precedence over collection variable with same key', () => {\n    // collection-variable-1 exists at collection level with value \"collection-var-1-initial-value\"\n    // but request variable overrides it with \"request-wins\"\n    pw.expect(pw.response.body.args[\"precedence-test\"]).toBe(\"request-wins\");\n});",
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "body": {
+        "contentType": null,
+        "body": null
+      },
+      "requestVariables": [
+        {
+          "key": "collection-variable-1",
+          "value": "request-wins",
+          "active": true
+        }
+      ],
+      "responses": {}
+    }
+  ],
   "auth": {
     "authType": "none",
     "authActive": true

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -149,11 +149,11 @@ const processCollection = async (
   for (const folder of collection.folders) {
     const updatedFolder: HoppCollection = { ...folder };
 
-    if (updatedFolder.auth?.authType === "inherit") {
+    if (updatedFolder.auth.authType === "inherit") {
       updatedFolder.auth = collection.auth;
     }
 
-    if (collection.headers?.length) {
+    if (collection.headers.length) {
       // Filter out header entries present in the parent collection under the same name
       // This ensures the folder headers take precedence over the collection headers
       const filteredHeaders = collection.headers.filter(
@@ -167,16 +167,9 @@ const processCollection = async (
       updatedFolder.headers.push(...filteredHeaders);
     }
 
-    // Inherit collection variables into folder
-    // Folder variables take precedence over collection variables (same key = folder wins)
-    if (collection.variables?.length) {
-      // Ensure folder has a variables array
-      if (!updatedFolder.variables) {
-        updatedFolder.variables = [];
-      }
-
-      // Filter out collection variables that have the same key as folder variables
-      // This ensures folder variables take precedence
+    // Inherit collection variables into folder, with folder variables taking precedence
+    if (collection.variables.length) {
+      // Filter out collection variables with same key as folder variables
       const filteredVariables = collection.variables.filter(
         (collectionVariableEntries) => {
           return !updatedFolder.variables.some(


### PR DESCRIPTION
Closes FE-1105

Collection runners weren't inheriting variables from parent collections into child folders when those folders didn't define their own variables. For example:

Collection (defines: `baseUrl=https://api.example.com`)
  └── Folder A (no variables defined)
      └── Request 1 (references `<<baseUrl>>`) → Can't access `baseUrl`

While this worked fine:

Collection (defines: `baseUrl=https://api.example.com`)
  └── Folder B (defines: `apiKey=secret`)
      └── Request 2 (references `<<baseUrl>>`) → Can access both `baseUrl` and `apiKey`

The issue was in the inheritance condition, where it checked whether the folder already had variables before merging parent variables, so empty folders never received anything.

### What's changed

- Fixed inheritance logic in `collections.ts` to check parent collection variables instead of folder variables.
- Initialise an empty `variables` array for folders that don't have one.
- Maintain correct precedence so folder variables override collection variables with the same key.
- Added comprehensive test coverage for empty folders, nested inheritance, and precedence scenarios.
- Removed unnecessary optional chaining checks.

### Notes to reviewers

The fix itself is straightforward - changed the condition from `if (updatedFolder.variables?.length)` to `if (collection.variables?.length`)` and added array initialisation. Most of the diff is comprehensive test coverage to prevent regression.

The enhanced test collection now covers:

- Folders without variables inheriting from the parent (the bug).
- Nested folders inheriting through the parent chain.
- Folder variables take precedence over collection variables.
- Request variables take precedence over collection variables.
- Root-level requests accessing collection variables.
- Variable precedence remains: `Request` > `Folder` > `Collection` > `Environment`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI collection variable inheritance so folders without variables inherit parent collection variables. Addresses Linear FE-1105; requests in empty folders can now access collection vars while keeping precedence intact.

- **Bug Fixes**
  - Merge collection variables into all folders, even when empty.
  - Preserve precedence: Request > Folder > Collection > Environment.
  - Add e2e tests and updated fixtures for empty/nested folders, overrides, and root-level requests.

<sup>Written for commit 2328afefca7c1501b77e19ebe8b6b728899ab1da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

