### PR TITLE
fix(common): prevent duplication of request ID when duplicating requests

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -512,8 +512,9 @@ const duplicateRequest = async ({
 }) => {
   const isValidToken = await handleTokenValidation()
   if (!isValidToken) return
+  const { id: _, ...requestWithoutID } = request
   saveGraphqlRequestAs(folderPath, {
-    ...cloneDeep(request),
+    ...cloneDeep(requestWithoutID),
     name: `${request.name} - ${t("action.duplicate")}`,
   })
 }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1564,8 +1564,9 @@ const duplicateRequest = async (payload: {
   const { folderPath, request } = payload
   if (!folderPath) return
 
+  const { id: _, ...requestWithoutID } = request
   const newRequest = {
-    ...cloneDeep(request),
+    ...cloneDeep(requestWithoutID),
     _ref_id: generateUniqueRefId("req"),
     name: `${request.name} - ${t("action.duplicate")}`,
   }


### PR DESCRIPTION
Closes FE-1115

## Summary
- Fix bug where duplicating a request in collections created a duplicate with the same backend request ID
- This caused issues when logged in: duplicated requests couldn't be deleted, renamed, or edited
- The fix removes the `id` field when duplicating, allowing the backend to generate a new unique ID

## Changes
- Remove `id` field from request when duplicating (both REST and GraphQL)
- This ensures each request has a unique backend ID
- Backend correctly assigns new IDs for duplicated requests

## Testing
- Login
- Duplicate a request in collection → reload → delete works ✓
- Duplicate a request in collection → reload → rename works ✓  
- Duplicate a request in collection → reload → edit works ✓
- Both REST and GraphQL requests fixed ✓

## Related Issues
- Resolves issue where original request disappeared after duplicating and renaming a request
- Resolves issue where duplicated requests couldn't be deleted or edited

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where duplicating a collection request reused the same backend request ID. We now drop the id on duplicate so the backend assigns a new ID and the copy can be edited, renamed, and deleted.

- **Bug Fixes**
  - Strip id from duplicated REST and GraphQL requests before saving.
  - Confirmed delete/rename/edit works after reload for duplicated requests.

<sup>Written for commit f43a2ca5a97f2edad8d8eff244a8ce1720af1b39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

