### PR TITLE
fix(common): restore scrolling on response panel

### DIFF
--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -12,7 +12,7 @@
     <Pane
       :size="SIDEBAR && hasSidebar ? PANE_MAIN_SIZE : 100"
       min-size="65"
-      class="flex flex-col !overflow-hidden"
+      class="flex flex-col overflow-hidden"
     >
       <Splitpanes
         class="smart-splitter"
@@ -21,7 +21,7 @@
       >
         <Pane
           :size="PANE_MAIN_TOP_SIZE"
-          class="flex flex-col !overflow-auto"
+          class="flex flex-col overflow-auto"
           :min-size="isEmbed ? 12 : 25"
         >
           <slot name="primary" />
@@ -29,7 +29,7 @@
         <Pane
           v-if="hasSecondary"
           :size="PANE_MAIN_BOTTOM_SIZE"
-          class="flex flex-col !overflow-hidden"
+          class="flex flex-col overflow-auto"
           min-size="25"
         >
           <slot name="secondary" />


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes FE-1117 #5766 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR addresses the issue that prevented the response panel from scrolling.

### What's changed
The issue was caused by the pane layout being set to overflow-hidden. This PR updates it to overflow-auto, allowing the panel to scroll.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores scrolling in the response panel by updating PaneLayout overflow settings. The secondary pane now uses overflow-auto and forced overflow overrides were removed, aligning with Linear FE-1117.

<sup>Written for commit 457f356cfc61b62fc5781ee8229c2c532210f7aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

