### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-hoppscotch-agent.yml
+++ b/.github/workflows/build-hoppscotch-agent.yml
@@ -56,13 +56,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -93,7 +93,7 @@ jobs:
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -142,7 +142,7 @@ jobs:
             fi
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-macos-x86_64
           path: artifacts/*
@@ -156,13 +156,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -193,7 +193,7 @@ jobs:
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -242,7 +242,7 @@ jobs:
             fi
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-macos-arm64
           path: artifacts/*
@@ -256,13 +256,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -300,7 +300,7 @@ jobs:
           chmod +x trunk
           sudo mv trunk /usr/local/bin/
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -334,7 +334,7 @@ jobs:
             fi
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-linux-deb
           path: artifacts/*
@@ -348,13 +348,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -392,7 +392,7 @@ jobs:
           chmod +x trunk
           sudo mv trunk /usr/local/bin/
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -427,7 +427,7 @@ jobs:
             fi
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-linux-appimage
           path: artifacts/*
@@ -441,13 +441,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -475,7 +475,7 @@ jobs:
           cd packages/hoppscotch-agent
           cat './src-tauri/tauri.conf.json' | jq '.bundle .windows += { "signCommand": env.WINDOWS_SIGN_COMMAND}' > './src-tauri/temp.json' && mv './src-tauri/temp.json' './src-tauri/tauri.conf.json'
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -516,7 +516,7 @@ jobs:
             $hash.Hash + " " + $_.Name | Out-File -Encoding UTF8 "shas/$($_.Name).sha256"
           }
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-windows-installer
           path: artifacts/*
@@ -530,13 +530,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout hoppscotch/hoppscotch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: hoppscotch/hoppscotch
           ref: ${{ inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Setup pnpm
@@ -564,7 +564,7 @@ jobs:
           cd packages/hoppscotch-agent
           cat './src-tauri/tauri.portable.conf.json' | jq '.bundle .windows += { "signCommand": env.WINDOWS_SIGN_COMMAND}' > './src-tauri/temp_portable.json' && mv './src-tauri/temp_portable.json' './src-tauri/tauri.portable.conf.json'
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -617,7 +617,7 @@ jobs:
             $hash.Hash + " " + $_.Name | Out-File -Encoding UTF8 "shas/$($_.Name).sha256"
           }
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Hoppscotch_Agent-windows-portable
           path: artifacts/*
@@ -628,7 +628,7 @@ jobs:
     if: ${{ inputs.build_macos_x64 && inputs.build_macos_arm64 && inputs.build_linux_appimage && inputs.build_windows_installer }}
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
       - name: List downloaded artifacts
@@ -664,7 +664,7 @@ jobs:
           }
           EOF
       - name: Upload manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: update-manifest
           path: artifacts/hoppscotch-agent-update.json

--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ inputs.build_linux }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
@@ -98,7 +98,7 @@ jobs:
             libjavascriptcoregtk-4.1-dev=2.44.0-2 \
             gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
             gir1.2-webkit2-4.1=2.44.0-2;
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -150,7 +150,7 @@ jobs:
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/appimage/*.AppImage.sig dist/Hoppscotch_SelfHost_linux_x64.AppImage.sig
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/deb/*.deb dist/Hoppscotch_SelfHost_linux_x64.deb
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selfhost-desktop-linux
           path: dist/*
@@ -158,7 +158,7 @@ jobs:
     runs-on: windows-latest
     if: ${{ inputs.build_windows }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
@@ -168,7 +168,7 @@ jobs:
         run: |
           echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
@@ -194,7 +194,7 @@ jobs:
           WINDOWS_SIGN_COMMAND: trusted-signing-cli -e ${{ secrets.AZURE_ENDPOINT }} -a ${{ secrets.AZURE_CODE_SIGNING_NAME }} -c ${{ secrets.AZURE_CERT_PROFILE_NAME }} %1
         run: |
           cat "${{ env.DESKTOP_PATH }}/src-tauri/tauri.conf.json" | jq '.bundle .windows += { "signCommand": env.WINDOWS_SIGN_COMMAND}' > "${{ env.DESKTOP_PATH }}/src-tauri/temp.json" && mv "${{ env.DESKTOP_PATH }}/src-tauri/temp.json" "${{ env.DESKTOP_PATH }}/src-tauri/tauri.conf.json"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -258,7 +258,7 @@ jobs:
           Copy-Item ${{ env.DESKTOP_PATH }}\src-tauri\target\release\bundle\msi\*_x64_en-US.msi dist\Hoppscotch_SelfHost_win_x64.msi
           Copy-Item ${{ env.DESKTOP_PATH }}\src-tauri\target\release\bundle\msi\*_x64_en-US.msi.sig dist\Hoppscotch_SelfHost_win_x64.msi.sig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selfhost-desktop-windows
           path: dist/*
@@ -266,12 +266,12 @@ jobs:
     runs-on: macos-latest
     if: ${{ inputs.build_macos_x64 }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
@@ -297,7 +297,7 @@ jobs:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -355,7 +355,7 @@ jobs:
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz dist/Hoppscotch_SelfHost_mac_x64.tar.gz
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz.sig dist/Hoppscotch_SelfHost_mac_x64.tar.gz.sig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selfhost-desktop-macos-x64
           path: dist/*
@@ -363,12 +363,12 @@ jobs:
     runs-on: macos-latest
     if: ${{ inputs.build_macos_arm64 }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
           token: ${{ secrets.HOPPSCOTCH_GITHUB_CHECKOUT_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
@@ -394,7 +394,7 @@ jobs:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -452,7 +452,7 @@ jobs:
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz dist/Hoppscotch_SelfHost_mac_aarch64.tar.gz
           cp ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz.sig dist/Hoppscotch_SelfHost_mac_aarch64.tar.gz.sig
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selfhost-desktop-macos-aarch64
           path: dist/*
@@ -462,7 +462,7 @@ jobs:
     if: ${{ inputs.build_linux && inputs.build_windows && inputs.build_macos_x64 && inputs.build_macos_arm64 }}
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
       - name: Create update manifest
@@ -496,7 +496,7 @@ jobs:
           }
           EOF
       - name: Upload manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: selfhost-desktop-update-manifest
           path: artifacts/hoppscotch-selfhost-desktop.json

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release-push-docker.yml
+++ b/.github/workflows/release-push-docker.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup environment
         run: cp .env.example .env
@@ -31,14 +31,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push the backend container by digest
         id: backend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./prod.Dockerfile
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push the frontend container by digest
         id: frontend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./prod.Dockerfile
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push the admin dashboard container by digest
         id: sh_admin-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./prod.Dockerfile
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push the AIO container by digest
         id: aio-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./prod.Dockerfile
@@ -111,7 +111,7 @@ jobs:
           touch "digests/aio/${aio_digest#sha256:}"
 
       - name: Upload digests files as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-docker-build-digests-${{ github.ref_name }}-${{ matrix.platform.artifactSuffix }}
           path: digests/*
@@ -124,7 +124,7 @@ jobs:
       - build
     steps:
       - name: Download digests from artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: digests
           pattern: release-docker-build-digests-${{ github.ref_name }}-*
@@ -137,7 +137,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup environment
         run: mv .env.example .env
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
           run_install: false


### PR DESCRIPTION
### What's changed
- [ ] Updated `pnpm/action-setup` from `v3` to `v4` in `.github/workflows/tests.yml`
- [ ] Updated `docker/build-push-action` from `v4` to `v6` in `.github/workflows/release-push-docker.yml`
- [ ] Updated `docker/login-action` from `v2` to `v3` in `.github/workflows/release-push-docker.yml`
- [ ] Updated `actions/cache` from `v4` to `v5` in `.github/workflows/build-hoppscotch-desktop.yml`
- [ ] Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/build-hoppscotch-agent.yml`
- [ ] Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/build-hoppscotch-desktop.yml`
- [ ] Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/build-hoppscotch-desktop.yml`
- [ ] Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/build-hoppscotch-desktop.yml`
- [ ] Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/build-hoppscotch-agent.yml`
- [ ] Updated `actions/cache` from `v4` to `v5` in `.github/workflows/build-hoppscotch-agent.yml`
- [ ] Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/build-hoppscotch-agent.yml`
- [ ] Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/release-push-docker.yml`
- [ ] Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release-push-docker.yml`
- [ ] Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/tests.yml`
- [ ] Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/build-hoppscotch-agent.yml`
- [ ] Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/build-hoppscotch-desktop.yml`
- [ ] Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/tests.yml`
- [ ] Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release-push-docker.yml`
- [ ] Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/codeql-analysis.yml`

### Notes to reviewers
This PR updates outdated GitHub Action versions to ensure compatibility and leverage the latest features. The changes will be tested in the CI pipeline of the pull request.

