### PR TITLE
fix(common): prevent support menu from triggering in editors

### DIFF
--- a/packages/hoppscotch-common/src/services/inspection/index.ts
+++ b/packages/hoppscotch-common/src/services/inspection/index.ts
@@ -181,11 +181,18 @@ export class InspectionService extends Service {
         maxWait: 2000,
       })
 
-      const inspectorRefs = computed(() =>
-        Array.from(this.inspectors.values()).map((x) =>
-          x.getInspections(debouncedReq, debouncedRes)
+      const inspectorRefs = computed(() => {
+        if (debouncedReq.value === null) return []
+
+        return Array.from(this.inspectors.values()).map((inspector) =>
+          inspector.getInspections(
+            debouncedReq as Readonly<
+              Ref<HoppRESTRequest | HoppRESTResponseOriginalRequest>
+            >,
+            debouncedRes
+          )
         )
-      )
+      })
 
       const activeInspections = computed(() =>
         inspectorRefs.value.flatMap((x) => x?.value ?? [])


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

**What the fix does:**

Prevents the Support menu (triggered by Shift+/) from opening when typing "/" in CodeMirror or Monaco editors. The fix adds a defensive check at the action execution level to ensure that when you're typing in an editor, the keystroke is treated as text input rather than a keyboard shortcut.

Why both fixes are needed:

**Old fix** (65046526f, line 280): Attempts to prevent the binding string generation early in the event flow. When it works, it's more efficient - avoids unnecessary lookups and checks.

**New fix** : Catches cases where the old fix fails due to event capture phase timing issues. With capture: true (973572d06 ), events are intercepted very early, sometimes before CodeMirror's focus handlers complete. This causes the early check to miss some cases.

Together they provide "defense in depth" where The old fix handles most cases efficiently, while the new fix acts as a safety net for edge cases caused by the capture phase event handling. Both are needed because the capture phase can cause timing-dependent detection failures that neither fix alone can handle reliably.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->
https://github.com/hoppscotch/hoppscotch/issues/5777

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Support menu (Shift+/) from opening when typing "/" in CodeMirror, Monaco, or input fields. Typing now behaves normally without accidental shortcut triggers.

- **Bug Fixes**
  - Added a binding-level check for "shift-/" in the keydown handler.
  - Skip the shortcut when the focused element is a CodeMirror editor, Monaco editor, or any typable element.

<sup>Written for commit c042452677cebccbaf98d04a024c48ddfeed6965. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

