### PR TITLE
fix(common): handle null request `ref` in `InspectionService` for test-runner tabs

### DIFF
--- a/packages/hoppscotch-common/src/services/inspection/index.ts
+++ b/packages/hoppscotch-common/src/services/inspection/index.ts
@@ -182,16 +182,15 @@ export class InspectionService extends Service {
       })
 
       const inspectorRefs = computed(() => {
-        // Skip inspection if request is null (e.g., test-runner tab)
-        const req = debouncedReq.value
-        if (req === null) return []
+        if (debouncedReq.value === null) return []
 
-        const nonNullReqRef = debouncedReq as Readonly<
-          Ref<HoppRESTRequest | HoppRESTResponseOriginalRequest>
-        >
-
-        return Array.from(this.inspectors.values()).map((x) =>
-          x.getInspections(nonNullReqRef, debouncedRes)
+        return Array.from(this.inspectors.values()).map((inspector) =>
+          inspector.getInspections(
+            debouncedReq as Readonly<
+              Ref<HoppRESTRequest | HoppRESTResponseOriginalRequest>
+            >,
+            debouncedRes
+          )
         )
       })
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
Add a null guard before calling getInspections() to:

1. Skip inspection when request is null
2. Use type assertion to satisfy TypeScript after the null check

```
const inspectorRefs = computed(() => {
  // Skip inspection if request is null (e.g., test-runner tab)
  const req = debouncedReq.value
  if (req === null) return []

  return Array.from(this.inspectors.values()).map((x) =>
    x.getInspections(debouncedReq as any, debouncedRes)
  )
})
```

This null value propagates to debouncedReq, which is then passed to getInspections(), causing a type mismatch.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->
https://github.com/hoppscotch/hoppscotch/issues/5813
<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip inspection when the request is null to prevent pre-hook errors in test‑runner tabs. Adds a null guard in InspectionService and a type assertion to satisfy TypeScript, avoiding getInspections() calls with a null request.

<sup>Written for commit ce4c587b7015a3dab0727eadec2275d7d38b0c02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

