### PR TITLE
fix: broken scroll on latest chrome versions

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -25,9 +25,9 @@
 }
 
 :root {
-  @apply antialiased;
   accent-color: var(--accent-color);
   font-variant-ligatures: common-ligatures;
+  @apply antialiased;
   @apply overscroll-none;
 }
 

--- a/packages/hoppscotch-desktop/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-desktop/src/assets/scss/styles.scss
@@ -69,13 +69,13 @@
 
   @apply selection:bg-accentDark;
   @apply selection:text-accentContrast;
-  @apply overscroll-none;
 }
 
 :root {
-  @apply antialiased;
   accent-color: var(--accent-color);
   font-variant-ligatures: common-ligatures;
+  @apply antialiased;
+  @apply overscroll-none;
 }
 
 input::placeholder,

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -87,13 +87,13 @@
 
   @apply selection:bg-accentDark;
   @apply selection:text-accentContrast;
-  @apply overscroll-none;
 }
 
 :root {
-  @apply antialiased;
   accent-color: var(--accent-color);
   font-variant-ligatures: common-ligatures;
+  @apply antialiased;
+  @apply overscroll-none;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
**Closes #5815** 

This update fixes broken scroll functionality in **Google Chrome versions >= 144.X.X.X**

## Root Cause
**Google Chrome Major Version 144 (January 2026)** introduced stricter enforcement of `overscroll-behaviour: none`, which prevents scroll events entirely on scroll containers. The global application of this property via the `*` selector caused scrollable elements in some components to become non-functional.
<img width="1509" height="504" alt="image" src="https://github.com/user-attachments/assets/ee18ec68-c8fd-4a79-a62a-2130e0861c7b" />

**Affected Areas:**
- Collections List - cannot scroll through collections (or) requests
- Environment Selector Dropdown - cannot scroll through environments

## What's changed
- Moved `overscroll-behaviour: none` from global `*` container to only `:root`
- This is because `:root` is the viewport scroll container which prevents page bounce (desired behaviour)

### Note to reviewers
**Video demonstrating the fix:**

https://github.com/user-attachments/assets/ebbad22a-bfb6-4b5c-95a5-4d1155d24938

While this issue fixes it on Google Chrome, there's a difference on Safari that I want to point out:

https://github.com/user-attachments/assets/97b67cbf-e941-4426-abce-c9382b94bbee

- If you carefully observe, there's a bounce effect that's observed at the component level in some cases. This behaviour is not observed in the latest versions of Google Chrome.

## References
[Google Chrome Release Notes for Major Version 144](https://developer.chrome.com/release-notes/144)
[Tailwind Docs for overscroll-behaviour](https://tailwindcss.com/docs/overscroll-behavior)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken scrolling in Chrome 144+ by applying overscroll-none only to :root instead of globally. Restores scrolling in lists and dropdowns while keeping viewport bounce disabled.

- **Bug Fixes**
  - Collections list scroll works again.
  - Environment selector dropdown scroll works again.

<sup>Written for commit 4d0a76b9dd114232312cd9d8bb9f5a8bd5cc91bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



