### PR TITLE
fix(backend): use duration instead of timestamp for auth cookie maxAge

### DIFF
--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -58,13 +58,13 @@ export const authCookieHandler = (
     httpOnly: true,
     secure: configService.get('INFRA.ALLOW_SECURE_COOKIES') === 'true',
     sameSite: 'lax',
-    maxAge: Date.now() + accessTokenValidityInMs,
+    maxAge: accessTokenValidityInMs,
   });
   res.cookie(AuthTokenType.REFRESH_TOKEN, authTokens.refresh_token, {
     httpOnly: true,
     secure: configService.get('INFRA.ALLOW_SECURE_COOKIES') === 'true',
     sameSite: 'lax',
-    maxAge: Date.now() + refreshTokenValidityInMs,
+    maxAge: refreshTokenValidityInMs,
   });
 
   if (!redirect) {


### PR DESCRIPTION
## Summary

This PR fixes a bug where auth cookies were being set with incorrect `maxAge` values, causing authentication issues particularly on macOS.

## Problem

The `maxAge` option in Express's `res.cookie()` expects a **duration in milliseconds**, not an absolute timestamp. The previous code was:

```typescript
maxAge: Date.now() + accessTokenValidityInMs
```

This caused cookies to have `maxAge` values of approximately 55+ years (since `Date.now()` returns ~1.7 trillion milliseconds), rather than the intended 1 day / 7 days.

## Solution

Simply use the duration directly:

```typescript
maxAge: accessTokenValidityInMs
```

## Why macOS was particularly affected

macOS (Safari/WebKit) has stricter cookie handling compared to Chrome on Windows, which caused the "Session expired. Please log in again" errors to be more prevalent on macOS.

## Testing

- Verified that cookies now correctly expire after their intended validity periods (1 day for access token, 7 days for refresh token)

Fixes #5818

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set auth cookies with correct maxAge durations (in milliseconds) instead of absolute timestamps, so they expire as intended—1 day for the access token and 7 days for the refresh token. This fixes unexpected logout issues, especially in Safari on macOS.

<sup>Written for commit 7a7d594d54957545cd77e3a2eef212e6a71238ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

