### PR TITLE
fix(backend): resolve database connection leak in infra-config operations

### DIFF
--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { InfraConfig } from './infra-config.model';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { InfraConfig as DBInfraConfig } from 'src/generated/prisma/client';
@@ -26,6 +26,7 @@ import { ConfigService } from '@nestjs/config';
 import {
   ServiceStatus,
   buildDerivedEnv,
+  disconnectSharedPrismaInstance,
   getDefaultInfraConfigs,
   getEncryptionRequiredInfraConfigEntries,
   getMissingInfraConfigEntries,
@@ -45,7 +46,7 @@ import * as crypto from 'crypto';
 import { PrismaError } from 'src/prisma/prisma-error-codes';
 
 @Injectable()
-export class InfraConfigService implements OnModuleInit {
+export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
@@ -71,6 +72,9 @@ export class InfraConfigService implements OnModuleInit {
 
   async onModuleInit() {
     await this.initializeInfraConfigTable();
+  }
+  async onModuleDestroy() {
+    await disconnectSharedPrismaInstance();
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes BE-711


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolved a database connection leak in infra-config operations by using a shared PrismaService and closing it on shutdown. This reduces redundant connections and improves reliability during startup and SSO config reads.

- **Bug Fixes**
  - Centralized Prisma access via a shared getSharedPrismaInstance in infra-config helpers.
  - Added disconnectSharedPrismaInstance and hooked it into InfraConfigService.onModuleDestroy.
  - Removed repeated PrismaService instantiation across infra-config helper methods.

<sup>Written for commit b503e8be635c9edf7e8750fb3cbdb8af000c1f4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

