### PR TITLE
fix(curl): properly handle ANSI-C quoted strings ($'...') in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1029,12 +1029,11 @@ data2: {"type":"test2","typeId":"123"}`,
     }),
   },
   // Test for ANSI-C quoting ($'...') with escape sequences - issue #5728
-  // The $'...' syntax should be converted to a regular quoted string
-  // Simple test: $'hello' becomes "hello"
+  // The $'...' syntax should evaluate escape sequences like \n, \t, etc.
   {
     command: `curl 'https://api.example.com/test' \
       -H 'content-type: text/plain' \
-      --data-raw $'simple test data'`,
+      --data-raw $'line1\\nline2\\ttabbed'`,
     response: makeRESTRequest({
       method: "POST",
       name: "Untitled",
@@ -1045,7 +1044,34 @@ data2: {"type":"test2","typeId":"123"}`,
       },
       body: {
         contentType: "text/plain",
-        body: "simple test data",
+        // The body should contain actual newline and tab characters
+        body: "line1\nline2\ttabbed",
+      },
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
+  // Test ANSI-C quoting with hex and octal escapes
+  {
+    command: `curl 'https://api.example.com/hex' \
+      -H 'content-type: text/plain' \
+      --data-raw $'A\\x42C\\101'`,
+    response: makeRESTRequest({
+      method: "POST",
+      name: "Untitled",
+      endpoint: "https://api.example.com/hex",
+      auth: {
+        authType: "inherit",
+        authActive: true,
+      },
+      body: {
+        contentType: "text/plain",
+        // \x42 = 'B', \101 (octal) = 'A' -> "ABCA"
+        body: "ABCA",
       },
       params: [],
       headers: [],

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -17,10 +17,10 @@ const replaceables: { [key: string]: string } = {
 }
 
 /**
- * ANSI-C escape sequence mappings as per bash specification.
+ * Subset of ANSI-C escape sequence mappings inspired by Bash's ANSI-C quoting.
  * See: https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting
  *
- * Note: \\ must be processed carefully to avoid double-processing.
+ * Note: This does not implement all escape forms supported by Bash (e.g. \cX, \UHHHHHHHH).
  * We use a single-pass regex to handle all escapes correctly.
  */
 const ansiCEscapeMap: Record<string, string> = {
@@ -88,7 +88,7 @@ const paperCuts = flow(
   S.replace(/\n/g, " "),
   // Process ANSI-C quoted strings ($'...') with proper escape handling
   processAnsiCQuotedStrings,
-  // Handle $"..." (which in bash just does variable expansion, treat as regular quote)
+  // Handle $"..." (which in bash is a locale-translated string) by normalizing to a regular double-quoted string
   S.replace(/\$"/g, '"'),
   S.trim
 )


### PR DESCRIPTION
## Summary
Fixes #5728

The cURL import was failing to parse commands containing ANSI-C quoted strings (`$'...'`), which are commonly used when copying cURL commands from browser DevTools. The previous implementation simply stripped the `$` prefix without processing the escape sequences inside.

## Changes

Added proper ANSI-C escape sequence handling in `preproc.ts`:

- Standard escapes: `\n`, `\t`, `\r`, `\\`, `\'`, `\"`, `\a`, `\b`, `\e`, `\f`, `\v`
- Octal escapes: `\nnn` (1-3 digits)
- Hex escapes: `\xHH`
- Unicode escapes: `\uHHHH`

The processed content is then converted to a double-quoted string with proper escaping for the yargs parser.

## Testing

Added a test case for basic ANSI-C quoted string handling. Existing tests pass (sample #12 was already failing due to a pre-existing multipart form data parsing issue unrelated to this change).

## Example

Before this fix:
```bash
curl 'https://api.example.com' --data-raw $'{"key": "value\nwith newline"}'
```
Would fail to import or produce incorrect results.

After this fix:
The command is correctly parsed with the escape sequences properly processed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import failures for ANSI‑C quoted strings ($'...') by evaluating escape sequences and converting them to regular quoted strings. Commands copied from browser DevTools now import with the correct body content.

- **Bug Fixes**
  - Parse $'...' with a single-pass escape handler (standard, octal, hex, unicode) and emit safely escaped double-quoted strings for yargs.
  - Added a test for ANSI‑C quoting; existing tests still pass.

<sup>Written for commit 2f9e8db476f5f1c99f993269b18f922ec1f6ed47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

