### PR TITLE
feature: Update Hoppscotch UI and fix Docker deployment issues

### DIFF
--- a/aio-subpath-access.Caddyfile
+++ b/aio-subpath-access.Caddyfile
@@ -3,7 +3,9 @@
   persist_config off
 }
 
-:{$HOPP_AIO_ALTERNATE_PORT:80} {
+# Caddy listens on PORT (whatever Render assigns dynamically)
+# Backend uses HOPP_BACKEND_PORT (set via aio_run.mjs, defaults to 3170)
+:{$PORT:80} {
 	# Serve the `selfhost-web` SPA by default
 	root * /site/selfhost-web
 	file_server
@@ -17,18 +19,19 @@
 	}
 
 	# Handle requests under `/backend*` path
+	# Backend on HOPP_BACKEND_PORT (aio_run.mjs overrides PORT for backend process)
 	handle_path /backend* {
 		@mock {
 			header_regexp host Host ^[^.]+\.mock\..*$
 		}
-		
+
 		handle @mock {
 			rewrite * /mock{uri}
-			reverse_proxy localhost:8080
+			reverse_proxy localhost:{$HOPP_BACKEND_PORT:3170}
 		}
-		
+
 		handle {
-			reverse_proxy localhost:8080
+			reverse_proxy localhost:{$HOPP_BACKEND_PORT:3170}
 		}
 	}
 

--- a/packages/hoppscotch-agent/index.html
+++ b/packages/hoppscotch-agent/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hoppscotch Agent</title>
+    <title>RBS PostMan Agent</title>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/hoppscotch-common/assets/themes/base-themes.scss
+++ b/packages/hoppscotch-common/assets/themes/base-themes.scss
@@ -1,8 +1,8 @@
 @mixin base-theme {
   --font-sans: "Inter Variable", sans-serif;
   --font-mono: "Roboto Mono Variable", monospace;
-  --font-size-body: 0.75rem;
-  --font-size-tiny: 0.625rem;
+  --font-size-body: 1rem;
+  --font-size-tiny: 0.75rem;
   --line-height-body: 1rem;
   --upper-primary-sticky-fold: 4.125rem;
   --upper-runner-sticky-fold: 4.125rem;

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -224,10 +224,13 @@ const getHoppResponses = (
   return Object.fromEntries(
     pipe(
       responses.all(),
-      A.map((response) => {
+      A.mapWithIndex((index, response) => {
+        // Provide fallback name for examples without names
+        const responseName = response.name || `Example ${index + 1}`
+
         const res = {
-          name: response.name,
-          status: response.status,
+          name: responseName,
+          status: response.status || "",
           body: getHoppResponseBody(response.body),
           headers: getHoppReqHeaders(response.headers),
           code: response.code,
@@ -242,16 +245,19 @@ const getHoppResponses = (
               response.originalRequest?.headers ?? null
             ),
             method: response.originalRequest?.method ?? "",
-            name: response.originalRequest?.name ?? response.name,
+            name:
+              (response.originalRequest?.name &&
+                response.originalRequest.name.trim()) ||
+              responseName,
             params: getHoppReqParams(
-              response.originalRequest?.url.query ?? null
+              response.originalRequest?.url?.query ?? null
             ),
             requestVariables: getHoppReqVariables(
-              response.originalRequest?.url.variables ?? null
+              response.originalRequest?.url?.variables ?? null
             ),
           }),
         }
-        return [response.name, res]
+        return [responseName, res]
       })
     )
   )

--- a/packages/hoppscotch-desktop/index.html
+++ b/packages/hoppscotch-desktop/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hoppscotch Desktop App</title>
+    <title>RBS PostMan Desktop App</title>
   </head>
 
   <body>

--- a/packages/hoppscotch-desktop/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-desktop/src/assets/scss/styles.scss
@@ -1,8 +1,8 @@
 @mixin base-theme {
   --font-sans: 'Inter Variable', sans-serif;
   --font-mono: 'Roboto Mono Variable', monospace;
-  --font-size-body: 0.75rem;
-  --font-size-tiny: 0.625rem;
+  --font-size-body: 1rem;
+  --font-size-tiny: 0.75rem;
   --line-height-body: 1rem;
 }
 

--- a/packages/hoppscotch-selfhost-web/index.html
+++ b/packages/hoppscotch-selfhost-web/index.html
@@ -4,7 +4,7 @@
     <script>
       globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"')
     </script>
-    <title>Hoppscotch • Open source API development ecosystem</title>
+    <title>RBS PostMan</title>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -6,8 +6,8 @@
 @mixin base-theme {
   --font-sans: 'Inter Variable', sans-serif;
   --font-mono: 'Roboto Mono Variable', monospace;
-  --font-size-body: 0.75rem;
-  --font-size-tiny: 0.625rem;
+  --font-size-body: 1rem;
+  --font-size-tiny: 0.75rem;
   --line-height-body: 1rem;
   --upper-primary-sticky-fold: 4rem;
   --upper-secondary-sticky-fold: 6.188rem;

--- a/packages/hoppscotch-sh-admin/index.html
+++ b/packages/hoppscotch-sh-admin/index.html
@@ -7,7 +7,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hoppscotch Admin</title>
+    <title>RBS PostMan Admin</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary
Enhanced admin dashboard user interface with updated styles and titles, and resolved Docker build and deployment issues.

## Changes Made

### UI/UX Improvements
- **Updated admin dashboard styles** (`packages/hoppscotch-sh-admin/assets/scss/styles.scss`)
  - Customized admin panel styling for improved visual appearance
  - Modified color schemes and layout elements
  
- **Updated page titles and branding**
  - Improved admin dashboard title elements
  - Enhanced user-facing text and labels

### Docker Configuration Fixes
- **Fixed Dockerfile GitHub dependency handling** (lines 118-126)
  - Updated sed commands to match actual package.json dependency format (`github:owner/repo#commit`)
  - Pre-download GitHub tarballs and replace with local `file:///` paths
  - Resolves build failures due to network issues when fetching Tauri plugin dependencies

- **Fixed port configuration in .env**
  - Set `PORT=80` for Caddy inside container (mapped to host 3080)
  - Set `HOPP_BACKEND_PORT=3170` for backend service
  - Resolves port conflict error `EADDRINUSE: address already in use :::3170`

### Code Quality
- **Fixed linting errors blocking commits:**
  - Removed unused `cloneDeep` import from OpenAPI import helper
  - Fixed prettier format

## Deployment
- Built custom Docker image: `rbsdeveloper/hoppscotch-aio:latest`
- Successfully pushed to Docker Hub
- Ready for production deployment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates app branding and font sizing, adds path-based folder grouping for OpenAPI imports, and fixes container port routing for reliable self-hosted runs on Render. Also hardens import behavior and prevents FK errors during team collection creation.

- **New Features**
  - OpenAPI import groups requests into nested folders by URL path within a single collection.
  - Request naming prefers summary over operationId for OpenAPI; cleaner example names in Postman imports.
  - Updated titles to “RBS PostMan” and increased base font sizes for better readability.

- **Bug Fixes**
  - Caddy now listens on PORT; backend binds to HOPP_BACKEND_PORT (default 3170) and reverse_proxy targets it.
  - Backend is started with PORT=HOPP_BACKEND_PORT to avoid EADDRINUSE; Caddyfile and runner updated accordingly.
  - Team collections are created sequentially to avoid foreign key violations with nested folders.
  - Postman import handles missing status/url fields and unnamed examples gracefully.

<sup>Written for commit 73ed6e908e66a54ad4be3817826965accd504c6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

