### PR TITLE
Fix Linux desktop failing to start on Ubuntu 22.04 (GLIBC mismatch)

### DIFF
--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -92,12 +92,12 @@ jobs:
             librsvg2-dev;
 
           sudo apt install -y \
-            libwebkit2gtk-4.1-0=2.44.0-2 \
-            libwebkit2gtk-4.1-dev=2.44.0-2 \
-            libjavascriptcoregtk-4.1-0=2.44.0-2 \
-            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-            gir1.2-webkit2-4.1=2.44.0-2;
+             libwebkit2gtk-4.1-0 \
+             libwebkit2gtk-4.1-dev \
+             libjavascriptcoregtk-4.1-0 \
+             libjavascriptcoregtk-4.1-dev \
+             gir1.2-javascriptcoregtk-4.1 \
+             gir1.2-webkit2-4.1;
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
The Linux desktop binary is currently built on ubuntu-24.04, which links
against GLIBC 2.38/2.39. Ubuntu 22.04 LTS ships with GLIBC 2.35, causing
the application to fail at startup with:

GLIBC_2.38 not found
GLIBC_2.39 not found

Linux binaries should be built on the oldest supported distribution to ensure
forward compatibility across newer distros.

This PR changes the build environment to ubuntu-22.04 so the produced binary
works on Ubuntu 22.04 and newer Linux distributions.

No runtime code changes were made — only CI build environment adjustment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Linux desktop CI build from ubuntu-24.04 to ubuntu-22.04 so the binary links against GLIBC 2.35 and starts correctly on Ubuntu 22.04 and newer. Also removes version pinning for WebKitGTK packages to match 22.04 repos; no runtime code changes.

- **Bug Fixes**
  - Build runs on ubuntu-22.04 and drops WebKitGTK version pinning for 22.04 compatibility.
  - Resolves “GLIBC_2.38/2.39 not found” startup errors on Ubuntu 22.04.

<sup>Written for commit 3fb83861c9c224f05a5b5b81e5f7421c760afa31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

