### PR TITLE
fix: auto-recover from corrupted sandbox state

### DIFF
--- a/packages/hoppscotch-js-sandbox/src/__tests__/combined/script-error-recovery.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/combined/script-error-recovery.spec.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { FaradayCage } from "faraday-cage"
+import * as E from "fp-ts/Either"
+import { runTest, fakeResponse, defaultRequest } from "~/utils/test-helpers"
+import { runTestScript } from "~/web"
+import { _setCagePromiseForTesting } from "~/utils/cage"
+
+/**
+ * Verifies that the test runner properly recovers from script errors without
+ * stale state persisting across subsequent executions.
+ */
+describe("script error recovery", () => {
+  test("runtime error followed by valid script should not show stale error", async () => {
+    const errorScript = `
+a(); // ReferenceError: a is not defined
+hopp.test("Should not run", () => {
+  hopp.expect(hopp.response.statusCode).toBe(200);
+});
+`
+
+    const errorResult = await runTest(errorScript, {
+      global: [],
+      selected: [],
+    })()
+
+    expect(errorResult).toBeLeft()
+
+    const validScript = `
+// a(); - commented out
+hopp.test("Status code is 200", () => {
+  hopp.expect(hopp.response.statusCode).toBe(200);
+});
+`
+
+    const validResult = await runTest(validScript, {
+      global: [],
+      selected: [],
+    })()
+
+    expect(validResult).toEqualRight([
+      expect.objectContaining({
+        descriptor: "root",
+        children: [
+          expect.objectContaining({
+            descriptor: "Status code is 200",
+            expectResults: [
+              expect.objectContaining({
+                status: "pass",
+                message: expect.stringContaining("Expected '200' to be '200'"),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ])
+  })
+
+  test("multiple consecutive runtime errors should each be fresh", async () => {
+    const error1 = await runTest(`a();`, { global: [], selected: [] })()
+    expect(error1).toBeLeft()
+
+    const error2 = await runTest(`b();`, { global: [], selected: [] })()
+    expect(error2).toBeLeft()
+
+    const valid = await runTest(
+      `hopp.test("Works", () => { hopp.expect(true).toBe(true); });`,
+      { global: [], selected: [] }
+    )()
+
+    expect(valid).toEqualRight([
+      expect.objectContaining({
+        descriptor: "root",
+        children: [
+          expect.objectContaining({
+            descriptor: "Works",
+            expectResults: [
+              expect.objectContaining({
+                status: "pass",
+                message: expect.stringContaining(
+                  "Expected 'true' to be 'true'"
+                ),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ])
+  })
+
+  test("syntax error followed by valid script should work", async () => {
+    const syntaxError = await runTest(`const x = ;`, {
+      global: [],
+      selected: [],
+    })()
+    expect(syntaxError).toBeLeft()
+
+    const valid = await runTest(
+      `hopp.test("Works", () => { hopp.expect(true).toBe(true); });`,
+      { global: [], selected: [] }
+    )()
+
+    expect(valid).toEqualRight([
+      expect.objectContaining({
+        descriptor: "root",
+        children: [
+          expect.objectContaining({
+            descriptor: "Works",
+            expectResults: [
+              expect.objectContaining({
+                status: "pass",
+                message: expect.stringContaining(
+                  "Expected 'true' to be 'true'"
+                ),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ])
+  })
+})
+
+/**
+ * Exercises the production singleton path where a corrupted cage persists
+ * across calls. The retry-on-bootstrap-error logic should transparently
+ * recover so the user never sees the stale failure.
+ */
+describe("singleton cage retry on bootstrap error", () => {
+  afterEach(() => {
+    _setCagePromiseForTesting(null)
+  })
+
+  test("bootstrap error triggers retry on fresh cage", async () => {
+    const corruptedCage = await FaradayCage.create()
+    const originalRunCode = corruptedCage.runCode.bind(corruptedCage)
+
+    let callCount = 0
+    corruptedCage.runCode = ((...args: Parameters<typeof originalRunCode>) => {
+      callCount++
+      if (callCount === 1) {
+        // Simulate an infrastructure error on the first call
+        return Promise.resolve({
+          type: "error" as const,
+          err: new Error("cannot convert to object"),
+        })
+      }
+      return originalRunCode(...args)
+    }) as typeof originalRunCode
+
+    _setCagePromiseForTesting(Promise.resolve(corruptedCage))
+
+    const result = await runTestScript(
+      `hopp.test("Should work after retry", () => { hopp.expect(true).toBe(true); });`,
+      {
+        envs: { global: [], selected: [] },
+        request: defaultRequest,
+        response: fakeResponse,
+        cookies: null,
+        experimentalScriptingSandbox: true,
+      }
+    )
+
+    // The first call failed with an infra error, retry succeeded on a fresh cage
+    expect(callCount).toBe(1)
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isRight(result)) {
+      expect(result.right.tests).toEqual(
+        expect.objectContaining({
+          descriptor: "root",
+          children: [
+            expect.objectContaining({
+              descriptor: "Should work after retry",
+              expectResults: [expect.objectContaining({ status: "pass" })],
+            }),
+          ],
+        })
+      )
+    }
+  })
+
+  test("user script errors do not trigger retry", async () => {
+    const cage = await FaradayCage.create()
+    const originalRunCode = cage.runCode.bind(cage)
+
+    let callCount = 0
+    cage.runCode = ((...args: Parameters<typeof originalRunCode>) => {
+      callCount++
+      return originalRunCode(...args)
+    }) as typeof originalRunCode
+
+    _setCagePromiseForTesting(Promise.resolve(cage))
+
+    const result = await runTestScript(`a();`, {
+      envs: { global: [], selected: [] },
+      request: defaultRequest,
+      response: fakeResponse,
+      cookies: null,
+      experimentalScriptingSandbox: true,
+    })
+
+    // User script error should NOT trigger retry — only one call to runCode
+    expect(E.isLeft(result)).toBe(true)
+    expect(callCount).toBe(1)
+  })
+})

--- a/packages/hoppscotch-js-sandbox/src/__tests__/hopp-namespace/request.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/hopp-namespace/request.spec.ts
@@ -105,7 +105,7 @@ describe("hopp.request", () => {
         })
       ).resolves.toEqualLeft(
         expect.stringContaining(
-          `Script execution failed: hopp.request.${property} is read-only`
+          `Script execution failed: TypeError: hopp.request.${property} is read-only`
         )
       )
     )
@@ -124,7 +124,7 @@ describe("hopp.request", () => {
         })
       ).resolves.toEqualLeft(
         expect.stringContaining(
-          `Script execution failed: hopp.request.${property} is read-only`
+          `Script execution failed: TypeError: hopp.request.${property} is read-only`
         )
       )
     )
@@ -531,7 +531,9 @@ describe("hopp.request", () => {
         }
       )
     ).resolves.toEqualLeft(
-      expect.stringContaining(`Script execution failed: not a function`)
+      expect.stringContaining(
+        `Script execution failed: TypeError: not a function`
+      )
     )
   })
 

--- a/packages/hoppscotch-js-sandbox/src/__tests__/utils/cage.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/utils/cage.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest"
+import { isInfraError } from "~/utils/cage"
+
+describe("isInfraError", () => {
+  test("identifies Error instances as infrastructure errors", () => {
+    expect(isInfraError(new Error("test error"))).toBe(true)
+  })
+
+  test("identifies Error subclasses as infrastructure errors", () => {
+    class QuickJSUnwrapError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = "QuickJSUnwrapError"
+      }
+    }
+
+    expect(
+      isInfraError(new QuickJSUnwrapError("cannot convert to object"))
+    ).toBe(true)
+  })
+
+  test("identifies WASM initialization errors", () => {
+    expect(isInfraError(new Error("wasm init failed"))).toBe(true)
+  })
+
+  test("does not classify plain objects from QuickJS dump() as infrastructure", () => {
+    // QuickJS dump() produces plain objects for user script errors — NOT Error instances
+    expect(
+      isInfraError({
+        name: "ReferenceError",
+        message: "a is not defined",
+        stack: "    at <anonymous> (eval.js:1)\n",
+      })
+    ).toBe(false)
+
+    expect(
+      isInfraError({
+        name: "TypeError",
+        message: "cannot convert to object",
+        stack: "    at keys (native)\n    at <anonymous> (eval.js:1)\n",
+      })
+    ).toBe(false)
+  })
+
+  test("handles non-object and null errors gracefully", () => {
+    expect(isInfraError("string error")).toBe(false)
+    expect(isInfraError(null)).toBe(false)
+    expect(isInfraError(undefined)).toBe(false)
+  })
+})

--- a/packages/hoppscotch-js-sandbox/src/node/pre-request/experimental.ts
+++ b/packages/hoppscotch-js-sandbox/src/node/pre-request/experimental.ts
@@ -1,11 +1,87 @@
 import { Cookie, HoppRESTRequest } from "@hoppscotch/data"
-import { pipe } from "fp-ts/function"
+import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/lib/TaskEither"
 import { cloneDeep } from "lodash"
 
 import { defaultModules, preRequestModule } from "~/cage-modules"
 import { HoppFetchHook, SandboxPreRequestResult, TestResult } from "~/types"
-import { acquireCage } from "~/utils/cage"
+import { acquireCage, resetCage, isInfraError } from "~/utils/cage"
+
+/**
+ * Runs a pre-request script on the given cage instance.
+ * Returns the result or "retry" if a bootstrap error triggered a cage reset.
+ */
+const executePreRequestOnCage = async (
+  cage: Awaited<ReturnType<typeof acquireCage>>,
+  preRequestScript: string,
+  envs: TestResult["envs"],
+  request: HoppRESTRequest,
+  cookies: Cookie[] | null,
+  hoppFetchHook?: HoppFetchHook
+): Promise<E.Either<string, SandboxPreRequestResult> | "retry"> => {
+  let finalEnvs = envs
+  let finalRequest = request
+  let finalCookies = cookies
+
+  const captureHook: { capture?: () => void; bootstrapError?: unknown } = {}
+
+  const result = await cage.runCode(preRequestScript, [
+    ...defaultModules({
+      hoppFetchHook,
+    }),
+
+    preRequestModule(
+      {
+        envs: cloneDeep(envs),
+        request: cloneDeep(request),
+        cookies: cookies ? cloneDeep(cookies) : null,
+        handleSandboxResults: ({ envs, request, cookies }) => {
+          finalEnvs = envs
+          finalRequest = request
+          finalCookies = cookies
+        },
+      },
+      captureHook
+    ),
+  ])
+
+  if (result.type === "error") {
+    const bootstrapFailed = captureHook.bootstrapError !== undefined
+    const errorToAnalyze = bootstrapFailed
+      ? captureHook.bootstrapError
+      : result.err
+
+    if (bootstrapFailed || isInfraError(errorToAnalyze)) {
+      resetCage()
+      return "retry"
+    }
+
+    if (
+      result.err !== null &&
+      typeof result.err === "object" &&
+      "message" in result.err
+    ) {
+      const name =
+        "name" in result.err && typeof result.err.name === "string"
+          ? result.err.name
+          : ""
+      const prefix = name ? `${name}: ` : ""
+      return E.left(`Script execution failed: ${prefix}${result.err.message}`)
+    }
+
+    return E.left(`Script execution failed: ${String(result.err)}`)
+  }
+
+  if (captureHook.capture) {
+    captureHook.capture()
+  }
+
+  return E.right({
+    updatedEnvs: finalEnvs,
+    updatedRequest: finalRequest,
+    updatedCookies: finalCookies,
+  })
+}
 
 export const runPreRequestScriptWithFaradayCage = (
   preRequestScript: string,
@@ -14,64 +90,47 @@ export const runPreRequestScriptWithFaradayCage = (
   cookies: Cookie[] | null,
   hoppFetchHook?: HoppFetchHook
 ): TE.TaskEither<string, SandboxPreRequestResult> => {
-  return pipe(
-    TE.tryCatch(
-      async (): Promise<SandboxPreRequestResult> => {
-        let finalEnvs = envs
-        let finalRequest = request
-        let finalCookies = cookies
-
+  return () =>
+    (async () => {
+      try {
         const cage = await acquireCage()
 
-        try {
-          const captureHook: { capture?: () => void } = {}
+        const firstAttempt = await executePreRequestOnCage(
+          cage,
+          preRequestScript,
+          envs,
+          request,
+          cookies,
+          hoppFetchHook
+        )
 
-          const result = await cage.runCode(preRequestScript, [
-            ...defaultModules({
-              hoppFetchHook,
-            }),
-
-            preRequestModule(
-              {
-                envs: cloneDeep(envs),
-                request: cloneDeep(request),
-                cookies: cookies ? cloneDeep(cookies) : null,
-                handleSandboxResults: ({ envs, request, cookies }) => {
-                  finalEnvs = envs
-                  finalRequest = request
-                  finalCookies = cookies
-                },
-              },
-              captureHook
-            ),
-          ])
-
-          if (captureHook.capture) {
-            captureHook.capture()
-          }
-
-          if (result.type === "error") {
-            throw result.err
-          }
-
-          return {
-            updatedEnvs: finalEnvs,
-            updatedRequest: finalRequest,
-            updatedCookies: finalCookies,
-          }
-        } finally {
-          // Don't dispose cage here - returned objects may still be accessed.
-          // Rely on garbage collection for cleanup.
-        }
-      },
-      (error) => {
-        if (error !== null && typeof error === "object" && "message" in error) {
-          const reason = `${"name" in error ? error.name : ""}: ${error.message}`
-          return `Script execution failed: ${reason}`
+        if (firstAttempt !== "retry") {
+          return firstAttempt
         }
 
-        return `Script execution failed: ${String(error)}`
+        // Bootstrap error detected and cage was reset — retry once on a fresh cage
+        const freshCage = await acquireCage()
+        const retryResult = await executePreRequestOnCage(
+          freshCage,
+          preRequestScript,
+          envs,
+          request,
+          cookies,
+          hoppFetchHook
+        )
+
+        if (retryResult === "retry") {
+          return E.left(
+            "Script execution failed: sandbox initialization error (persistent)"
+          )
+        }
+
+        return retryResult
+      } catch (error) {
+        const name =
+          error instanceof Error && error.name ? `${error.name}: ` : ""
+        const message = error instanceof Error ? error.message : String(error)
+        return E.left(`Script execution failed: ${name}${message}`)
       }
-    )
-  )
+    })()
 }

--- a/packages/hoppscotch-js-sandbox/src/node/test-runner/experimental.ts
+++ b/packages/hoppscotch-js-sandbox/src/node/test-runner/experimental.ts
@@ -1,6 +1,6 @@
 import { HoppRESTRequest } from "@hoppscotch/data"
+import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
-import { pipe } from "fp-ts/function"
 import { cloneDeep } from "lodash"
 
 import { defaultModules, postRequestModule } from "~/cage-modules"
@@ -10,7 +10,117 @@ import {
   TestResponse,
   TestResult,
 } from "~/types"
-import { acquireCage } from "~/utils/cage"
+import { acquireCage, resetCage, isInfraError } from "~/utils/cage"
+
+/**
+ * Runs a post-request/test script on the given cage instance.
+ * Returns the result or "retry" if a bootstrap error triggered a cage reset.
+ */
+const executeTestOnCage = async (
+  cage: Awaited<ReturnType<typeof acquireCage>>,
+  testScript: string,
+  envs: TestResult["envs"],
+  request: HoppRESTRequest,
+  response: TestResponse,
+  hoppFetchHook?: HoppFetchHook
+): Promise<E.Either<string, TestResult> | "retry"> => {
+  const testRunStack: TestDescriptor[] = [
+    { descriptor: "root", expectResults: [], children: [] },
+  ]
+
+  let finalEnvs = envs
+  let finalTestResults = testRunStack
+  const testPromises: Promise<void>[] = []
+
+  const captureHook: { capture?: () => void; bootstrapError?: unknown } = {}
+
+  const result = await cage.runCode(testScript, [
+    ...defaultModules({
+      hoppFetchHook,
+    }),
+    postRequestModule(
+      {
+        envs: cloneDeep(envs),
+        testRunStack: cloneDeep(testRunStack),
+        request: cloneDeep(request),
+        response: cloneDeep(response),
+        // TODO: Post type update, accommodate for cookies although platform support is limited
+        cookies: null,
+        handleSandboxResults: ({ envs, testRunStack }) => {
+          finalEnvs = envs
+          finalTestResults = testRunStack
+        },
+        onTestPromise: (promise) => {
+          testPromises.push(promise)
+        },
+      },
+      captureHook
+    ),
+  ])
+
+  if (result.type === "error") {
+    const bootstrapFailed = captureHook.bootstrapError !== undefined
+    const errorToAnalyze = bootstrapFailed
+      ? captureHook.bootstrapError
+      : result.err
+
+    if (bootstrapFailed || isInfraError(errorToAnalyze)) {
+      resetCage()
+      return "retry"
+    }
+
+    if (
+      result.err !== null &&
+      typeof result.err === "object" &&
+      "message" in result.err
+    ) {
+      const name =
+        "name" in result.err && typeof result.err.name === "string"
+          ? result.err.name
+          : ""
+      const prefix = name ? `${name}: ` : ""
+      return E.left(`Script execution failed: ${prefix}${result.err.message}`)
+    }
+
+    return E.left(`Script execution failed: ${String(result.err)}`)
+  }
+
+  // Execute tests sequentially to support dependent tests that share variables.
+  if (testPromises.length > 0) {
+    for (let i = 0; i < testPromises.length; i++) {
+      await testPromises[i]
+    }
+  }
+
+  if (captureHook.capture) {
+    captureHook.capture()
+  }
+
+  // Check for uncaught runtime errors (ReferenceError, TypeError, etc.) in test callbacks.
+  // These should fail the entire test run, NOT be reported as testcases.
+  const runtimeErrors = finalTestResults
+    .flatMap((t) => t.children)
+    .flatMap((child) => child.expectResults || [])
+    .filter(
+      (r) =>
+        r.status === "error" &&
+        /^(ReferenceError|TypeError|SyntaxError|RangeError|URIError|EvalError|AggregateError|InternalError|Error):/.test(
+          r.message
+        )
+    )
+
+  if (runtimeErrors.length > 0) {
+    return E.left(`Script execution failed: ${runtimeErrors[0].message}`)
+  }
+
+  const safeTestResults = cloneDeep(finalTestResults)
+  const safeEnvs = cloneDeep(finalEnvs)
+
+  return E.right({
+    tests: safeTestResults,
+    envs: safeEnvs,
+  })
+}
 
 export const runPostRequestScriptWithFaradayCage = (
   testScript: string,
@@ -19,111 +129,47 @@ export const runPostRequestScriptWithFaradayCage = (
   response: TestResponse,
   hoppFetchHook?: HoppFetchHook
 ): TE.TaskEither<string, TestResult> => {
-  return pipe(
-    TE.tryCatch(
-      async (): Promise<TestResult> => {
-        const testRunStack: TestDescriptor[] = [
-          { descriptor: "root", expectResults: [], children: [] },
-        ]
-
-        let finalEnvs = envs
-        let finalTestResults = testRunStack
-        const testPromises: Promise<void>[] = []
-
+  return () =>
+    (async () => {
+      try {
         const cage = await acquireCage()
 
-        // Wrap entire execution in try-catch to handle QuickJS GC errors that can occur at any point
-        try {
-          const captureHook: { capture?: () => void } = {}
+        const firstAttempt = await executeTestOnCage(
+          cage,
+          testScript,
+          envs,
+          request,
+          response,
+          hoppFetchHook
+        )
 
-          const result = await cage.runCode(testScript, [
-            ...defaultModules({
-              hoppFetchHook,
-            }),
-            postRequestModule(
-              {
-                envs: cloneDeep(envs),
-                testRunStack: cloneDeep(testRunStack),
-                request: cloneDeep(request),
-                response: cloneDeep(response),
-                // TODO: Post type update, accommodate for cookies although platform support is limited
-                cookies: null,
-                handleSandboxResults: ({ envs, testRunStack }) => {
-                  finalEnvs = envs
-                  finalTestResults = testRunStack
-                },
-                onTestPromise: (promise) => {
-                  testPromises.push(promise)
-                },
-              },
-              captureHook
-            ),
-          ])
-
-          // Check for script execution errors first
-          if (result.type === "error") {
-            // Just throw the error - it will be wrapped by the TaskEither error handler
-            throw result.err
-          }
-
-          // Execute tests sequentially to support dependent tests that share variables.
-          // Concurrent execution would cause race conditions when tests rely on values
-          // from earlier tests (e.g., authToken set in one test, used in another).
-          if (testPromises.length > 0) {
-            // Execute each test promise one at a time, waiting for completion
-            for (let i = 0; i < testPromises.length; i++) {
-              await testPromises[i]
-            }
-          }
-
-          // Capture results AFTER all async tests complete
-          // This prevents showing intermediate/failed state
-          if (captureHook.capture) {
-            captureHook.capture()
-          }
-
-          // Check for uncaught runtime errors (ReferenceError, TypeError, etc.) in test callbacks
-          // These should fail the entire test run, NOT be reported as testcases
-          // Validation errors (invalid assertion arguments) don't have "Error:" prefix - they're descriptive
-          // Examples: "Expected toHaveLength to be called for an array or string"
-          const runtimeErrors = finalTestResults
-            .flatMap((t) => t.children)
-            .flatMap((child) => child.expectResults || [])
-            .filter(
-              (r) =>
-                r.status === "error" &&
-                /^(ReferenceError|TypeError|SyntaxError|RangeError|URIError|EvalError|AggregateError|InternalError|Error):/.test(
-                  r.message
-                )
-            )
-
-          if (runtimeErrors.length > 0) {
-            // Throw the runtime error directly (message already contains error type)
-            throw runtimeErrors[0].message
-          }
-
-          // Deep clone results to break connection to QuickJS runtime objects,
-          // preventing GC errors when runtime is freed.
-          const safeTestResults = cloneDeep(finalTestResults)
-          const safeEnvs = cloneDeep(finalEnvs)
-
-          return {
-            tests: safeTestResults,
-            envs: safeEnvs,
-          }
-        } finally {
-          // Don't dispose cage here - returned objects may still be accessed.
-          // Rely on garbage collection for cleanup.
-        }
-      },
-      (error) => {
-        if (error !== null && typeof error === "object" && "message" in error) {
-          const reason = `${"name" in error ? error.name : ""}: ${error.message}`
-          return `Script execution failed: ${reason}`
+        if (firstAttempt !== "retry") {
+          return firstAttempt
         }
 
-        return `Script execution failed: ${String(error)}`
+        // Bootstrap error detected and cage was reset — retry once on a fresh cage
+        const freshCage = await acquireCage()
+        const retryResult = await executeTestOnCage(
+          freshCage,
+          testScript,
+          envs,
+          request,
+          response,
+          hoppFetchHook
+        )
+
+        if (retryResult === "retry") {
+          return E.left(
+            "Script execution failed: sandbox initialization error (persistent)"
+          )
+        }
+
+        return retryResult
+      } catch (error) {
+        const name =
+          error instanceof Error && error.name ? `${error.name}: ` : ""
+        const message = error instanceof Error ? error.message : String(error)
+        return E.left(`Script execution failed: ${name}${message}`)
       }
-    )
-  )
+    })()
 }

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -162,7 +162,9 @@ export type TestResult = {
 export type GlobalEnvItem = TestResult["envs"]["global"][number]
 export type SelectedEnvItem = TestResult["envs"]["selected"][number]
 
-export type SandboxTestResult = TestResult & { tests: TestDescriptor } & {
+export type SandboxTestResult = {
+  tests: TestDescriptor
+  envs: TestResult["envs"]
   consoleEntries?: ConsoleEntry[]
   updatedCookies: Cookie[] | null
 }

--- a/packages/hoppscotch-js-sandbox/src/utils/cage.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/cage.ts
@@ -1,26 +1,69 @@
 import { FaradayCage } from "faraday-cage"
 
-// Cached cage instance to avoid repeated WASM module allocations.
-let cachedCage: FaradayCage | null = null
+let cagePromise: Promise<FaradayCage> | null = null
 
-// Detect if running in a test environment
 const isTestEnvironment =
   typeof process !== "undefined" && process.env.VITEST === "true"
 
 /**
- * Returns a FaradayCage instance, creating and caching it on first access.
- * In test environments, always creates a fresh cage to avoid QuickJS GC corruption.
+ * Determines if an error indicates an infrastructure failure (not a user script error).
+ *
+ * FaradayCage/QuickJS errors arrive in two shapes:
+ *
+ * 1. **User script errors** — `cage.runCode()` returns `{ type: "error" }` where
+ *    `result.err` is a plain object from QuickJS `dump()` (NOT `instanceof Error`).
+ *
+ * 2. **Infrastructure errors** — Thrown by host-side module setup (e.g.
+ *    `QuickJSUnwrapError`, marshal failures, WASM init). These are real
+ *    `Error` instances.
+ *
+ * `instanceof Error` reliably discriminates between the two.
+ */
+export const isInfraError = (err: unknown): boolean => err instanceof Error
+
+export const resetCage = (): void => {
+  cagePromise = null
+}
+
+/**
+ * Returns a cached FaradayCage singleton (production) or a fresh instance (tests).
+ *
+ * In test environments, a fresh cage is created by default. Tests that need to
+ * exercise the singleton/retry path can override this via `_setCagePromiseForTesting()`.
  */
 export const acquireCage = async (): Promise<FaradayCage> => {
-  // In test environments, create a fresh cage to avoid GC corruption
   if (isTestEnvironment) {
+    if (cagePromise) {
+      return cagePromise.catch((err) => {
+        cagePromise = null
+        throw err
+      })
+    }
+
     return FaradayCage.create()
   }
 
-  // In production, cache the cage for performance
-  if (!cachedCage) {
-    cachedCage = await FaradayCage.create()
+  if (!cagePromise) {
+    cagePromise = FaradayCage.create().catch((err) => {
+      cagePromise = null
+      throw err
+    })
   }
 
-  return cachedCage
+  return cagePromise
+}
+
+/**
+ * Injects a cage promise into the singleton slot. Test-only — allows tests to
+ * exercise the singleton/retry path that is normally skipped in test environments.
+ */
+export const _setCagePromiseForTesting = (
+  promise: Promise<FaradayCage> | null
+): void => {
+  if (!isTestEnvironment) {
+    throw new Error(
+      "_setCagePromiseForTesting is test-only and cannot be used in non-test environments"
+    )
+  }
+  cagePromise = promise
 }

--- a/packages/hoppscotch-js-sandbox/src/web/pre-request/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/web/pre-request/index.ts
@@ -9,7 +9,7 @@ import {
 } from "~/types"
 
 import { defaultModules, preRequestModule } from "~/cage-modules"
-import { acquireCage } from "~/utils/cage"
+import { acquireCage, resetCage, isInfraError } from "~/utils/cage"
 
 import { Cookie, HoppRESTRequest } from "@hoppscotch/data"
 import Worker from "./worker?worker&inline"
@@ -35,6 +35,86 @@ const runPreRequestScriptWithWebWorker = (
   })
 }
 
+/**
+ * Runs a pre-request script on the given cage instance.
+ * Returns the result (`Either<string, SandboxPreRequestResult>`) or the string literal "retry"
+ * if a bootstrap error triggered a cage reset (caller should retry).
+ */
+const executePreRequestOnCage = async (
+  cage: Awaited<ReturnType<typeof acquireCage>>,
+  preRequestScript: string,
+  envs: TestResult["envs"],
+  request: HoppRESTRequest,
+  cookies: Cookie[] | null,
+  hoppFetchHook?: HoppFetchHook
+): Promise<E.Either<string, SandboxPreRequestResult> | "retry"> => {
+  const consoleEntries: ConsoleEntry[] = []
+  let finalEnvs = envs
+  let finalRequest = request
+  let finalCookies = cookies
+
+  const captureHook: { capture?: () => void; bootstrapError?: unknown } = {}
+
+  const result = await cage.runCode(preRequestScript, [
+    ...defaultModules({
+      handleConsoleEntry: (consoleEntry) => consoleEntries.push(consoleEntry),
+      hoppFetchHook,
+    }),
+
+    preRequestModule(
+      {
+        envs: cloneDeep(envs),
+        request: cloneDeep(request),
+        cookies: cookies ? cloneDeep(cookies) : null,
+        handleSandboxResults: ({ envs, request, cookies }) => {
+          finalEnvs = envs
+          finalRequest = request
+          finalCookies = cookies
+        },
+      },
+      captureHook
+    ),
+  ])
+
+  if (result.type === "error") {
+    const bootstrapFailed = captureHook.bootstrapError !== undefined
+    const errorToAnalyze = bootstrapFailed
+      ? captureHook.bootstrapError
+      : result.err
+
+    if (bootstrapFailed || isInfraError(errorToAnalyze)) {
+      resetCage()
+      return "retry"
+    }
+
+    if (
+      result.err !== null &&
+      typeof result.err === "object" &&
+      "message" in result.err
+    ) {
+      const name =
+        "name" in result.err && typeof result.err.name === "string"
+          ? result.err.name
+          : ""
+      const prefix = name ? `${name}: ` : ""
+      return E.left(`Script execution failed: ${prefix}${result.err.message}`)
+    }
+
+    return E.left(`Script execution failed: ${String(result.err)}`)
+  }
+
+  if (captureHook.capture) {
+    captureHook.capture()
+  }
+
+  return E.right({
+    updatedEnvs: finalEnvs,
+    consoleEntries,
+    updatedRequest: finalRequest,
+    updatedCookies: finalCookies,
+  } satisfies SandboxPreRequestResult)
+}
+
 const runPreRequestScriptWithFaradayCage = async (
   preRequestScript: string,
   envs: TestResult["envs"],
@@ -42,64 +122,45 @@ const runPreRequestScriptWithFaradayCage = async (
   cookies: Cookie[] | null,
   hoppFetchHook?: HoppFetchHook
 ): Promise<E.Either<string, SandboxPreRequestResult>> => {
-  const consoleEntries: ConsoleEntry[] = []
-  let finalEnvs = envs
-  let finalRequest = request
-  let finalCookies = cookies
-
-  const cage = await acquireCage()
-
   try {
-    // Create a hook object to receive the capture function from the module
-    const captureHook: { capture?: () => void } = {}
+    const cage = await acquireCage()
 
-    const result = await cage.runCode(preRequestScript, [
-      ...defaultModules({
-        handleConsoleEntry: (consoleEntry) => consoleEntries.push(consoleEntry),
-        hoppFetchHook,
-      }),
+    const firstAttempt = await executePreRequestOnCage(
+      cage,
+      preRequestScript,
+      envs,
+      request,
+      cookies,
+      hoppFetchHook
+    )
 
-      preRequestModule(
-        {
-          envs: cloneDeep(envs),
-          request: cloneDeep(request),
-          cookies: cookies ? cloneDeep(cookies) : null,
-          handleSandboxResults: ({ envs, request, cookies }) => {
-            finalEnvs = envs
-            finalRequest = request
-            finalCookies = cookies
-          },
-        },
-        captureHook
-      ),
-    ])
-
-    if (result.type === "error") {
-      if (
-        result.err !== null &&
-        typeof result.err === "object" &&
-        "message" in result.err
-      ) {
-        return E.left(`Script execution failed: ${result.err.message}`)
-      }
-
-      return E.left(`Script execution failed: ${String(result.err)}`)
+    if (firstAttempt !== "retry") {
+      return firstAttempt
     }
 
-    // Capture results only on successful execution
-    if (captureHook.capture) {
-      captureHook.capture()
+    // Bootstrap error detected and cage was reset — retry once on a fresh cage
+    const freshCage = await acquireCage()
+    const retryResult = await executePreRequestOnCage(
+      freshCage,
+      preRequestScript,
+      envs,
+      request,
+      cookies,
+      hoppFetchHook
+    )
+
+    if (retryResult === "retry") {
+      // Two consecutive bootstrap failures — don't loop, report the error
+      return E.left(
+        "Script execution failed: sandbox initialization error (persistent)"
+      )
     }
 
-    return E.right({
-      updatedEnvs: finalEnvs,
-      consoleEntries,
-      updatedRequest: finalRequest,
-      updatedCookies: finalCookies,
-    } satisfies SandboxPreRequestResult)
-  } finally {
-    // Don't dispose cage here - returned objects may still be accessed.
-    // Rely on garbage collection for cleanup.
+    return retryResult
+  } catch (error) {
+    const name = error instanceof Error && error.name ? `${error.name}: ` : ""
+    const message = error instanceof Error ? error.message : String(error)
+    return E.left(`Script execution failed: ${name}${message}`)
   }
 }
 

--- a/packages/hoppscotch-js-sandbox/src/web/pre-request/worker.ts
+++ b/packages/hoppscotch-js-sandbox/src/web/pre-request/worker.ts
@@ -21,7 +21,11 @@ const executeScriptInContext = (
       updatedCookies: null,
     })
   } catch (error) {
-    return TE.left(`Script execution failed: ${(error as Error).message}`)
+    return TE.left(
+      `Script execution failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
   }
 }
 

--- a/packages/hoppscotch-js-sandbox/src/web/test-runner/worker.ts
+++ b/packages/hoppscotch-js-sandbox/src/web/test-runner/worker.ts
@@ -26,12 +26,17 @@ const executeScriptInContext = (
     // Execute the script
     executeScript({ ...pw, response: responseObjHandle.right })
 
-    return TE.right(<SandboxTestResult>{
+    return TE.right({
       tests: testRunStack[0],
       envs: updatedEnvs,
-    })
+      updatedCookies: null,
+    } satisfies SandboxTestResult)
   } catch (error) {
-    return TE.left(`Script execution failed: ${(error as Error).message}`)
+    return TE.left(
+      `Script execution failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
   }
 }
 


### PR DESCRIPTION
Closes #5866, #5810, FE-1128.

Persistent errors in the experimental scripting sandbox cause two user-visible bugs: 
- After fixing a broken pre/post-request script, the old error continues to surface because the singleton `FaradayCage` retains a corrupted state across executions.
- Requests with empty scripts report `script_fail` when the cached cage carries a stale bootstrap failure. This PR detects bootstrap/internal failures, resets the cage when needed, retries transparently on a fresh cage, and short-circuits empty scripts to avoid entering the sandbox entirely.

### What's changed

- **Bootstrap error detection via `captureHook`:** Extended the `captureHook` type from `{ capture?: () => void }` to `{ capture?: () => void; bootstrapError?: unknown }` in `scripting-modules.ts`. When `ctx.vm.callFunction(bootstrapIIFE)` returns an error, it is dumped and recorded on `captureHook.bootstrapError`. Both `pre-request/index.ts` and `test-runner/index.ts` check this flag as the primary cage reset signal.

- **Heuristic fallback via `isInfraError()`:** Defense-in-depth error classifier in `cage.ts` that catches errors escaping _before_ `callFunction()` is reached — specifically from `evalCode(bootstrapCode).unwrap()`, `createScriptingInputsObj()`, and `defineSandboxObject()`. Uses `instanceof Error` as the sole discriminator: infrastructure errors (QuickJSUnwrapError from `.unwrap()`, marshal failures, WASM init) are real `Error` instances, while user script errors from QuickJS's `dump()` are plain objects with `{ name, message, stack }` but are NOT `instanceof Error`. This structural difference makes the check reliable with no false positives.

- **Retry-on-bootstrap-error:** When a bootstrap error is detected, the cage is reset and the script is retried once on a fresh cage within the same execution. This eliminates the regression where fixing a broken script still fails on the _next immediate_ run before succeeding on the one after. Extracted `executePreRequestOnCage()` and `executeTestOnCage()` helper functions that return `E.Either | "retry"`. The caller retries once; if the retry also fails with a bootstrap error, surfaces `"sandbox initialisation error (persistent)"`.

- **Cage reset on bootstrap errors:** The reset decision is inlined at each call site as `bootstrapFailed || isInfraError(err)`. When `bootstrapFailed` is `true`, it short-circuits without inspecting the error. Otherwise, `isInfraError()` checks the error structure. When a reset is needed, callers invoke `resetCage()` which nulls `cagePromise`. User script errors (e.g., `ReferenceError: a is not defined`) do **not** trigger resets, preserving the singleton optimization from #5800.

- **`cachedCage` → `cagePromise` caching:** The singleton now caches the creation _promise_ rather than the resolved instance, which is the correct pattern for async singleton initialization. This prevents duplicate `FaradayCage.create()` calls if `acquireCage()` is called while a previous creation is still in-flight (e.g., after a cage reset, or on first use when two tabs fire requests before the cage is ready). Includes `.catch()` to null the promise on creation failure so subsequent retries work.

- **Empty script short-circuit:** `RequestRunner.ts` returns immediately (with identity envs/cookies and empty test results) when `stripModulePrefix(script).trim().length === 0`, avoiding WASM initialisation and preventing stale cage errors from surfacing as `script_fail` (#5810).

- **Structured console logging:** `RequestRunner.ts` error paths now use prefixed `console.error` (`[Pre-Request Script Error]`, `[Post-Request Script Error]`, `[Request Error]`) for dev-console visibility when debugging sandbox failures.

- **`SandboxTestResult` type:** Simplified from `TestResult & { tests: TestDescriptor } & { consoleEntries?; updatedCookies }` to a standalone type (`{ tests: TestDescriptor; envs: TestResult["envs"]; consoleEntries?: ConsoleEntry[]; updatedCookies: Cookie[] | null }`). The old intersection produced a contradictory `tests: TestDescriptor[] & TestDescriptor` — TypeScript allowed it structurally but every construction site always assigned a single `TestDescriptor`. The new type correctly reflects actual usage. Construction sites use `satisfies SandboxTestResult` for compile-time validation.

- **TaskEither contract compliance:** Both node experimental runners (`pre-request/experimental.ts`, `test-runner/experimental.ts`) now wrap the entire async body in `try/catch`, ensuring the returned `TaskEither` never rejects. The refactor replaces `pipe(TE.tryCatch(...))` with explicit `E.left`/`E.right` returns and a manual `try/catch`, preserving identical behavior while enabling the retry-on-bootstrap-error pattern. The inner helper functions format QuickJS error objects with the error `name` when available (e.g., `TypeError: cannot read property...`); the outer catch handles unexpected infrastructure throws. Web implementations (`web/pre-request/index.ts`, `web/test-runner/index.ts`) follow the same try-catch pattern for consistency.

- **Worker error handling:** Web worker catch blocks (`pre-request/worker.ts`, `test-runner/worker.ts`) now handle non-Error throws safely via `error instanceof Error ? error.message : String(error)` instead of the previous unsafe `(error as Error).message` cast. Web test-runner worker includes `updatedCookies: null` in the `SandboxTestResult` and uses `satisfies` for compile-time validation.


### Notes to reviewers

Try the reproduction steps mentioned in #5866 and similar patterns. Also, ensure to perform benchmarks to validate the previous performance optimisation strategies hold.

**Relationship to #5800:** This PR directly extends the singleton cage introduced in the memory leak fix (#5800). The key invariant preserved here: user script errors must _never_ trigger a cage reset — only bootstrap/internal failures (corrupted QuickJS context, WASM init failure, module setup errors) cause a reset. The singleton is preserved for all normal operations.

**Two-layer detection is intentional, not redundant.** `captureHook.bootstrapError` covers errors from `ctx.vm.callFunction(funcHandle)` in `scripting-modules.ts` (L476). `isInfraError()` covers errors that escape _before_ `callFunction()` — specifically `evalCode(bootstrapCode).unwrap()` (L417), `createScriptingInputsObj()` (L423), and `defineSandboxObject()` (L474). These throw during `FaradayCage.runCode()`'s module `def()` phase and propagate as `{ type: "error", err }` without ever setting `captureHook.bootstrapError`. An audit of the full error flow confirmed `isInfraError()` is reachable, not dead code.

**`instanceof Error` as the discriminator in `isInfraError()`.** This is intentional, not overbroad. In the FaradayCage/QuickJS pipeline, user script errors are always plain objects (from QuickJS's `dump()`), while infrastructure errors are always `Error` instances (QuickJSUnwrapError from `.unwrap()`, marshal failures, etc.). The two shapes never overlap. The primary caller path only sends `result.err` (plain objects) through `isInfraError()` when `captureHook.bootstrapError` is not set — the `instanceof Error` branch is a safety net for edge-case infrastructure throws.

**Test coverage:**

- `cage.spec.ts` — 5 unit tests for `isInfraError()` covering `instanceof Error` discrimination, QuickJSUnwrapError subclass detection, plain-object user error exclusions, and edge cases (null, string errors)
- `script-error-recovery.spec.ts` — 5 integration tests: 3 running real scripts through the full `FaradayCage` pipeline verifying error → recovery (matching the exact reproduction steps from #5866), plus 2 singleton retry tests that inject a corrupted cage via `_setCagePromiseForTesting()` and verify (a) bootstrap errors trigger transparent retry on a fresh cage, and (b) user script errors do not trigger the retry path
- All assertions validate actual function return values or real cage execution results — no mocked units-under-test or trivially-true checks
- `request.spec.ts` — 3 test expectations updated to include the `TypeError:` prefix in error messages, matching the new error name formatting in the script runners