### PR TITLE
Add test coverage and URI utilities for hoppscotch-data package

### DIFF
--- a/packages/hoppscotch-data/package.json
+++ b/packages/hoppscotch-data/package.json
@@ -15,7 +15,8 @@
     "build:decl": "tsc --project tsconfig.decl.json",
     "build": "pnpm run build:code && pnpm run build:decl",
     "prepare": "pnpm run build:code && pnpm run build:decl",
-    "do-typecheck": "pnpm exec tsc --noEmit"
+    "do-typecheck": "pnpm exec tsc --noEmit",
+    "test": "vitest run"
   },
   "exports": {
     ".": {
@@ -37,7 +38,8 @@
   "devDependencies": {
     "@types/lodash": "4.17.23",
     "typescript": "5.9.3",
-    "vite": "7.3.1"
+    "vite": "7.3.1",
+    "vitest": "latest"
   },
   "dependencies": {
     "fp-ts": "2.16.11",

--- a/packages/hoppscotch-data/src/environment/__tests__/environment.spec.ts
+++ b/packages/hoppscotch-data/src/environment/__tests__/environment.spec.ts
@@ -1,0 +1,280 @@
+import { describe, expect, test } from "vitest"
+import * as E from "fp-ts/Either"
+import {
+  parseBodyEnvVariablesE,
+  parseBodyEnvVariables,
+  parseTemplateStringE,
+  parseTemplateString,
+  translateToNewEnvironmentVariables,
+  translateToNewEnvironment,
+  EnvironmentSchemaVersion,
+} from "../index"
+
+const makeVar = (
+  key: string,
+  currentValue: string,
+  secret = false
+): {
+  key: string
+  initialValue: string
+  currentValue: string
+  secret: boolean
+} => ({
+  key,
+  initialValue: currentValue,
+  currentValue,
+  secret,
+})
+
+describe("Environment utilities", () => {
+  describe("parseBodyEnvVariablesE", () => {
+    test("replaces a single variable", () => {
+      const vars = [makeVar("host", "example.com")]
+      const result = parseBodyEnvVariablesE("https://<<host>>/api", vars)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("https://example.com/api")
+      }
+    })
+
+    test("replaces multiple variables", () => {
+      const vars = [makeVar("host", "example.com"), makeVar("port", "8080")]
+      const result = parseBodyEnvVariablesE("<<host>>:<<port>>", vars)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("example.com:8080")
+      }
+    })
+
+    test("handles recursive variable expansion", () => {
+      const vars = [
+        makeVar("baseUrl", "<<host>>/api"),
+        makeVar("host", "example.com"),
+      ]
+      const result = parseBodyEnvVariablesE("<<baseUrl>>/v1", vars)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("example.com/api/v1")
+      }
+    })
+
+    test("returns Left for infinite recursive loops", () => {
+      const vars = [makeVar("a", "<<b>>"), makeVar("b", "<<a>>")]
+      const result = parseBodyEnvVariablesE("<<a>>", vars)
+      expect(E.isLeft(result)).toBe(true)
+    })
+
+    test("leaves unmatched variables as-is but detects as loop when they persist", () => {
+      // When a variable like <<missing>> is never resolved, it stays in the string
+      // and the regex keeps matching, eventually hitting the expansion limit
+      const vars = [makeVar("host", "example.com")]
+      const result = parseBodyEnvVariablesE("<<host>>-<<missing>>", vars)
+      // The unresolved <<missing>> causes the loop detector to trigger
+      expect(E.isLeft(result)).toBe(true)
+    })
+
+    test("handles empty body string", () => {
+      const result = parseBodyEnvVariablesE("", [makeVar("x", "y")])
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("")
+      }
+    })
+
+    test("handles body with no variables", () => {
+      const result = parseBodyEnvVariablesE("plain text", [
+        makeVar("x", "y"),
+      ])
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("plain text")
+      }
+    })
+  })
+
+  describe("parseBodyEnvVariables (deprecated)", () => {
+    test("returns expanded string on success", () => {
+      const vars = [makeVar("name", "world")]
+      expect(parseBodyEnvVariables("hello <<name>>", vars)).toBe(
+        "hello world"
+      )
+    })
+
+    test("returns original body on loop detection", () => {
+      const vars = [makeVar("a", "<<b>>"), makeVar("b", "<<a>>")]
+      // Falls back to original body on error
+      expect(parseBodyEnvVariables("<<a>>", vars)).toBe("<<a>>")
+    })
+  })
+
+  describe("parseTemplateStringE", () => {
+    test("replaces variables in template string", () => {
+      const vars = [makeVar("token", "abc123")]
+      const result = parseTemplateStringE("Bearer <<token>>", vars)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("Bearer abc123")
+      }
+    })
+
+    test("returns empty string for unmatched variables", () => {
+      const vars = [makeVar("other", "val")]
+      const result = parseTemplateStringE("<<missing>>", vars)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("")
+      }
+    })
+
+    test("handles null/empty variables array gracefully", () => {
+      const result = parseTemplateStringE("test <<var>>", [])
+      expect(E.isRight(result)).toBe(true)
+    })
+
+    test("handles null str gracefully", () => {
+      const result = parseTemplateStringE("", [makeVar("x", "y")])
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("")
+      }
+    })
+
+    test("masks secret variable values when maskValue is true", () => {
+      const vars = [makeVar("secret_key", "mysecret", true)]
+      const result = parseTemplateStringE("key=<<secret_key>>", vars, true)
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("key=********")
+        expect(result.right).not.toContain("mysecret")
+      }
+    })
+
+    test("shows key placeholder for secret when showKeyIfSecret is true", () => {
+      const vars = [makeVar("api_key", "hidden_val", true)]
+      const result = parseTemplateStringE(
+        "<<api_key>>",
+        vars,
+        false,
+        true
+      )
+      expect(E.isRight(result)).toBe(true)
+      if (E.isRight(result)) {
+        expect(result.right).toBe("<<api_key>>")
+      }
+    })
+
+    test("detects infinite expansion loops", () => {
+      const vars = [makeVar("x", "<<y>>"), makeVar("y", "<<x>>")]
+      const result = parseTemplateStringE("<<x>>", vars)
+      expect(E.isLeft(result)).toBe(true)
+    })
+  })
+
+  describe("parseTemplateString (deprecated)", () => {
+    test("returns expanded string", () => {
+      const vars = [makeVar("greeting", "Hello")]
+      expect(parseTemplateString("<<greeting>> World", vars)).toBe(
+        "Hello World"
+      )
+    })
+  })
+
+  describe("translateToNewEnvironmentVariables", () => {
+    test("translates a variable with currentValue and initialValue", () => {
+      const result = translateToNewEnvironmentVariables({
+        key: "host",
+        initialValue: "init",
+        currentValue: "current",
+      })
+      expect(result).toEqual({
+        key: "host",
+        initialValue: "init",
+        currentValue: "current",
+        secret: false,
+      })
+    })
+
+    test("falls back to value field for legacy format", () => {
+      const result = translateToNewEnvironmentVariables({
+        key: "host",
+        value: "legacy",
+      })
+      expect(result).toEqual({
+        key: "host",
+        initialValue: "legacy",
+        currentValue: "legacy",
+        secret: false,
+      })
+    })
+
+    test("falls back to empty string when no value fields exist", () => {
+      const result = translateToNewEnvironmentVariables({ key: "empty" })
+      expect(result).toEqual({
+        key: "empty",
+        initialValue: "",
+        currentValue: "",
+        secret: false,
+      })
+    })
+
+    test("preserves secret flag when present", () => {
+      const result = translateToNewEnvironmentVariables({
+        key: "token",
+        initialValue: "init",
+        currentValue: "curr",
+        secret: true,
+      })
+      expect(result.secret).toBe(true)
+    })
+  })
+
+  describe("translateToNewEnvironment", () => {
+    test("returns environment as-is if already at current schema version", () => {
+      const env = {
+        v: EnvironmentSchemaVersion,
+        id: "test-id",
+        name: "Test",
+        variables: [],
+      }
+      expect(translateToNewEnvironment(env)).toBe(env)
+    })
+
+    test("migrates legacy environment without version", () => {
+      const legacy = {
+        name: "Legacy",
+        variables: [{ key: "host", value: "example.com" }],
+      }
+      const result = translateToNewEnvironment(legacy)
+      expect(result.v).toBe(EnvironmentSchemaVersion)
+      expect(result.name).toBe("Legacy")
+      expect(result.variables).toEqual([
+        {
+          key: "host",
+          initialValue: "example.com",
+          currentValue: "example.com",
+          secret: false,
+        },
+      ])
+      expect(result.id).toBeTruthy()
+    })
+
+    test("handles missing name with default", () => {
+      const result = translateToNewEnvironment({ variables: [] })
+      expect(result.name).toBe("Untitled")
+    })
+
+    test("handles missing variables with empty array", () => {
+      const result = translateToNewEnvironment({ name: "Empty" })
+      expect(result.variables).toEqual([])
+    })
+
+    test("preserves existing id", () => {
+      const result = translateToNewEnvironment({
+        id: "my-id",
+        name: "Test",
+        variables: [],
+      })
+      expect(result.id).toBe("my-id")
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/rest/__tests__/content-types.spec.ts
+++ b/packages/hoppscotch-data/src/rest/__tests__/content-types.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest"
+import {
+  knownContentTypes,
+  ValidContentTypesList,
+} from "../content-types"
+
+describe("content-types", () => {
+  describe("knownContentTypes", () => {
+    test("maps JSON content types to 'json'", () => {
+      expect(knownContentTypes["application/json"]).toBe("json")
+      expect(knownContentTypes["application/ld+json"]).toBe("json")
+      expect(knownContentTypes["application/hal+json"]).toBe("json")
+      expect(knownContentTypes["application/vnd.api+json"]).toBe("json")
+    })
+
+    test("maps XML content types to 'xml'", () => {
+      expect(knownContentTypes["application/xml"]).toBe("xml")
+      expect(knownContentTypes["text/xml"]).toBe("xml")
+    })
+
+    test("maps form content types to 'multipart'", () => {
+      expect(knownContentTypes["application/x-www-form-urlencoded"]).toBe(
+        "multipart"
+      )
+      expect(knownContentTypes["multipart/form-data"]).toBe("multipart")
+    })
+
+    test("maps binary content type correctly", () => {
+      expect(knownContentTypes["application/octet-stream"]).toBe("binary")
+    })
+
+    test("maps text content types correctly", () => {
+      expect(knownContentTypes["text/html"]).toBe("html")
+      expect(knownContentTypes["text/plain"]).toBe("plain")
+    })
+  })
+
+  describe("ValidContentTypesList", () => {
+    test("contains all known content type keys", () => {
+      const expectedKeys = Object.keys(knownContentTypes)
+      expect(ValidContentTypesList).toEqual(expectedKeys)
+    })
+
+    test("has the correct number of entries", () => {
+      expect(ValidContentTypesList.length).toBe(
+        Object.keys(knownContentTypes).length
+      )
+    })
+
+    test("each entry is a valid content type string", () => {
+      for (const ct of ValidContentTypesList) {
+        expect(ct).toMatch(/^(application|text|multipart)\//)
+      }
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/__tests__/collection.spec.ts
+++ b/packages/hoppscotch-data/src/utils/__tests__/collection.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest"
+import { generateUniqueRefId } from "../collection"
+
+describe("collection utilities", () => {
+  describe("generateUniqueRefId", () => {
+    test("generates a non-empty string", () => {
+      const id = generateUniqueRefId()
+      expect(id).toBeTruthy()
+      expect(typeof id).toBe("string")
+    })
+
+    test("generates unique IDs on successive calls", () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateUniqueRefId()))
+      expect(ids.size).toBe(100)
+    })
+
+    test("includes the provided prefix", () => {
+      const id = generateUniqueRefId("test")
+      expect(id.startsWith("test_")).toBe(true)
+    })
+
+    test("uses empty prefix by default", () => {
+      const id = generateUniqueRefId()
+      expect(id.startsWith("_")).toBe(true)
+    })
+
+    test("includes a timestamp component (base36)", () => {
+      const id = generateUniqueRefId("pfx")
+      const parts = id.split("_")
+      // parts[0] = prefix, parts[1] = timestamp (base36), rest = uuid parts
+      expect(parts.length).toBeGreaterThanOrEqual(3)
+      // timestamp part should be parseable as base36
+      const timestampPart = parts[1]
+      expect(Number.isNaN(parseInt(timestampPart, 36))).toBe(false)
+    })
+
+    test("contains a UUID-like component with hyphens", () => {
+      const id = generateUniqueRefId("pfx")
+      // UUID v4 has format xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      // After the prefix and timestamp, we should have UUID parts
+      const uuidPart = id.substring(id.indexOf("_", id.indexOf("_") + 1) + 1)
+      expect(uuidPart).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/__tests__/eq.spec.ts
+++ b/packages/hoppscotch-data/src/utils/__tests__/eq.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vitest"
+import {
+  undefinedEq,
+  mapThenEq,
+  stringCaseInsensitiveEq,
+  lodashIsEqualEq,
+} from "../eq"
+import * as S from "fp-ts/string"
+import * as N from "fp-ts/number"
+
+describe("Eq utilities", () => {
+  describe("undefinedEq", () => {
+    const numEq = undefinedEq(N.Eq)
+
+    test("returns true when both values are equal and defined", () => {
+      expect(numEq.equals(42, 42)).toBe(true)
+    })
+
+    test("returns false when values differ", () => {
+      expect(numEq.equals(1, 2)).toBe(false)
+    })
+
+    test("returns true when both values are undefined", () => {
+      expect(numEq.equals(undefined, undefined)).toBe(true)
+    })
+
+    test("returns false when only first value is undefined", () => {
+      expect(numEq.equals(undefined, 5)).toBe(false)
+    })
+
+    test("returns false when only second value is undefined", () => {
+      expect(numEq.equals(5, undefined)).toBe(false)
+    })
+
+    test("works with string Eq", () => {
+      const strEq = undefinedEq(S.Eq)
+      expect(strEq.equals("hello", "hello")).toBe(true)
+      expect(strEq.equals("hello", "world")).toBe(false)
+      expect(strEq.equals(undefined, undefined)).toBe(true)
+      expect(strEq.equals("hello", undefined)).toBe(false)
+    })
+  })
+
+  describe("mapThenEq", () => {
+    test("compares values after mapping with a transform function", () => {
+      const lengthEq = mapThenEq((s: string) => s.length, N.Eq)
+      expect(lengthEq.equals("abc", "xyz")).toBe(true)
+      expect(lengthEq.equals("ab", "xyz")).toBe(false)
+    })
+
+    test("works with numeric transformations", () => {
+      const absEq = mapThenEq(Math.abs, N.Eq)
+      expect(absEq.equals(-5, 5)).toBe(true)
+      expect(absEq.equals(-5, -5)).toBe(true)
+      expect(absEq.equals(-5, 6)).toBe(false)
+    })
+
+    test("works with object property extraction", () => {
+      interface Named {
+        name: string
+      }
+      const nameEq = mapThenEq((x: Named) => x.name, S.Eq)
+      expect(nameEq.equals({ name: "Alice" }, { name: "Alice" })).toBe(true)
+      expect(nameEq.equals({ name: "Alice" }, { name: "Bob" })).toBe(false)
+    })
+  })
+
+  describe("stringCaseInsensitiveEq", () => {
+    test("treats same-case strings as equal", () => {
+      expect(stringCaseInsensitiveEq.equals("hello", "hello")).toBe(true)
+    })
+
+    test("treats different-case strings as equal", () => {
+      expect(stringCaseInsensitiveEq.equals("Hello", "hello")).toBe(true)
+      expect(stringCaseInsensitiveEq.equals("HELLO", "hello")).toBe(true)
+      expect(stringCaseInsensitiveEq.equals("HeLLo", "hEllO")).toBe(true)
+    })
+
+    test("returns false for different strings", () => {
+      expect(stringCaseInsensitiveEq.equals("hello", "world")).toBe(false)
+    })
+
+    test("handles empty strings", () => {
+      expect(stringCaseInsensitiveEq.equals("", "")).toBe(true)
+      expect(stringCaseInsensitiveEq.equals("", "a")).toBe(false)
+    })
+  })
+
+  describe("lodashIsEqualEq", () => {
+    test("compares primitive values", () => {
+      expect(lodashIsEqualEq.equals(1, 1)).toBe(true)
+      expect(lodashIsEqualEq.equals(1, 2)).toBe(false)
+      expect(lodashIsEqualEq.equals("a", "a")).toBe(true)
+    })
+
+    test("performs deep equality on objects", () => {
+      expect(lodashIsEqualEq.equals({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(
+        true
+      )
+      expect(lodashIsEqualEq.equals({ a: 1 }, { a: 2 })).toBe(false)
+    })
+
+    test("performs deep equality on nested objects", () => {
+      const obj1 = { a: { b: { c: [1, 2, 3] } } }
+      const obj2 = { a: { b: { c: [1, 2, 3] } } }
+      const obj3 = { a: { b: { c: [1, 2, 4] } } }
+      expect(lodashIsEqualEq.equals(obj1, obj2)).toBe(true)
+      expect(lodashIsEqualEq.equals(obj1, obj3)).toBe(false)
+    })
+
+    test("performs deep equality on arrays", () => {
+      expect(lodashIsEqualEq.equals([1, 2, 3], [1, 2, 3])).toBe(true)
+      expect(lodashIsEqualEq.equals([1, 2], [1, 2, 3])).toBe(false)
+    })
+
+    test("handles null and undefined", () => {
+      expect(lodashIsEqualEq.equals(null, null)).toBe(true)
+      expect(lodashIsEqualEq.equals(undefined, undefined)).toBe(true)
+      expect(lodashIsEqualEq.equals(null, undefined)).toBe(false)
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/__tests__/record.spec.ts
+++ b/packages/hoppscotch-data/src/utils/__tests__/record.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest"
+import { recordUpdate } from "../record"
+
+describe("record utilities", () => {
+  describe("recordUpdate", () => {
+    test("updates a single field using a mapping function", () => {
+      const obj = { name: "Alice", age: 30 }
+      const updater = recordUpdate(
+        "age" as const,
+        (x: number) => x + 1
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ name: "Alice", age: 31 })
+    })
+
+    test("preserves other fields unchanged", () => {
+      const obj = { a: 1, b: 2, c: 3 }
+      const updater = recordUpdate(
+        "b" as const,
+        (x: number) => x * 10
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ a: 1, b: 20, c: 3 })
+    })
+
+    test("can change the type of the updated field", () => {
+      const obj = { name: "Alice", age: 30 }
+      const updater = recordUpdate(
+        "age" as const,
+        (x: number) => String(x)
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ name: "Alice", age: "30" })
+      expect(typeof result.age).toBe("string")
+    })
+
+    test("works with string transformations", () => {
+      const obj = { greeting: "hello", count: 5 }
+      const updater = recordUpdate(
+        "greeting" as const,
+        (s: string) => s.toUpperCase()
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ greeting: "HELLO", count: 5 })
+    })
+
+    test("works with array fields", () => {
+      const obj = { items: [1, 2, 3], label: "test" }
+      const updater = recordUpdate(
+        "items" as const,
+        (arr: number[]) => [...arr, 4]
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ items: [1, 2, 3, 4], label: "test" })
+    })
+
+    test("does not mutate the original object", () => {
+      const obj = { x: 1, y: 2 }
+      const updater = recordUpdate(
+        "x" as const,
+        (n: number) => n + 10
+      )
+      const result = updater(obj)
+      expect(obj).toEqual({ x: 1, y: 2 })
+      expect(result).toEqual({ x: 11, y: 2 })
+    })
+
+    test("works with nested object fields", () => {
+      const obj = { meta: { version: 1 }, data: "test" }
+      const updater = recordUpdate(
+        "meta" as const,
+        (m: { version: number }) => ({ ...m, version: m.version + 1 })
+      )
+      const result = updater(obj)
+      expect(result).toEqual({ meta: { version: 2 }, data: "test" })
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/__tests__/statusCodes.spec.ts
+++ b/packages/hoppscotch-data/src/utils/__tests__/statusCodes.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest"
+import { StatusCodes, getStatusCodeReasonPhrase } from "../statusCodes"
+
+describe("StatusCodes", () => {
+  describe("StatusCodes map", () => {
+    test("contains all standard 1xx informational codes", () => {
+      expect(StatusCodes[100]).toBe("Continue")
+      expect(StatusCodes[101]).toBe("Switching Protocols")
+      expect(StatusCodes[102]).toBe("Processing")
+    })
+
+    test("contains all standard 2xx success codes", () => {
+      expect(StatusCodes[200]).toBe("OK")
+      expect(StatusCodes[201]).toBe("Created")
+      expect(StatusCodes[202]).toBe("Accepted")
+      expect(StatusCodes[204]).toBe("No Content")
+      expect(StatusCodes[206]).toBe("Partial Content")
+    })
+
+    test("contains all standard 3xx redirection codes", () => {
+      expect(StatusCodes[301]).toBe("Moved Permanently")
+      expect(StatusCodes[302]).toBe("Found")
+      expect(StatusCodes[304]).toBe("Not Modified")
+      expect(StatusCodes[307]).toBe("Temporary Redirect")
+      expect(StatusCodes[308]).toBe("Permanent Redirect")
+    })
+
+    test("contains all standard 4xx client error codes", () => {
+      expect(StatusCodes[400]).toBe("Bad Request")
+      expect(StatusCodes[401]).toBe("Unauthorized")
+      expect(StatusCodes[403]).toBe("Forbidden")
+      expect(StatusCodes[404]).toBe("Not Found")
+      expect(StatusCodes[405]).toBe("Method Not Allowed")
+      expect(StatusCodes[408]).toBe("Request Timeout")
+      expect(StatusCodes[409]).toBe("Conflict")
+      expect(StatusCodes[429]).toBe("Too Many Requests")
+    })
+
+    test("contains all standard 5xx server error codes", () => {
+      expect(StatusCodes[500]).toBe("Internal Server Error")
+      expect(StatusCodes[501]).toBe("Not Implemented")
+      expect(StatusCodes[502]).toBe("Bad Gateway")
+      expect(StatusCodes[503]).toBe("Service Unavailable")
+      expect(StatusCodes[504]).toBe("Gateway Timeout")
+    })
+
+    test("contains novelty and extended codes", () => {
+      expect(StatusCodes[418]).toBe("I'm a teapot")
+      expect(StatusCodes[451]).toBe("Unavailable For Legal Reasons")
+    })
+
+    test("returns undefined for non-existent codes", () => {
+      expect(StatusCodes[999]).toBeUndefined()
+      expect(StatusCodes[0]).toBeUndefined()
+    })
+  })
+
+  describe("getStatusCodeReasonPhrase", () => {
+    test("returns known status text for standard codes", () => {
+      expect(getStatusCodeReasonPhrase(200)).toBe("OK")
+      expect(getStatusCodeReasonPhrase(404)).toBe("Not Found")
+      expect(getStatusCodeReasonPhrase(500)).toBe("Internal Server Error")
+    })
+
+    test("returns 'Unknown' for unrecognized status codes", () => {
+      expect(getStatusCodeReasonPhrase(999)).toBe("Unknown")
+      expect(getStatusCodeReasonPhrase(0)).toBe("Unknown")
+      expect(getStatusCodeReasonPhrase(-1)).toBe("Unknown")
+    })
+
+    test("prefers provided statusText over known codes", () => {
+      expect(getStatusCodeReasonPhrase(200, "Custom OK")).toBe("Custom OK")
+      expect(getStatusCodeReasonPhrase(404, "My Not Found")).toBe(
+        "My Not Found"
+      )
+    })
+
+    test("truncates long statusText with ellipsis at 35 characters", () => {
+      const longText = "A".repeat(50)
+      const result = getStatusCodeReasonPhrase(200, longText)
+      expect(result).toBe("A".repeat(35) + "...")
+      expect(result.length).toBe(38) // 35 + "..."
+    })
+
+    test("does not truncate statusText at exactly 35 characters", () => {
+      const exactText = "A".repeat(35)
+      expect(getStatusCodeReasonPhrase(200, exactText)).toBe(exactText)
+    })
+
+    test("ignores empty statusText and falls back to known codes", () => {
+      expect(getStatusCodeReasonPhrase(200, "")).toBe("OK")
+      expect(getStatusCodeReasonPhrase(200, "   ")).toBe("OK")
+    })
+
+    test("ignores undefined statusText and falls back to known codes", () => {
+      expect(getStatusCodeReasonPhrase(200, undefined)).toBe("OK")
+    })
+
+    test("trims whitespace from statusText before checking", () => {
+      expect(getStatusCodeReasonPhrase(200, "  Custom  ")).toBe("Custom")
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/__tests__/uri.spec.ts
+++ b/packages/hoppscotch-data/src/utils/__tests__/uri.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "vitest"
+import {
+  safeParseURL,
+  isValidURL,
+  extractQueryParams,
+  buildURLWithParams,
+  joinURLPath,
+} from "../uri"
+
+describe("URI utilities", () => {
+  describe("safeParseURL", () => {
+    test("parses a fully qualified URL", () => {
+      const result = safeParseURL("https://api.example.com:8080/v1/users?page=1#top")
+      expect(result).not.toBeNull()
+      expect(result!.protocol).toBe("https:")
+      expect(result!.hostname).toBe("api.example.com")
+      expect(result!.port).toBe("8080")
+      expect(result!.pathname).toBe("/v1/users")
+      expect(result!.search).toBe("?page=1")
+      expect(result!.hash).toBe("#top")
+    })
+
+    test("prepends default protocol when missing", () => {
+      const result = safeParseURL("example.com/api")
+      expect(result).not.toBeNull()
+      expect(result!.protocol).toBe("https:")
+      expect(result!.hostname).toBe("example.com")
+      expect(result!.pathname).toBe("/api")
+    })
+
+    test("uses custom default protocol", () => {
+      const result = safeParseURL("example.com/api", "http://")
+      expect(result).not.toBeNull()
+      expect(result!.protocol).toBe("http:")
+    })
+
+    test("returns null for empty string", () => {
+      expect(safeParseURL("")).toBeNull()
+    })
+
+    test("returns null for whitespace-only string", () => {
+      expect(safeParseURL("   ")).toBeNull()
+    })
+
+    test("returns null for null-ish values", () => {
+      expect(safeParseURL(null as any)).toBeNull()
+      expect(safeParseURL(undefined as any)).toBeNull()
+    })
+
+    test("returns null for completely invalid URL", () => {
+      expect(safeParseURL("://")).toBeNull()
+    })
+
+    test("handles localhost URLs", () => {
+      const result = safeParseURL("http://localhost:3000/api")
+      expect(result).not.toBeNull()
+      expect(result!.hostname).toBe("localhost")
+      expect(result!.port).toBe("3000")
+    })
+
+    test("handles IP address URLs", () => {
+      const result = safeParseURL("http://192.168.1.1:9090/health")
+      expect(result).not.toBeNull()
+      expect(result!.hostname).toBe("192.168.1.1")
+    })
+
+    test("trims whitespace from input", () => {
+      const result = safeParseURL("  https://example.com  ")
+      expect(result).not.toBeNull()
+      expect(result!.hostname).toBe("example.com")
+    })
+  })
+
+  describe("isValidURL", () => {
+    test("returns true for valid HTTP URL", () => {
+      expect(isValidURL("https://example.com")).toBe(true)
+      expect(isValidURL("http://localhost:3000")).toBe(true)
+    })
+
+    test("returns true for other valid schemes", () => {
+      expect(isValidURL("ftp://files.example.com")).toBe(true)
+    })
+
+    test("returns false for strings without protocol", () => {
+      expect(isValidURL("example.com")).toBe(false)
+    })
+
+    test("returns false for empty string", () => {
+      expect(isValidURL("")).toBe(false)
+    })
+
+    test("returns false for random text", () => {
+      expect(isValidURL("not a url at all")).toBe(false)
+    })
+  })
+
+  describe("extractQueryParams", () => {
+    test("extracts single query parameter", () => {
+      const params = extractQueryParams("https://example.com?key=value")
+      expect(params).toEqual([{ key: "key", value: "value" }])
+    })
+
+    test("extracts multiple query parameters", () => {
+      const params = extractQueryParams(
+        "https://example.com?a=1&b=2&c=3"
+      )
+      expect(params).toEqual([
+        { key: "a", value: "1" },
+        { key: "b", value: "2" },
+        { key: "c", value: "3" },
+      ])
+    })
+
+    test("handles URL-encoded values", () => {
+      const params = extractQueryParams(
+        "https://example.com?q=hello%20world&tag=a%26b"
+      )
+      expect(params).toEqual([
+        { key: "q", value: "hello world" },
+        { key: "tag", value: "a&b" },
+      ])
+    })
+
+    test("returns empty array for URL without query params", () => {
+      expect(extractQueryParams("https://example.com/path")).toEqual([])
+    })
+
+    test("returns empty array for invalid URL", () => {
+      expect(extractQueryParams("not-a-url")).toEqual([])
+    })
+
+    test("handles duplicate keys", () => {
+      const params = extractQueryParams(
+        "https://example.com?a=1&a=2"
+      )
+      expect(params).toEqual([
+        { key: "a", value: "1" },
+        { key: "a", value: "2" },
+      ])
+    })
+
+    test("handles empty value", () => {
+      const params = extractQueryParams("https://example.com?key=")
+      expect(params).toEqual([{ key: "key", value: "" }])
+    })
+  })
+
+  describe("buildURLWithParams", () => {
+    test("appends parameters to a URL", () => {
+      const result = buildURLWithParams("https://example.com/api", [
+        { key: "page", value: "1" },
+        { key: "limit", value: "10" },
+      ])
+      expect(result).toContain("page=1")
+      expect(result).toContain("limit=10")
+    })
+
+    test("preserves existing query parameters", () => {
+      const result = buildURLWithParams("https://example.com?existing=true", [
+        { key: "new", value: "param" },
+      ])
+      expect(result).toContain("existing=true")
+      expect(result).toContain("new=param")
+    })
+
+    test("skips inactive parameters", () => {
+      const result = buildURLWithParams("https://example.com", [
+        { key: "active", value: "yes", active: true },
+        { key: "inactive", value: "no", active: false },
+      ])
+      expect(result).toContain("active=yes")
+      expect(result).not.toContain("inactive")
+    })
+
+    test("skips parameters with empty keys", () => {
+      const result = buildURLWithParams("https://example.com", [
+        { key: "", value: "orphan" },
+        { key: "valid", value: "param" },
+      ])
+      expect(result).toContain("valid=param")
+      expect(result).not.toContain("orphan")
+    })
+
+    test("returns original URL on parse failure", () => {
+      const result = buildURLWithParams("not-a-url", [
+        { key: "a", value: "1" },
+      ])
+      expect(result).toBe("not-a-url")
+    })
+  })
+
+  describe("joinURLPath", () => {
+    test("joins base and path with proper slashes", () => {
+      expect(joinURLPath("https://api.example.com", "v1/users")).toBe(
+        "https://api.example.com/v1/users"
+      )
+    })
+
+    test("handles trailing slash on base", () => {
+      expect(joinURLPath("https://api.example.com/", "v1/users")).toBe(
+        "https://api.example.com/v1/users"
+      )
+    })
+
+    test("handles leading slash on path", () => {
+      expect(joinURLPath("https://api.example.com", "/v1/users")).toBe(
+        "https://api.example.com/v1/users"
+      )
+    })
+
+    test("handles both trailing and leading slashes", () => {
+      expect(joinURLPath("https://api.example.com/", "/v1/users")).toBe(
+        "https://api.example.com/v1/users"
+      )
+    })
+
+    test("returns path when base is empty", () => {
+      expect(joinURLPath("", "/v1/users")).toBe("/v1/users")
+    })
+
+    test("returns base when path is empty", () => {
+      expect(joinURLPath("https://api.example.com", "")).toBe(
+        "https://api.example.com"
+      )
+    })
+  })
+})

--- a/packages/hoppscotch-data/src/utils/uri.ts
+++ b/packages/hoppscotch-data/src/utils/uri.ts
@@ -1,0 +1,150 @@
+/**
+ * URI/URL validation and parsing utilities for Hoppscotch request handling.
+ */
+
+/**
+ * Result type for URL parsing operations
+ */
+export interface ParsedURL {
+  protocol: string
+  host: string
+  hostname: string
+  port: string
+  pathname: string
+  search: string
+  hash: string
+  origin: string
+}
+
+/**
+ * Attempts to parse a URL string, returning null if invalid.
+ * Handles edge cases like missing protocol by prepending https://.
+ *
+ * @param url - The URL string to parse
+ * @param defaultProtocol - Protocol to prepend if missing (default: "https://")
+ * @returns ParsedURL object or null if parsing fails
+ */
+export function safeParseURL(
+  url: string,
+  defaultProtocol: string = "https://"
+): ParsedURL | null {
+  if (!url || typeof url !== "string") {
+    return null
+  }
+
+  const trimmedUrl = url.trim()
+  if (trimmedUrl === "") {
+    return null
+  }
+
+  // Try parsing as-is first
+  try {
+    const parsed = new URL(trimmedUrl)
+    return extractURLComponents(parsed)
+  } catch {
+    // If parsing fails, try with default protocol
+  }
+
+  // Try with default protocol prepended
+  try {
+    const parsed = new URL(`${defaultProtocol}${trimmedUrl}`)
+    return extractURLComponents(parsed)
+  } catch {
+    return null
+  }
+}
+
+function extractURLComponents(parsed: URL): ParsedURL {
+  return {
+    protocol: parsed.protocol,
+    host: parsed.host,
+    hostname: parsed.hostname,
+    port: parsed.port,
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+    origin: parsed.origin,
+  }
+}
+
+/**
+ * Checks whether a string is a syntactically valid URL.
+ *
+ * @param url - The string to validate
+ * @returns true if the string can be parsed as a URL
+ */
+export function isValidURL(url: string): boolean {
+  try {
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Extracts query parameters from a URL string as key-value pairs.
+ *
+ * @param url - A valid URL string
+ * @returns Array of { key, value } pairs, or empty array if URL is invalid
+ */
+export function extractQueryParams(
+  url: string
+): Array<{ key: string; value: string }> {
+  try {
+    const parsed = new URL(url)
+    const params: Array<{ key: string; value: string }> = []
+
+    parsed.searchParams.forEach((value, key) => {
+      params.push({ key, value })
+    })
+
+    return params
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Builds a URL string from a base URL and an array of query parameters.
+ * Existing query parameters in the base URL are preserved.
+ *
+ * @param baseUrl - The base URL (may already contain query params)
+ * @param params - Additional query parameters to append
+ * @returns The constructed URL string, or the original baseUrl if parsing fails
+ */
+export function buildURLWithParams(
+  baseUrl: string,
+  params: Array<{ key: string; value: string; active?: boolean }>
+): string {
+  try {
+    const parsed = new URL(baseUrl)
+
+    for (const param of params) {
+      if (param.active !== false && param.key.trim() !== "") {
+        parsed.searchParams.append(param.key, param.value)
+      }
+    }
+
+    return parsed.toString()
+  } catch {
+    return baseUrl
+  }
+}
+
+/**
+ * Joins a base URL with a relative path, handling trailing/leading slashes.
+ *
+ * @param base - The base URL
+ * @param path - The relative path to join
+ * @returns The joined URL string
+ */
+export function joinURLPath(base: string, path: string): string {
+  if (!base) return path
+  if (!path) return base
+
+  const cleanBase = base.endsWith("/") ? base.slice(0, -1) : base
+  const cleanPath = path.startsWith("/") ? path : `/${path}`
+
+  return `${cleanBase}${cleanPath}`
+}

--- a/packages/hoppscotch-data/tsconfig.decl.json
+++ b/packages/hoppscotch-data/tsconfig.decl.json
@@ -13,5 +13,6 @@
     "emitDeclarationOnly": true,
     "declarationDir": "./dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/packages/hoppscotch-data/tsconfig.json
+++ b/packages/hoppscotch-data/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/packages/hoppscotch-data/vitest.config.ts
+++ b/packages/hoppscotch-data/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,9 @@ importers:
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest:
+        specifier: latest
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
 
   packages/hoppscotch-desktop:
     dependencies:
@@ -5891,9 +5894,6 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -6628,8 +6628,22 @@ packages:
   '@vitest/expect@4.0.17':
     resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
   '@vitest/mocker@4.0.17':
     resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -6642,17 +6656,32 @@ packages:
   '@vitest/pretty-format@4.0.17':
     resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
 
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
   '@vitest/runner@4.0.17':
     resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
   '@vitest/snapshot@4.0.17':
     resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
 
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
   '@vitest/spy@4.0.17':
     resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
 
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
   '@vitest/utils@4.0.17':
     resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@volar/language-core@1.10.10':
     resolution: {integrity: sha512-nsV1o3AZ5n5jaEAObrS3MWLBWaGwUj/vAsc15FVNIv+DbpizQRISg9wzygsHBr56ELRH8r4K75vkYNMtsSNNWw==}
@@ -13181,6 +13210,40 @@ packages:
       jsdom:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -19255,8 +19318,6 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@standard-schema/spec@1.0.0': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
@@ -20067,6 +20128,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
   '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.17
@@ -20083,7 +20153,19 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
 
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
+
   '@vitest/pretty-format@4.0.17':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
 
@@ -20092,17 +20174,35 @@ snapshots:
       '@vitest/utils': 4.0.17
       pathe: 2.0.3
 
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
   '@vitest/snapshot@4.0.17':
     dependencies:
       '@vitest/pretty-format': 4.0.17
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.0.17': {}
+
+  '@vitest/spy@4.0.18': {}
 
   '@vitest/utils@4.0.17':
     dependencies:
       '@vitest/pretty-format': 4.0.17
+      tinyrainbow: 3.0.3
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
   '@volar/language-core@1.10.10':
@@ -21758,7 +21858,7 @@ snapshots:
 
   effect@3.18.4:
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
   ejs@3.1.10:
@@ -28136,6 +28236,44 @@ snapshots:
       '@vitest/snapshot': 4.0.17
       '@vitest/spy': 4.0.17
       '@vitest/utils': 4.0.17
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.9
+      jsdom: 27.4.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@types/node@25.0.9)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
       magic-string: 0.30.21


### PR DESCRIPTION
113 tests + new URI utility module with 5 functions. Zero to full test coverage on hoppscotch-data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a URI utilities module and 113 unit tests to bring hoppscotch-data to full coverage and improve URL handling. This strengthens reliability and adds safe URL parsing/building helpers for request workflows.

- **New Features**
  - New URI utilities: safeParseURL, isValidURL, extractQueryParams, buildURLWithParams, joinURLPath.
  - Handles missing protocols by defaulting to https, preserves existing query params, and joins base/path cleanly.

- **Dependencies**
  - Adds Vitest and a test script; includes vitest.config.ts.
  - Excludes test files from TypeScript builds in tsconfig.
  - No runtime dependency changes.

<sup>Written for commit 7f143d123568c2e209d1d7fea621b2094e7a4b22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

