### PR TITLE
docs: add local development setup example to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,31 @@ Please note we have a code of conduct, please follow it in all your interactions
 2. Update the README.md with details of changes to the interface, this includes new environment
    variables, exposed ports, useful file locations and container parameters.
 3. Make sure you do not expose environment variables or other sensitive information in your PR.
+
+## Local Development Setup
+
+1. Fork the repository and clone your fork:
+
+   ```bash
+   git clone https://github.com/<your-username>/hoppscotch.git
+   cd hoppscotch
+   ```
+
+2. Install dependencies using [pnpm](https://pnpm.io/) (this project requires pnpm):
+
+   ```bash
+   pnpm install
+   ```
+
+3. Start the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
+4. Before submitting a PR, run linting and type checks:
+
+   ```bash
+   pnpm lint
+   pnpm typecheck
+   ```


### PR DESCRIPTION
Fixes #5875

The CONTRIBUTING.md currently describes the PR process but doesn't include instructions for setting up a local development environment. This adds a quick-start section covering forking, cloning, installing dependencies with pnpm, running the dev server, and running lint/typecheck before submitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Local Development Setup" quick-start to CONTRIBUTING.md covering forking/cloning, installing with pnpm, running the dev server, and running lint/typecheck before PRs. Addresses #5875.

<sup>Written for commit 83dc0c4cc3657bcde7c2d576e0ba2bbfcee53f25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

