### PR TITLE
fix: allow empty MAILER_SMTP_USER and MAILER_SMTP_PASSWORD for unauthenticated SMTP

### DIFF
--- a/packages/hoppscotch-backend/src/infra-config/helper.ts
+++ b/packages/hoppscotch-backend/src/infra-config/helper.ts
@@ -71,8 +71,6 @@ export function getAuthProviderRequiredKeys(
             InfraConfigEnum.MAILER_SMTP_HOST,
             InfraConfigEnum.MAILER_SMTP_PORT,
             InfraConfigEnum.MAILER_SMTP_SECURE,
-            InfraConfigEnum.MAILER_SMTP_USER,
-            InfraConfigEnum.MAILER_SMTP_PASSWORD,
             InfraConfigEnum.MAILER_TLS_REJECT_UNAUTHORIZED,
             InfraConfigEnum.MAILER_ADDRESS_FROM,
           ]

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -309,8 +309,6 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
             configMap.MAILER_SMTP_HOST &&
             configMap.MAILER_SMTP_PORT &&
             configMap.MAILER_SMTP_SECURE &&
-            configMap.MAILER_SMTP_USER &&
-            configMap.MAILER_SMTP_PASSWORD &&
             configMap.MAILER_TLS_REJECT_UNAUTHORIZED &&
             configMap.MAILER_ADDRESS_FROM
           );
@@ -695,10 +693,13 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
           if (!domainPart || !domainRegex.test(domainPart)) return fail();
           break;
 
-        case InfraConfigEnum.MAILER_SMTP_HOST:
-        case InfraConfigEnum.MAILER_SMTP_PORT:
         case InfraConfigEnum.MAILER_SMTP_USER:
         case InfraConfigEnum.MAILER_SMTP_PASSWORD:
+          // Allow empty strings for SMTP servers that don't require authentication
+          break;
+
+        case InfraConfigEnum.MAILER_SMTP_HOST:
+        case InfraConfigEnum.MAILER_SMTP_PORT:
         case InfraConfigEnum.GOOGLE_CLIENT_ID:
         case InfraConfigEnum.GOOGLE_CLIENT_SECRET:
         case InfraConfigEnum.GOOGLE_SCOPE:

--- a/packages/hoppscotch-backend/src/mailer/helper.ts
+++ b/packages/hoppscotch-backend/src/mailer/helper.ts
@@ -1,9 +1,5 @@
 import { TransportType } from '@nestjs-modules/mailer/dist/interfaces/mailer-options.interface';
-import {
-  MAILER_SMTP_PASSWORD_UNDEFINED,
-  MAILER_SMTP_URL_UNDEFINED,
-  MAILER_SMTP_USER_UNDEFINED,
-} from 'src/errors';
+import { MAILER_SMTP_URL_UNDEFINED } from 'src/errors';
 import { throwErr } from 'src/utils';
 
 function isSMTPCustomConfigsEnabled(value) {
@@ -24,17 +20,23 @@ export function getTransportOption(env): TransportType {
     return env.INFRA.MAILER_SMTP_URL ?? throwErr(MAILER_SMTP_URL_UNDEFINED);
   } else {
     console.log('Using advanced mailer configuration');
+
+    const smtpUser = env.INFRA.MAILER_SMTP_USER;
+    const smtpPassword = env.INFRA.MAILER_SMTP_PASSWORD;
+
+    // Only include auth if user or password is provided.
+    // SMTP servers that don't require authentication should work
+    // with empty MAILER_SMTP_USER and MAILER_SMTP_PASSWORD.
+    const auth =
+      smtpUser || smtpPassword
+        ? { user: smtpUser ?? '', pass: smtpPassword ?? '' }
+        : undefined;
+
     return {
       host: env.INFRA.MAILER_SMTP_HOST,
       port: +env.INFRA.MAILER_SMTP_PORT,
       secure: env.INFRA.MAILER_SMTP_SECURE === 'true',
-      auth: {
-        user:
-          env.INFRA.MAILER_SMTP_USER ?? throwErr(MAILER_SMTP_USER_UNDEFINED),
-        pass:
-          env.INFRA.MAILER_SMTP_PASSWORD ??
-          throwErr(MAILER_SMTP_PASSWORD_UNDEFINED),
-      },
+      ...(auth ? { auth } : {}),
       tls: {
         rejectUnauthorized: env.INFRA.MAILER_TLS_REJECT_UNAUTHORIZED === 'true',
       },


### PR DESCRIPTION
## Summary

Fixes #4586

SMTP servers on internal networks often don't require authentication. When `MAILER_USE_CUSTOM_CONFIGS=true`, setting `MAILER_SMTP_USER=` and `MAILER_SMTP_PASSWORD=` to empty strings causes hoppscotch to reject the configuration as invalid and fail to start with `auth/provider_not_configured_correctly`.

This PR makes `MAILER_SMTP_USER` and `MAILER_SMTP_PASSWORD` optional so that unauthenticated SMTP configurations are accepted.

## Changes

- **`packages/hoppscotch-backend/src/infra-config/helper.ts`**: Removed `MAILER_SMTP_USER` and `MAILER_SMTP_PASSWORD` from the required auth provider configuration keys, since they are not needed for unauthenticated SMTP.
- **`packages/hoppscotch-backend/src/infra-config/infra-config.service.ts`**: 
  - Removed `MAILER_SMTP_USER` and `MAILER_SMTP_PASSWORD` from the `isServiceConfigured()` truthiness check, so empty values no longer cause the EMAIL provider to be considered unconfigured.
  - Added a dedicated case for `MAILER_SMTP_USER` and `MAILER_SMTP_PASSWORD` in `validateEnvValues()` that allows empty strings (previously they fell through to a case that rejected empty values).
- **`packages/hoppscotch-backend/src/mailer/helper.ts`**: Only includes the `auth` object in the nodemailer transport options when a user or password is actually provided. When both are empty, the `auth` property is omitted entirely, which tells nodemailer to connect without authentication.

## Test plan

- [ ] Set `.env` with `MAILER_USE_CUSTOM_CONFIGS=true`, `MAILER_SMTP_USER=`, `MAILER_SMTP_PASSWORD=` and verify the app starts without error
- [ ] Verify sending email still works with an unauthenticated SMTP server (e.g. local maildev or internal relay)
- [ ] Verify sending email still works with an authenticated SMTP server (non-empty user/password)
- [ ] Verify the onboarding SMTP setup flow accepts empty user/password fields

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept empty MAILER_SMTP_USER and MAILER_SMTP_PASSWORD to support unauthenticated SMTP when MAILER_USE_CUSTOM_CONFIGS=true. This prevents startup failures and lets nodemailer connect without auth when both are empty.

- **Bug Fixes**
  - Removed MAILER_SMTP_USER/PASSWORD from required keys and isServiceConfigured checks.
  - Allowed empty strings for these env values in validateEnvValues.
  - Only include auth in SMTP transport when a user or password is provided.

<sup>Written for commit 6b3b49c850c113efd8018e290479a017478b4eaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

