### PR TITLE
fix(common): resolve env variables before base64 encoding in basic auth

### DIFF
--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/basic.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/basic.spec.ts
@@ -49,5 +49,25 @@ describe("Basic Auth", () => {
 
       expect(headers[0].value).toBe(`Basic ${btoa(":")}`)
     })
+
+    test("resolves secret env vars before base64 encoding even with showKeyIfSecret", async () => {
+      const auth: HoppRESTAuth & { authType: "basic" } = {
+        authActive: true,
+        authType: "basic",
+        username: "<<USERNAME>>",
+        password: "<<PASSWORD>>",
+      }
+
+      // PASSWORD is a secret env var in mockEnvVars.
+      // With showKeyIfSecret=true, it should still resolve before base64 encoding.
+      // See: https://github.com/hoppscotch/hoppscotch/issues/5863
+      const headers = await generateBasicAuthHeaders(
+        auth,
+        mockEnvVars,
+        true // showKeyIfSecret
+      )
+
+      expect(headers[0].value).toBe(`Basic ${btoa("testuser:testpass")}`)
+    })
   })
 })

--- a/packages/hoppscotch-common/src/helpers/auth/types/basic.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/basic.ts
@@ -8,20 +8,14 @@ import {
 export async function generateBasicAuthHeaders(
   auth: HoppRESTAuth & { authType: "basic" },
   envVars: Environment["variables"],
-  showKeyIfSecret = false
+  _showKeyIfSecret = false
 ): Promise<HoppRESTHeader[]> {
-  const username = parseTemplateString(
-    auth.username,
-    envVars,
-    false,
-    showKeyIfSecret
-  )
-  const password = parseTemplateString(
-    auth.password,
-    envVars,
-    false,
-    showKeyIfSecret
-  )
+  // Always resolve environment variables before base64 encoding,
+  // regardless of showKeyIfSecret. Encoding unresolved template
+  // strings (e.g. <<Env-Username>>) produces unusable output.
+  // See: https://github.com/hoppscotch/hoppscotch/issues/5863
+  const username = parseTemplateString(auth.username, envVars)
+  const password = parseTemplateString(auth.password, envVars)
 
   return [
     {


### PR DESCRIPTION
## Description

Fixes #5863

When generating code exports (cURL, etc.), environment variables in Basic Auth credentials were not being resolved before base64 encoding. The raw `<<variable>>` placeholder text was encoded instead of the actual variable values, producing unusable Authorization headers in generated code.

### Root Cause

In `generateBasicAuthHeaders()`, the `showKeyIfSecret` parameter was passed through to `parseTemplateString()`. When code generation called `getEffectiveRESTRequest()` with `showKeyIfSecret = true`, secret environment variables (like passwords) were intentionally left unresolved as `<<varName>>`. This is appropriate for displaying headers in the UI, but not for base64 encoding, where the unresolved template string produces meaningless output.

For example, `btoa("<<Env-Username>>:<<Env-Password>>")` produces `PDxFbnYtVXNlcm5hbWU+Pjo8PEVudi1QYXNzd29yZD4+` instead of the correctly encoded credentials.

### Fix

Always resolve environment variables before base64 encoding in `generateBasicAuthHeaders()`, regardless of the `showKeyIfSecret` flag. Encoding unresolved template strings is never useful since the base64 output obscures the key names anyway.

### Changes

- **`packages/hoppscotch-common/src/helpers/auth/types/basic.ts`**: Remove `showKeyIfSecret` from `parseTemplateString` calls so that environment variables (including secrets) are always resolved before base64 encoding.
- **`packages/hoppscotch-common/src/helpers/auth/types/__tests__/basic.spec.ts`**: Add test case verifying that secret env vars are resolved before base64 encoding even when `showKeyIfSecret` is `true`.

### Testing

All 57 existing auth tests pass, plus the new test case:

```
✓ src/helpers/auth/types/__tests__/basic.spec.ts (4 tests)
✓ src/helpers/auth/types/__tests__/oauth2.spec.ts (7 tests)
✓ src/helpers/auth/types/__tests__/api-key.spec.ts (5 tests)
✓ src/helpers/auth/types/__tests__/jwt.spec.ts (10 tests)
✓ src/helpers/auth/types/__tests__/hawk.spec.ts (4 tests)
✓ src/helpers/auth/types/__tests__/aws-signature.spec.ts (12 tests)
✓ src/helpers/auth/types/__tests__/bearer.spec.ts (3 tests)
✓ src/helpers/auth/types/__tests__/digest.spec.ts (12 tests)

Test Files  8 passed (8)
Tests       57 passed (57)
```

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve environment variables in Basic Auth before base64 encoding so generated Authorization headers in code exports (cURL, etc.) are correct. Encoding now uses actual username/password values regardless of showKeyIfSecret, preventing placeholders like <<USERNAME>> from being encoded.

<sup>Written for commit 8495db2c7062a6ec600ffb5b7d7d892148b693ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

