### PR TITLE
fix(common): prevent infinite auth refresh retry loop on permanent token failure

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/retryAuthGuard.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/retryAuthGuard.spec.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect, vi } from "vitest"
+import { createAuthRetryGuard } from "../retryAuthGuard"
+
+const refreshSuccess = () => Promise.resolve(true)
+const refreshFailure = () => Promise.resolve(false)
+const refreshThrow = () => Promise.reject(new Error("network error"))
+
+describe("createAuthRetryGuard", () => {
+  describe("success resets failure count", () => {
+    test("returns true on successful refresh", async () => {
+      const guard = createAuthRetryGuard(vi.fn())
+
+      expect(await guard.execute(refreshSuccess)).toBe(true)
+    })
+
+    test("resets failure count after a success", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      // Accumulate 2 failures
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      // Success resets the counter
+      await guard.execute(refreshSuccess)
+
+      // 3 more failures needed to exhaust
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      expect(onExhausted).not.toHaveBeenCalled()
+
+      await guard.execute(refreshFailure)
+      expect(onExhausted).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe("exhaustion after MAX_RETRIES (3)", () => {
+    test("calls onExhausted after 3 consecutive failures", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      expect(onExhausted).not.toHaveBeenCalled()
+
+      await guard.execute(refreshFailure)
+      expect(onExhausted).toHaveBeenCalledOnce()
+    })
+
+    test("returns false for every failed attempt", async () => {
+      const guard = createAuthRetryGuard(vi.fn())
+
+      expect(await guard.execute(refreshFailure)).toBe(false)
+      expect(await guard.execute(refreshFailure)).toBe(false)
+      expect(await guard.execute(refreshFailure)).toBe(false)
+    })
+
+    test("short-circuits to false after exhaustion without calling refreshFn", async () => {
+      const guard = createAuthRetryGuard(vi.fn())
+
+      // Exhaust the guard
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      const refreshFn = vi.fn(refreshSuccess)
+      expect(await guard.execute(refreshFn)).toBe(false)
+      expect(refreshFn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("onExhausted runs at most once", () => {
+    test("does not call onExhausted again on subsequent execute calls", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      expect(onExhausted).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe("thrown errors count as failures", () => {
+    test("treats a thrown refreshFn as a failed attempt", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshThrow)
+      await guard.execute(refreshThrow)
+      await guard.execute(refreshThrow)
+
+      expect(onExhausted).toHaveBeenCalledOnce()
+    })
+
+    test("does not propagate the error to the caller", async () => {
+      const guard = createAuthRetryGuard(vi.fn())
+
+      await expect(guard.execute(refreshThrow)).resolves.toBe(false)
+    })
+  })
+
+  describe("onExhausted failure handling", () => {
+    test("stays exhausted if onExhausted throws", async () => {
+      const onExhausted = vi.fn(() => {
+        throw new Error("sign-out failed")
+      })
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      // Guard is still exhausted — short-circuits
+      const refreshFn = vi.fn(refreshSuccess)
+      expect(await guard.execute(refreshFn)).toBe(false)
+      expect(refreshFn).not.toHaveBeenCalled()
+    })
+
+    test("does not propagate onExhausted error to caller", async () => {
+      const guard = createAuthRetryGuard(() =>
+        Promise.reject(new Error("sign-out failed"))
+      )
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      await expect(guard.execute(refreshFailure)).resolves.toBe(false)
+    })
+  })
+
+  describe("reset()", () => {
+    test("re-enables the guard after exhaustion", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      // Exhaust
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      guard.reset()
+
+      // Guard is usable again
+      expect(await guard.execute(refreshSuccess)).toBe(true)
+    })
+
+    test("resets the failure counter", async () => {
+      const onExhausted = vi.fn()
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      guard.reset()
+
+      // Need 3 fresh failures to exhaust again
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+      expect(onExhausted).not.toHaveBeenCalled()
+
+      await guard.execute(refreshFailure)
+      expect(onExhausted).toHaveBeenCalledOnce()
+    })
+
+    test("is a no-op while onExhausted is in-flight", async () => {
+      let resolveExhausted!: () => void
+      const exhaustedPromise = new Promise<void>((resolve) => {
+        resolveExhausted = resolve
+      })
+      const onExhausted = vi.fn(() => exhaustedPromise)
+      const guard = createAuthRetryGuard(onExhausted)
+
+      await guard.execute(refreshFailure)
+      await guard.execute(refreshFailure)
+
+      // Start the 3rd failure — onExhausted is now in-flight.
+      // Don't await: we want to call reset() while it's still pending.
+      const thirdCall = guard.execute(refreshFailure)
+
+      // Flush microtasks so execute() progresses past `await refreshFn()`
+      // and sets exhaustionPromise before we call reset().
+      await Promise.resolve()
+
+      // reset() while onExhausted hasn't resolved yet — should be a no-op
+      guard.reset()
+
+      // Guard should still be exhausted
+      const refreshFn = vi.fn(refreshSuccess)
+      expect(await guard.execute(refreshFn)).toBe(false)
+      expect(refreshFn).not.toHaveBeenCalled()
+
+      // Let onExhausted finish
+      resolveExhausted()
+      await thirdCall
+
+      // Now reset() should work
+      guard.reset()
+      expect(await guard.execute(refreshSuccess)).toBe(true)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
@@ -114,7 +114,7 @@ const createHoppClient = () => {
           const refresh = platform.auth.refreshAuthToken
           if (!refresh) return
 
-          await authRetryGuard.execute(refresh)
+          await authRetryGuard.execute(() => refresh.call(platform.auth))
         },
       }
     }),

--- a/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
@@ -21,7 +21,7 @@ import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
 import { pipe, constVoid, flow } from "fp-ts/function"
 import { subscribe, pipe as wonkaPipe } from "wonka"
-import { filter, map, Subject } from "rxjs"
+import { filter, map, Subject, Subscription } from "rxjs"
 import { platform } from "~/platform"
 import { createAuthRetryGuard } from "~/helpers/retryAuthGuard"
 
@@ -149,6 +149,7 @@ const createHoppClient = () => {
 }
 
 let subscriptionClient: SubscriptionClient | null
+let authEventSubscription: Subscription | null = null
 export const client = ref<Client>()
 
 export function initBackendGQLClient() {
@@ -156,11 +157,14 @@ export function initBackendGQLClient() {
 
   // Reset the retry guard only on successful login, not on every
   // client recreation (which also fires on logout/token_refresh).
-  platform.auth.getAuthEventsStream().subscribe((event) => {
-    if (event.event === "login") {
-      authRetryGuard.reset()
-    }
-  })
+  authEventSubscription?.unsubscribe()
+  authEventSubscription = platform.auth
+    .getAuthEventsStream()
+    .subscribe((event) => {
+      if (event.event === "login") {
+        authRetryGuard.reset()
+      }
+    })
 
   platform.auth.onBackendGQLClientShouldReconnect(() => {
     const currentUser = platform.auth.getCurrentUser()

--- a/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
@@ -23,6 +23,7 @@ import { pipe, constVoid, flow } from "fp-ts/function"
 import { subscribe, pipe as wonkaPipe } from "wonka"
 import { filter, map, Subject } from "rxjs"
 import { platform } from "~/platform"
+import { createAuthRetryGuard } from "~/helpers/retryAuthGuard"
 
 // TODO: Implement caching
 
@@ -30,19 +31,6 @@ const BACKEND_GQL_URL =
   import.meta.env.VITE_BACKEND_GQL_URL ?? "https://api.hoppscotch.io/graphql"
 const BACKEND_WS_URL =
   import.meta.env.VITE_BACKEND_WS_URL ?? "wss://api.hoppscotch.io/graphql"
-
-/**
- * Maximum number of consecutive auth refresh failures before signing the user out.
- * Prevents infinite retry loops when tokens are permanently invalid.
- * @see https://github.com/hoppscotch/hoppscotch/issues/5885
- */
-const AUTH_REFRESH_MAX_RETRIES = 3
-
-/**
- * Tracks consecutive auth refresh failures across the authExchange lifecycle.
- * Reset to 0 on successful refresh or when a new client is created.
- */
-let authRefreshFailCount = 0
 
 type GQLOpType = "query" | "mutation" | "subscription"
 /**
@@ -78,9 +66,10 @@ const createSubscriptionClient = () => {
   })
 }
 
+const authRetryGuard = createAuthRetryGuard(() => platform.auth.signOutUser())
+
 const createHoppClient = () => {
-  // Reset refresh failure counter when creating a new client (e.g. after re-login)
-  authRefreshFailCount = 0
+  authRetryGuard.reset()
 
   const exchanges = [
     // devtoolsExchange,
@@ -125,26 +114,7 @@ const createHoppClient = () => {
           const refresh = platform.auth.refreshAuthToken
           if (!refresh) return
 
-          // Prevent infinite retry loop when refresh permanently fails (#5885)
-          if (authRefreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-            authRefreshFailCount = 0
-            await platform.auth.signOutUser()
-            return
-          }
-
-          const success = await refresh()
-
-          if (success) {
-            authRefreshFailCount = 0
-          } else {
-            authRefreshFailCount++
-
-            // If we've exhausted retries, sign out immediately
-            if (authRefreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-              authRefreshFailCount = 0
-              await platform.auth.signOutUser()
-            }
-          }
+          await authRetryGuard.execute(refresh)
         },
       }
     }),

--- a/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/GQLClient.ts
@@ -69,8 +69,6 @@ const createSubscriptionClient = () => {
 const authRetryGuard = createAuthRetryGuard(() => platform.auth.signOutUser())
 
 const createHoppClient = () => {
-  authRetryGuard.reset()
-
   const exchanges = [
     // devtoolsExchange,
     authExchange(async (): Promise<AuthConfig> => {
@@ -155,6 +153,14 @@ export const client = ref<Client>()
 
 export function initBackendGQLClient() {
   client.value = createHoppClient()
+
+  // Reset the retry guard only on successful login, not on every
+  // client recreation (which also fires on logout/token_refresh).
+  platform.auth.getAuthEventsStream().subscribe((event) => {
+    if (event.event === "login") {
+      authRetryGuard.reset()
+    }
+  })
 
   platform.auth.onBackendGQLClientShouldReconnect(() => {
     const currentUser = platform.auth.getCurrentUser()

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -51,7 +51,7 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
       if (failCount >= MAX_RETRIES && !isExhausted) {
         isExhausted = true
         try {
-          exhaustionPromise = Promise.resolve(onExhausted())
+          exhaustionPromise = Promise.resolve().then(() => onExhausted())
           await exhaustionPromise
         } catch (_) {
           // Sign-out failed (e.g. network error), but the guard stays

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -17,6 +17,7 @@ const MAX_RETRIES = 3
 export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
   let failCount = 0
   let isExhausted = false
+  let exhaustionPromise: Promise<void> | null = null
 
   return {
     /**
@@ -39,14 +40,27 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
       failCount++
       if (failCount >= MAX_RETRIES && !isExhausted) {
         isExhausted = true
-        await onExhausted()
+        try {
+          exhaustionPromise = Promise.resolve(onExhausted())
+          await exhaustionPromise
+        } catch (_) {
+          // Sign-out failed (e.g. network error), but the guard stays
+          // exhausted so we don't re-enter the refresh loop.
+        } finally {
+          exhaustionPromise = null
+        }
       }
 
       return false
     },
 
-    /** Reset the failure counter (e.g. on login or manual logout). */
+    /**
+     * Reset the failure counter (e.g. on login or manual logout).
+     * No-op while an exhaustion callback (sign-out) is still in-flight.
+     */
     reset() {
+      if (exhaustionPromise) return
+
       failCount = 0
       isExhausted = false
     },

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -26,6 +26,9 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
      * consecutive failures and stays exhausted until `reset()` is called.
      */
     async execute(refreshFn: () => Promise<boolean>): Promise<boolean> {
+      // isExhausted covers the normal path; failCount >= MAX_RETRIES covers
+      // the concurrent-call edge case where two callers both passed the check
+      // at failCount = 2 before either could set isExhausted = true.
       if (isExhausted || failCount >= MAX_RETRIES) {
         return false
       }

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -1,0 +1,51 @@
+/**
+ * Maximum number of consecutive auth refresh failures before signing out.
+ * @see https://github.com/hoppscotch/hoppscotch/issues/5885
+ */
+const MAX_RETRIES = 3
+
+/**
+ * Creates an auth retry guard that tracks consecutive refresh failures
+ * and triggers a sign-out after {@link MAX_RETRIES} consecutive failures.
+ *
+ * After exhaustion, subsequent calls short-circuit to `false` without
+ * invoking `refreshFn` or `onExhausted` again. Call `reset()` on
+ * successful login to re-enable refresh attempts.
+ *
+ * @see https://github.com/hoppscotch/hoppscotch/issues/5885
+ */
+export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
+  let failCount = 0
+
+  return {
+    /**
+     * Wraps an auth refresh attempt with retry tracking.
+     * Resets on success. Calls `onExhausted` after {@link MAX_RETRIES}
+     * consecutive failures and stays exhausted until `reset()` is called.
+     */
+    async execute(refreshFn: () => Promise<boolean>): Promise<boolean> {
+      if (failCount >= MAX_RETRIES) {
+        return false
+      }
+
+      const success = await refreshFn()
+
+      if (success) {
+        failCount = 0
+        return true
+      }
+
+      failCount++
+      if (failCount >= MAX_RETRIES) {
+        await onExhausted()
+      }
+
+      return false
+    },
+
+    /** Reset the failure counter (e.g. on login or manual logout). */
+    reset() {
+      failCount = 0
+    },
+  }
+}

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -30,7 +30,14 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
         return false
       }
 
-      const success = await refreshFn()
+      let success: boolean
+      try {
+        success = await refreshFn()
+      } catch (_) {
+        // Treat thrown errors (network failures, etc.) as a failed refresh
+        // so they count toward exhaustion and don't bypass the guard.
+        success = false
+      }
 
       if (success) {
         failCount = 0

--- a/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-common/src/helpers/retryAuthGuard.ts
@@ -16,6 +16,7 @@ const MAX_RETRIES = 3
  */
 export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
   let failCount = 0
+  let isExhausted = false
 
   return {
     /**
@@ -24,7 +25,7 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
      * consecutive failures and stays exhausted until `reset()` is called.
      */
     async execute(refreshFn: () => Promise<boolean>): Promise<boolean> {
-      if (failCount >= MAX_RETRIES) {
+      if (isExhausted || failCount >= MAX_RETRIES) {
         return false
       }
 
@@ -36,7 +37,8 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
       }
 
       failCount++
-      if (failCount >= MAX_RETRIES) {
+      if (failCount >= MAX_RETRIES && !isExhausted) {
+        isExhausted = true
         await onExhausted()
       }
 
@@ -46,6 +48,7 @@ export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
     /** Reset the failure counter (e.g. on login or manual logout). */
     reset() {
       failCount = 0
+      isExhausted = false
     },
   }
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -523,7 +523,7 @@ export const def: AuthPlatformDef = {
 
   async refreshAuthToken() {
     const refreshed = await refreshToken()
-    return refreshed ?? false
+    return refreshed
   },
 
   /**
@@ -553,6 +553,6 @@ export const def: AuthPlatformDef = {
     }
 
     const refreshed = await refreshToken()
-    return refreshed ?? false
+    return refreshed
   },
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -47,14 +47,6 @@ const isGettingInitialUser: Ref<null | boolean> = ref(null)
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
 
-/**
- * Tracks consecutive token refresh failures to prevent infinite retry loops.
- * Reset to 0 on successful refresh or login.
- * @see https://github.com/hoppscotch/hoppscotch/issues/5885
- */
-const AUTH_REFRESH_MAX_RETRIES = 3
-let refreshFailCount = 0
-
 async function logout() {
   const { response } = interceptorService.execute({
     id: Date.now(),
@@ -219,8 +211,6 @@ export async function setInitialUser() {
     await setUser(HoppUserWithAuthDetail)
     isGettingInitialUser.value = false
 
-    refreshFailCount = 0
-
     authEvents$.next({
       event: "login",
       user: HoppUserWithAuthDetail,
@@ -229,15 +219,10 @@ export async function setInitialUser() {
 }
 
 async function refreshToken() {
-  // Short-circuit if we've already failed too many times (#5885)
-  if (refreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-    return false
-  }
-
   try {
     const refreshToken =
       await persistenceService.getLocalConfig("refresh_token")
-    if (!refreshToken) return null
+    if (!refreshToken) return false
 
     const { response } = interceptorService.execute({
       id: Date.now(),
@@ -250,36 +235,26 @@ async function refreshToken() {
     })
 
     const res = await response
-    if (E.isLeft(res)) {
-      refreshFailCount++
-      return false
-    }
+    if (E.isLeft(res)) return false
 
     await setAuthCookies(res.right.headers)
     const isSuccessful = res.right.status === 200
 
-    if (isSuccessful) {
-      refreshFailCount = 0
-
-      if (currentUser$.value) {
-        authEvents$.next({
-          event: "login",
-          user: {
-            uid: currentUser$.value.uid,
-            displayName: currentUser$.value.displayName,
-            email: currentUser$.value.email,
-            photoURL: currentUser$.value.photoURL,
-            emailVerified: currentUser$.value.emailVerified,
-          },
-        })
-      }
-    } else {
-      refreshFailCount++
+    if (isSuccessful && currentUser$.value) {
+      authEvents$.next({
+        event: "login",
+        user: {
+          uid: currentUser$.value.uid,
+          displayName: currentUser$.value.displayName,
+          email: currentUser$.value.email,
+          photoURL: currentUser$.value.photoURL,
+          emailVerified: currentUser$.value.emailVerified,
+        },
+      })
     }
 
     return isSuccessful
   } catch (_err) {
-    refreshFailCount++
     return false
   }
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/web/index.ts
@@ -19,14 +19,6 @@ export const probableUser$ = new BehaviorSubject<HoppUser | null>(null)
 
 const persistenceService = getService(PersistenceService)
 
-/**
- * Tracks consecutive token refresh failures to prevent infinite retry loops.
- * Reset to 0 on successful refresh or login.
- * @see https://github.com/hoppscotch/hoppscotch/issues/5885
- */
-const AUTH_REFRESH_MAX_RETRIES = 3
-let refreshFailCount = 0
-
 async function logout() {
   await axios.get(`${import.meta.env.VITE_BACKEND_API_URL}/auth/logout`, {
     withCredentials: true,
@@ -148,8 +140,6 @@ async function setInitialUser() {
 
     isGettingInitialUser.value = false
 
-    refreshFailCount = 0
-
     authEvents$.next({
       event: "login",
       user: hoppUser,
@@ -160,11 +150,6 @@ async function setInitialUser() {
 }
 
 async function refreshToken() {
-  // Short-circuit if we've already failed too many times (#5885)
-  if (refreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-    return false
-  }
-
   try {
     const res = await axios.get(
       `${import.meta.env.VITE_BACKEND_API_URL}/auth/refresh`,
@@ -176,17 +161,13 @@ async function refreshToken() {
     const isSuccessful = res.status === 200
 
     if (isSuccessful) {
-      refreshFailCount = 0
       authEvents$.next({
         event: "token_refresh",
       })
-    } else {
-      refreshFailCount++
     }
 
     return isSuccessful
   } catch (_error) {
-    refreshFailCount++
     return false
   }
 }
@@ -358,8 +339,6 @@ export const def: AuthPlatformDef = {
   },
 
   async signOutUser() {
-    // if (!currentUser$.value) throw new Error("No user has logged in")
-
     await logout()
 
     probableUser$.next(null)

--- a/packages/hoppscotch-sh-admin/src/helpers/auth.ts
+++ b/packages/hoppscotch-sh-admin/src/helpers/auth.ts
@@ -53,14 +53,6 @@ export type OnboardingStatus = {
   onboardingCompleted: boolean;
 };
 
-/**
- * Tracks consecutive token refresh failures to prevent infinite retry loops.
- * Reset to 0 on successful refresh or login.
- * @see https://github.com/hoppscotch/hoppscotch/issues/5885
- */
-const AUTH_REFRESH_MAX_RETRIES = 3;
-let refreshFailCount = 0;
-
 const currentUser$ = new BehaviorSubject<HoppUser | null>(null);
 
 const signOut = async (reloadWindow = false) => {
@@ -128,8 +120,6 @@ const setInitialUser = async () => {
 
     setUser(hoppUser);
 
-    refreshFailCount = 0;
-
     authEvents$.next({
       event: 'login',
       user: hoppUser,
@@ -140,27 +130,18 @@ const setInitialUser = async () => {
 };
 
 const refreshToken = async () => {
-  // Short-circuit if we've already failed too many times (#5885)
-  if (refreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-    return false;
-  }
-
   try {
     const res = await authQuery.refreshToken();
     const isSuccessful = res.status === 200;
 
     if (isSuccessful) {
-      refreshFailCount = 0;
       authEvents$.next({
         event: 'token_refresh',
       });
-    } else {
-      refreshFailCount++;
     }
 
     return isSuccessful;
   } catch {
-    refreshFailCount++;
     return false;
   }
 };

--- a/packages/hoppscotch-sh-admin/src/helpers/auth.ts
+++ b/packages/hoppscotch-sh-admin/src/helpers/auth.ts
@@ -56,12 +56,12 @@ export type OnboardingStatus = {
 const currentUser$ = new BehaviorSubject<HoppUser | null>(null);
 
 const signOut = async (reloadWindow = false) => {
-  await authQuery.logout();
-
-  // Reload the window if both `access_token` and `refresh_token`is invalid
-  // there by the user is taken to the login page
-  if (reloadWindow) {
-    window.location.reload();
+  // Best-effort backend logout — local state must be cleared regardless
+  // so the UI never stays stuck in an authenticated state.
+  try {
+    await authQuery.logout();
+  } catch (_) {
+    // Backend unreachable — continue with local cleanup
   }
 
   currentUser$.next(null);
@@ -70,6 +70,12 @@ const signOut = async (reloadWindow = false) => {
   authEvents$.next({
     event: 'logout',
   });
+
+  // Reload the window if both `access_token` and `refresh_token` are invalid
+  // thereby the user is taken to the login page
+  if (reloadWindow) {
+    window.location.reload();
+  }
 };
 
 const getUserDetails = async () => {

--- a/packages/hoppscotch-sh-admin/src/helpers/retryAuthGuard.ts
+++ b/packages/hoppscotch-sh-admin/src/helpers/retryAuthGuard.ts
@@ -1,0 +1,82 @@
+/**
+ * Maximum number of consecutive auth refresh failures before signing out.
+ * @see https://github.com/hoppscotch/hoppscotch/issues/5885
+ */
+const MAX_RETRIES = 3
+
+/**
+ * Creates an auth retry guard that tracks consecutive refresh failures
+ * and triggers a sign-out after {@link MAX_RETRIES} consecutive failures.
+ *
+ * After exhaustion, subsequent calls short-circuit to `false` without
+ * invoking `refreshFn` or `onExhausted` again. Call `reset()` on
+ * successful login to re-enable refresh attempts.
+ *
+ * NOTE: This is a copy of `@hoppscotch/common/helpers/retryAuthGuard.ts`.
+ * `sh-admin` cannot depend on `@hoppscotch/common`, so the utility is
+ * duplicated here. Keep both copies in sync.
+ *
+ * @see https://github.com/hoppscotch/hoppscotch/issues/5885
+ */
+export function createAuthRetryGuard(onExhausted: () => void | Promise<void>) {
+  let failCount = 0
+  let isExhausted = false
+  let exhaustionPromise: Promise<void> | null = null
+
+  return {
+    /**
+     * Wraps an auth refresh attempt with retry tracking.
+     * Resets on success. Calls `onExhausted` after {@link MAX_RETRIES}
+     * consecutive failures and stays exhausted until `reset()` is called.
+     */
+    async execute(refreshFn: () => Promise<boolean>): Promise<boolean> {
+      // isExhausted covers the normal path; failCount >= MAX_RETRIES covers
+      // the concurrent-call edge case where two callers both passed the check
+      // at failCount = 2 before either could set isExhausted = true.
+      if (isExhausted || failCount >= MAX_RETRIES) {
+        return false
+      }
+
+      let success: boolean
+      try {
+        success = await refreshFn()
+      } catch (_) {
+        // Treat thrown errors (network failures, etc.) as a failed refresh
+        // so they count toward exhaustion and don't bypass the guard.
+        success = false
+      }
+
+      if (success) {
+        failCount = 0
+        return true
+      }
+
+      failCount++
+      if (failCount >= MAX_RETRIES && !isExhausted) {
+        isExhausted = true
+        try {
+          exhaustionPromise = Promise.resolve().then(() => onExhausted())
+          await exhaustionPromise
+        } catch (_) {
+          // Sign-out failed (e.g. network error), but the guard stays
+          // exhausted so we don't re-enter the refresh loop.
+        } finally {
+          exhaustionPromise = null
+        }
+      }
+
+      return false
+    },
+
+    /**
+     * Reset the failure counter (e.g. on login or manual logout).
+     * No-op while an exhaustion callback (sign-out) is still in-flight.
+     */
+    reset() {
+      if (exhaustionPromise) return
+
+      failCount = 0
+      isExhausted = false
+    },
+  }
+}

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -1,6 +1,7 @@
 import { authExchange } from '@urql/exchange-auth';
 import urql, { cacheExchange, createClient, fetchExchange } from '@urql/vue';
 import { createApp, h } from 'vue';
+import * as O from 'fp-ts/Option';
 import App from './App.vue';
 import ErrorComponent from './pages/_.vue';
 
@@ -13,17 +14,16 @@ import '../assets/scss/styles.scss';
 import '../assets/scss/tailwind.scss';
 // END STYLES
 
-import * as O from 'fp-ts/Option';
 import { auth } from './helpers/auth';
 import { GRAPHQL_UNAUTHORIZED } from './helpers/errors';
 import { HOPP_MODULES } from './modules';
 
 /**
- * Maximum number of consecutive auth refresh failures before signing the user out.
- * Prevents infinite retry loops when tokens are permanently invalid.
+ * Auth retry guard — prevents infinite refreshAuth loops when tokens
+ * are permanently invalid. Stays exhausted until the page reloads.
  * @see https://github.com/hoppscotch/hoppscotch/issues/5885
  */
-const AUTH_REFRESH_MAX_RETRIES = 3;
+const MAX_RETRIES = 3;
 let authRefreshFailCount = 0;
 
 (async () => {
@@ -42,12 +42,7 @@ let authRefreshFailCount = 0;
             return operation;
           },
           async refreshAuth() {
-            // Prevent infinite retry loop when refresh permanently fails (#5885)
-            if (authRefreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-              authRefreshFailCount = 0;
-              auth.signOutUser(true);
-              return;
-            }
+            if (authRefreshFailCount >= MAX_RETRIES) return;
 
             const result = await auth.performAuthRefresh();
 
@@ -55,9 +50,8 @@ let authRefreshFailCount = 0;
               authRefreshFailCount = 0;
             } else {
               authRefreshFailCount++;
-              if (authRefreshFailCount >= AUTH_REFRESH_MAX_RETRIES) {
-                authRefreshFailCount = 0;
-                auth.signOutUser(true);
+              if (authRefreshFailCount >= MAX_RETRIES) {
+                await auth.signOutUser(true);
               }
             }
           },

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -2,6 +2,8 @@ import { authExchange } from '@urql/exchange-auth';
 import urql, { cacheExchange, createClient, fetchExchange } from '@urql/vue';
 import { createApp, h } from 'vue';
 import * as O from 'fp-ts/Option';
+import * as TE from 'fp-ts/TaskEither';
+import { pipe } from 'fp-ts/function';
 import App from './App.vue';
 import ErrorComponent from './pages/_.vue';
 
@@ -53,9 +55,16 @@ authEvents$.subscribe((event) => {
             if (authRefreshExhausted || authRefreshFailCount >= MAX_RETRIES)
               return;
 
-            const result = await auth.performAuthRefresh();
+            const success = await pipe(
+              TE.tryCatch(
+                () => auth.performAuthRefresh(),
+                () => false as const
+              ),
+              TE.map(O.isSome),
+              TE.getOrElse(() => async () => false)
+            )();
 
-            if (O.isSome(result)) {
+            if (success) {
               authRefreshFailCount = 0;
             } else {
               authRefreshFailCount++;

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -2,8 +2,6 @@ import { authExchange } from '@urql/exchange-auth';
 import urql, { cacheExchange, createClient, fetchExchange } from '@urql/vue';
 import { createApp, h } from 'vue';
 import * as O from 'fp-ts/Option';
-import * as TE from 'fp-ts/TaskEither';
-import { pipe } from 'fp-ts/function';
 import App from './App.vue';
 import ErrorComponent from './pages/_.vue';
 
@@ -50,16 +48,10 @@ authEvents$.subscribe((event) => {
             return operation;
           },
           async refreshAuth() {
-            await authRetryGuard.execute(() =>
-              pipe(
-                TE.tryCatch(
-                  () => auth.performAuthRefresh(),
-                  () => false as const
-                ),
-                TE.map(O.isSome),
-                TE.getOrElse(() => async () => false)
-              )()
-            );
+            await authRetryGuard.execute(async () => {
+              const result = await auth.performAuthRefresh();
+              return O.isSome(result);
+            });
           },
           didAuthError(error, _operation) {
             return error.message === GRAPHQL_UNAUTHORIZED;

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -25,10 +25,12 @@ import { HOPP_MODULES } from './modules';
  */
 const MAX_RETRIES = 3;
 let authRefreshFailCount = 0;
+let authRefreshExhausted = false;
 
 authEvents$.subscribe((event) => {
   if (event.event === 'login') {
     authRefreshFailCount = 0;
+    authRefreshExhausted = false;
   }
 });
 
@@ -48,7 +50,8 @@ authEvents$.subscribe((event) => {
             return operation;
           },
           async refreshAuth() {
-            if (authRefreshFailCount >= MAX_RETRIES) return;
+            if (authRefreshExhausted || authRefreshFailCount >= MAX_RETRIES)
+              return;
 
             const result = await auth.performAuthRefresh();
 
@@ -56,8 +59,16 @@ authEvents$.subscribe((event) => {
               authRefreshFailCount = 0;
             } else {
               authRefreshFailCount++;
-              if (authRefreshFailCount >= MAX_RETRIES) {
-                await auth.signOutUser(true);
+              if (
+                authRefreshFailCount >= MAX_RETRIES &&
+                !authRefreshExhausted
+              ) {
+                authRefreshExhausted = true;
+                auth.signOutUser(true).catch(() => {
+                  // Best-effort: sign-out failed (e.g. backend unreachable),
+                  // but the guard stays exhausted so refreshAuth() won't loop.
+                  // signOutUser(true) triggers a page reload on success anyway.
+                });
               }
             }
           },

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -18,6 +18,7 @@ import '../assets/scss/tailwind.scss';
 
 import { auth, authEvents$ } from './helpers/auth';
 import { GRAPHQL_UNAUTHORIZED } from './helpers/errors';
+import { createAuthRetryGuard } from './helpers/retryAuthGuard';
 import { HOPP_MODULES } from './modules';
 
 /**
@@ -25,14 +26,11 @@ import { HOPP_MODULES } from './modules';
  * are permanently invalid. Stays exhausted until the page reloads.
  * @see https://github.com/hoppscotch/hoppscotch/issues/5885
  */
-const MAX_RETRIES = 3;
-let authRefreshFailCount = 0;
-let authRefreshExhausted = false;
+const authRetryGuard = createAuthRetryGuard(() => auth.signOutUser(true));
 
 authEvents$.subscribe((event) => {
   if (event.event === 'login') {
-    authRefreshFailCount = 0;
-    authRefreshExhausted = false;
+    authRetryGuard.reset();
   }
 });
 
@@ -52,34 +50,16 @@ authEvents$.subscribe((event) => {
             return operation;
           },
           async refreshAuth() {
-            if (authRefreshExhausted || authRefreshFailCount >= MAX_RETRIES)
-              return;
-
-            const success = await pipe(
-              TE.tryCatch(
-                () => auth.performAuthRefresh(),
-                () => false as const
-              ),
-              TE.map(O.isSome),
-              TE.getOrElse(() => async () => false)
-            )();
-
-            if (success) {
-              authRefreshFailCount = 0;
-            } else {
-              authRefreshFailCount++;
-              if (
-                authRefreshFailCount >= MAX_RETRIES &&
-                !authRefreshExhausted
-              ) {
-                authRefreshExhausted = true;
-                auth.signOutUser(true).catch(() => {
-                  // Best-effort: sign-out failed (e.g. backend unreachable),
-                  // but the guard stays exhausted so refreshAuth() won't loop.
-                  // signOutUser(true) triggers a page reload on success anyway.
-                });
-              }
-            }
+            await authRetryGuard.execute(() =>
+              pipe(
+                TE.tryCatch(
+                  () => auth.performAuthRefresh(),
+                  () => false as const
+                ),
+                TE.map(O.isSome),
+                TE.getOrElse(() => async () => false)
+              )()
+            );
           },
           didAuthError(error, _operation) {
             return error.message === GRAPHQL_UNAUTHORIZED;

--- a/packages/hoppscotch-sh-admin/src/main.ts
+++ b/packages/hoppscotch-sh-admin/src/main.ts
@@ -14,7 +14,7 @@ import '../assets/scss/styles.scss';
 import '../assets/scss/tailwind.scss';
 // END STYLES
 
-import { auth } from './helpers/auth';
+import { auth, authEvents$ } from './helpers/auth';
 import { GRAPHQL_UNAUTHORIZED } from './helpers/errors';
 import { HOPP_MODULES } from './modules';
 
@@ -25,6 +25,12 @@ import { HOPP_MODULES } from './modules';
  */
 const MAX_RETRIES = 3;
 let authRefreshFailCount = 0;
+
+authEvents$.subscribe((event) => {
+  if (event.event === 'login') {
+    authRefreshFailCount = 0;
+  }
+});
 
 (async () => {
   try {


### PR DESCRIPTION
Closes #5885

This PR prevents the infinite auth refresh retry loop in the URQL auth exchange when refresh fails repeatedly, which was causing `/auth/refresh` request floods on permanent token failure.

### What's changed

- Add a shared `createAuthRetryGuard()` helper in `hoppscotch-common` to cap consecutive refresh failures and trigger sign-out after 3 failures
- Route the common GQL client `refreshAuth` path through that guard
- Reset the guard only on successful login, so the retry cap stays exhausted across client recreation until the user authenticates again
- Apply the same retry-guard pattern in sh-admin
- Make sh-admin logout best-effort so local auth state is still cleared if backend logout fails
- Normalize desktop refresh helpers to return `false` instead of `null`

### Notes to reviewers

The loop fix for the linked issue lives in the URQL auth-exchange layer (`GQLClient.ts` and the admin URQL client bootstrap), not as per-platform retry counters in `web/index.ts` or `desktop/index.ts`.

Unit coverage was added for the shared retry guard to cover success reset, exhaustion, thrown errors, and reset behavior while sign-out is still in flight.