### PR TITLE
fix(common): escape special characters in generated code snippets

### DIFF
--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -99,6 +99,55 @@ const buildHarPostParams = (
   })
 }
 
+/**
+ * JSON MIME types that httpsnippet parses into a jsonObj internally.
+ * When the parsed object contains special characters (newlines, tabs,
+ * backslashes, etc.), some code generators fail to re-escape them,
+ * producing syntactically broken generated code.
+ *
+ * @see https://github.com/hoppscotch/hoppscotch/issues/3011
+ */
+const JSON_MIME_TYPES: readonly string[] = [
+  "application/json",
+  "application/x-json",
+  "text/json",
+  "text/x-json",
+]
+
+/**
+ * Recursively checks whether any string value in a parsed JSON structure
+ * contains characters that httpsnippet's code generators fail to escape
+ * (control characters like \n, \t, \r, etc. and backslashes).
+ *
+ * When such characters are present, httpsnippet's internal `literalRepresentation`
+ * (Python), `convertType` (PHP), and similar helpers embed them literally into the
+ * generated code, producing syntactically invalid output.
+ */
+const jsonHasProblematicChars = (text: string): boolean => {
+  try {
+    return hasProblematicValue(JSON.parse(text))
+  } catch {
+    // Not valid JSON — httpsnippet won't use the jsonObj path anyway
+    return false
+  }
+}
+
+const hasProblematicValue = (value: unknown): boolean => {
+  if (typeof value === "string") {
+    // Check for control characters (U+0000–U+001F, U+007F–U+009F) and backslashes
+    // that literalRepresentation and similar helpers don't escape properly
+    // eslint-disable-next-line no-control-regex
+    return /[\x00-\x1f\x7f-\x9f\\]/.test(value)
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasProblematicValue)
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).some(hasProblematicValue)
+  }
+  return false
+}
+
 const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
   if (!req.body.contentType) return undefined
 
@@ -114,9 +163,27 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
     }
   }
 
+  const bodyText = (req.body.body as string) ?? ""
+
+  // Workaround for httpsnippet special character escaping bug (#3011):
+  // When a JSON body contains values with control characters (e.g. \n, \t) or
+  // backslashes, httpsnippet internally parses the JSON into an object. Some code
+  // generators then fail to re-escape these characters in the output, producing
+  // syntactically broken code (e.g. literal newlines inside Python string literals).
+  //
+  // By setting the HAR mimeType to "text/plain" instead of the JSON type, we prevent
+  // httpsnippet from parsing the body as JSON. This forces generators to use the raw
+  // text code path, which properly handles escaping via JSON.stringify() or equivalent.
+  // The actual Content-Type header is still preserved via buildHarHeaders().
+  const isJsonMime = JSON_MIME_TYPES.includes(req.body.contentType!)
+  const mimeType =
+    isJsonMime && jsonHasProblematicChars(bodyText)
+      ? "text/plain"
+      : req.body.contentType!
+
   return {
-    mimeType: req.body.contentType, // Let's assume by default content type is JSON
-    text: (req.body.body as string) ?? "",
+    mimeType,
+    text: bodyText,
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3011

When a JSON request body contains values with special characters (newlines `\n`, tabs `\t`, backslashes `\\`, etc.), the **Generate Code** feature produces syntactically broken output for several target languages. For example, a Python requests snippet might embed a literal newline character inside a string literal instead of using the `\n` escape sequence.

### Root cause

The code generation pipeline builds a [HAR](http://www.softwareishard.com/blog/har-12-spec/) request object and passes it to `@hoppscotch/httpsnippet`. For JSON bodies, httpsnippet internally calls `JSON.parse()` on the body text — converting escape sequences like `\n` into actual control characters. Some code generators (Python `requests`, Rust `reqwest`, PHP `curl`, Swift `nsurlsession`, Objective-C `nsurlsession`) then embed these control characters literally into the generated code without re-escaping them.

### Fix

In `buildHarPostData` (`packages/hoppscotch-common/src/helpers/new-codegen/har.ts`):

- Added `jsonHasProblematicChars()` — recursively checks whether a parsed JSON body contains string values with control characters or backslashes
- When such characters are detected, the HAR `postData.mimeType` is set to `"text/plain"` instead of `"application/json"`. This prevents httpsnippet from parsing the body into a `jsonObj` and forces generators to use the raw text code path, which handles escaping correctly via `JSON.stringify()` or equivalent
- The actual `Content-Type` header is preserved via `buildHarHeaders()`, so the generated code still sends `application/json`
- JSON bodies **without** special characters continue to use the `application/json` path for idiomatic generated code (e.g. Python's `json=payload`)

### Before / After

**Body:** `{"content": "a=1\nprint(a+20)"}`

**Before (broken Python):**
```python
payload = { "content": "a=1
print(a+20)" }
```

**After (valid Python):**
```python
payload = "{\"content\": \"a=1\\nprint(a+20)\"}"
```

## Test plan

- [x] Verified fix produces valid generated code for Python requests, Shell cURL, JavaScript fetch, Rust reqwest, PHP cURL
- [x] Verified normal JSON bodies (without special characters) still use the idiomatic `json=payload` path
- [x] All pre-commit lint checks pass (0 errors)
- [x] Type checking passes
- [ ] Manual test: open Hoppscotch, set a JSON body with `\n` in a string value, generate code in Python requests, verify the output is syntactically valid

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken generated code when JSON bodies contain special characters (e.g., \n, \t, \\) across targets like Python, Rust, PHP, Swift, and Objective-C. Detects such bodies and uses the raw text path so characters are correctly escaped while preserving Content-Type: application/json.

- **Bug Fixes**
  - Added jsonHasProblematicChars to flag control characters and backslashes in JSON.
  - When flagged, set HAR postData.mimeType to text/plain to avoid httpsnippet JSON parsing; headers still send application/json.
  - Clean JSON continues using the normal application/json path.

<sup>Written for commit cbed4c966523417ea3140330285b8761a3109fde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

