### PR TITLE
feat(common): fall back to `ref_id` in remove functions when `id` is missing

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -358,6 +358,7 @@ const saveRequestAs = async () => {
         folderPath: `${picked.value.collectionIndex}`,
         requestIndex: insertionIndex,
         exampleID: undefined,
+        requestRefID: requestUpdated._ref_id,
       },
     }
 
@@ -392,6 +393,7 @@ const saveRequestAs = async () => {
         originLocation: "user-collection",
         folderPath: picked.value.folderPath,
         requestIndex: insertionIndex,
+        requestRefID: requestUpdated._ref_id,
       },
     }
 

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1860,7 +1860,7 @@ export function removeGraphqlRequest(
       graphqlCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
     )?.requests[requestIndex]
-    requestID = request?.id || (request as any)?._ref_id
+    requestID = request?.id || `${path}/${requestIndex}`
   }
   graphqlCollectionStore.dispatch({
     dispatcher: "removeRequest",

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1636,7 +1636,7 @@ export function removeRESTRequest(
       restCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
     )?.requests[requestIndex]
-    requestID = request?.id || (request as any)?._ref_id
+    requestID = request?.id || (request as HoppRESTRequest)?._ref_id
   }
   restCollectionStore.dispatch({
     dispatcher: "removeRequest",

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1351,6 +1351,9 @@ export function removeRESTCollection(
   collectionIndex: number,
   collectionID?: string
 ) {
+  if (!collectionID) {
+    collectionID = restCollectionStore.value.state[collectionIndex]?._ref_id
+  }
   restCollectionStore.dispatch({
     dispatcher: "removeCollection",
     payload: {
@@ -1518,6 +1521,13 @@ export function editRESTFolder(path: string, folder: Partial<HoppCollection>) {
 }
 
 export function removeRESTFolder(path: string, folderID?: string) {
+  if (!folderID) {
+    const folder = navigateToFolderWithIndexPath(
+      restCollectionStore.value.state,
+      path.split("/").map((index) => parseInt(index))
+    )
+    folderID = folder?._ref_id
+  }
   restCollectionStore.dispatch({
     dispatcher: "removeFolder",
     payload: {
@@ -1621,6 +1631,13 @@ export function removeRESTRequest(
   requestIndex: number,
   requestID?: string
 ) {
+  if (!requestID) {
+    const request = navigateToFolderWithIndexPath(
+      restCollectionStore.value.state,
+      path.split("/").map((index) => parseInt(index))
+    )?.requests[requestIndex]
+    requestID = request?.id || (request as any)?._ref_id
+  }
   restCollectionStore.dispatch({
     dispatcher: "removeRequest",
     payload: {
@@ -1705,6 +1722,9 @@ export function removeGraphqlCollection(
   collectionIndex: number,
   collectionID?: string
 ) {
+  if (!collectionID) {
+    collectionID = graphqlCollectionStore.value.state[collectionIndex]?._ref_id
+  }
   graphqlCollectionStore.dispatch({
     dispatcher: "removeCollection",
     payload: {
@@ -1751,6 +1771,13 @@ export function editGraphqlFolder(
 }
 
 export function removeGraphqlFolder(path: string, folderID?: string) {
+  if (!folderID) {
+    const folder = navigateToFolderWithIndexPath(
+      graphqlCollectionStore.value.state,
+      path.split("/").map((index) => parseInt(index))
+    )
+    folderID = folder?._ref_id
+  }
   graphqlCollectionStore.dispatch({
     dispatcher: "removeFolder",
     payload: {
@@ -1828,6 +1855,13 @@ export function removeGraphqlRequest(
   requestIndex: number,
   requestID?: string
 ) {
+  if (!requestID) {
+    const request = navigateToFolderWithIndexPath(
+      graphqlCollectionStore.value.state,
+      path.split("/").map((index) => parseInt(index))
+    )?.requests[requestIndex]
+    requestID = request?.id || (request as any)?._ref_id
+  }
   graphqlCollectionStore.dispatch({
     dispatcher: "removeRequest",
     payload: {

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -88,7 +88,9 @@ export class RESTTabService extends TabService<HoppTabDocument> {
         tab.document.saveContext.folderPath === ctx?.folderPath &&
         tab.document.saveContext.requestIndex === ctx?.requestIndex &&
         tab.document.saveContext.exampleID === ctx?.exampleID &&
-        tab.document.saveContext.requestRefID === ctx?.requestRefID
+        (ctx?.requestRefID != null
+          ? tab.document.saveContext.requestRefID === ctx.requestRefID
+          : true)
       ) {
         return this.getTabRef(tab.id)
       }


### PR DESCRIPTION
Closes FE-1130.

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
Enhance the remove functions across collections, folders, and requests to automatically use the `_ref_id` when no ID is provided, improving usability and reducing errors.

### What's changed
- Updated `removeRESTCollection`, `removeRESTFolder`, and `removeRESTRequest` to use `_ref_id` if no ID is given.
- Updated `removeGraphqlCollection`, `removeGraphqlFolder`, and `removeGraphqlRequest` similarly to utilize `_ref_id`.

### Notes to reviewers
Review the changes to ensure that the fallback to `_ref_id` works as intended and does not introduce any regressions.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove functions for REST/GraphQL collections, folders, and requests now fall back to `_ref_id` when IDs are missing, with GraphQL request removal using `id` or index/path if needed. Also pass `requestRefID` in SaveRequest and only match it in `RESTTabService` when provided to keep tabs linked to saved requests and fix deletion/tab-matching when only `_ref_id` is available (FE-1130).

<sup>Written for commit 9aeb98d62bcad07875b85db109decf4482e598d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



