### PR TITLE
fix(common): hide horizontal scrollbar in Firefox for URL input

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -749,7 +749,7 @@ watch(
   @apply flex-shrink-0;
   @apply whitespace-nowrap py-4;
 
-  // 隐藏 Firefox 中 CodeMirror 的水平滚动条（Chrome 通过全局 ::-webkit-scrollbar { h-0 } 处理）
+  // Hide horizontal scrollbar for CodeMirror in Firefox (Chrome is handled by global ::-webkit-scrollbar { h-0 })
   :deep(.cm-scroller) {
     scrollbar-width: none;
   }


### PR DESCRIPTION
Description
Currently, long URLs cause a horizontal scrollbar to appear in Firefox because the global ::-webkit-scrollbar rule is WebKit-specific. This PR addresses the issue by applying scrollbar-width: none specifically to single-line CodeMirror instances (URL bar, headers, env variables) via the EnvInput wrapper.

Closes #5900 

What's changed
Added scrollbar-width: none to .cm-scroller within the .autocomplete-wrapper.

Used the :deep() selector to ensure the style penetrates the scoped component into the CodeMirror structure.

Focused the fix on EnvInput, which prevents the scrollbar from being hidden in multi-line editors (like the request body or response viewer) where scrolling is still necessary.

Notes to reviewers
This fix specifically targets Firefox users. Since Chrome/Edge already respect the ::-webkit-scrollbar { height: 0 } rule, this change ensures a consistent, clean UI across all modern browsers without affecting the usability of larger text areas.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the horizontal scrollbar in Firefox for single-line CodeMirror inputs (URL bar, headers, env vars) while keeping multi-line editor scrollbars, matching Chrome/Edge. Also translate a related comment to English.

- **Bug Fixes**
  - Applied scrollbar-width: none to .cm-scroller via :deep() in EnvInput.

<sup>Written for commit eec6d514713f9be070d702cab26341e8d75308b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

