### PR TITLE
fix(backend): prevent request payload from overriding id and name

### DIFF
--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
@@ -2314,3 +2314,69 @@ describe('updateUserCollection', () => {
     );
   });
 });
+
+describe('exportUserCollectionToJSONObject', () => {
+  test('should use DB row id and title over conflicting values in stored request payload', async () => {
+    const dbRowId = 'db-row-cuid-001';
+    const dbRowTitle = 'My Request';
+    const payloadId = 'stale-payload-id-from-original';
+    const payloadName = 'stale-payload-name-from-original';
+
+    mockPrisma.userCollection.findUniqueOrThrow.mockResolvedValueOnce({
+      ...rootRESTUserCollection,
+    });
+    mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
+    mockPrisma.userRequest.findMany.mockResolvedValueOnce([
+      {
+        id: dbRowId,
+        title: dbRowTitle,
+        collectionID: rootRESTUserCollection.id,
+        userUid: user.uid,
+        type: ReqType.REST,
+        orderIndex: 1,
+        createdOn: currentTime,
+        updatedOn: currentTime,
+        mockExamples: null,
+        request: {
+          id: payloadId,
+          name: payloadName,
+          v: '12',
+          endpoint: 'https://example.com',
+          method: 'GET',
+          params: [],
+          headers: [],
+          preRequestScript: '',
+          testScript: '',
+          auth: { authType: 'none', authActive: false },
+          body: { contentType: null, body: null },
+          requestVariables: [],
+          responses: {},
+        },
+      },
+    ]);
+
+    const result = await userCollectionService.exportUserCollectionToJSONObject(
+      user.uid,
+      rootRESTUserCollection.id,
+    );
+
+    expect(result).toEqualRight(
+      expect.objectContaining({
+        requests: [expect.objectContaining({ id: dbRowId, name: dbRowTitle })],
+      }),
+    );
+  });
+
+  test('should throw USER_COLL_NOT_FOUND when collectionID is invalid', async () => {
+    mockPrisma.userCollection.findUniqueOrThrow.mockRejectedValueOnce(
+      new Error('NotFoundError'),
+    );
+
+    const result = await userCollectionService.exportUserCollectionToJSONObject(
+      user.uid,
+      'non-existent-id',
+    );
+
+    expect(result).toEqualLeft(USER_COLL_NOT_FOUND);
+  });
+});

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -46,7 +46,7 @@ export class UserCollectionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly pubsub: PubSubService,
-  ) { }
+  ) {}
 
   TITLE_LENGTH = 1;
   MAX_RETRIES = 5; // Maximum number of retries for database transactions

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -46,7 +46,7 @@ export class UserCollectionService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly pubsub: PubSubService,
-  ) {}
+  ) { }
 
   TITLE_LENGTH = 1;
   MAX_RETRIES = 5; // Maximum number of retries for database transactions
@@ -920,9 +920,9 @@ export class UserCollectionService {
       folders: childrenCollectionObjects,
       requests: requests.map((x) => {
         return {
+          ...(x.request as Record<string, unknown>), // type casting x.request of type Prisma.JSONValue to an object to enable spread
           id: x.id,
           name: x.title,
-          ...(x.request as Record<string, unknown>), // type casting x.request of type Prisma.JSONValue to an object to enable spread
         };
       }),
       data,
@@ -996,9 +996,9 @@ export class UserCollectionService {
           folders: collectionListObjects,
           requests: requests.map((x) => {
             return {
+              ...(x.request as Record<string, unknown>), // type casting x.request of type Prisma.JSONValue to an object to enable spread
               id: x.id,
               name: x.title,
-              ...(x.request as Record<string, unknown>), // type casting x.request of type Prisma.JSONValue to an object to enable spread
             };
           }),
           data: JSON.stringify(parentCollection.right.data),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes BE-729.

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
Reorder the spread in the request mapping so `id` and `name` are assigned after spreading `x.request`, preventing the stored request JSON payload from overriding the authoritative DB row values and applied to both export paths in `exportUserCollectionToJSONObject` and `exportUserCollectionsToJSON`.

Also fixes constructor brace formatting and adds regression tests.

### Notes to reviewers
`exportUserCollectionToJSONObject` is called on every personal workspace page load and not only on explicit collection exports. Users who duplicated requests before the #5781 fix (v2026.1.1) have rows where the stored `request` JSON contains the original request's `id`. Without this fix, the wrong `id` is served to the frontend on reload, causing delete/rename/edit operations to target the wrong row. This resolves the stuck-duplicate-after-upgrade regression reported post `v2026.1.1`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes request mapping so a stored request payload can’t override id and name, ensuring correct identifiers in collection exports. Addresses BE-729.

- **Bug Fixes**
  - Spread cast request before setting id/name in both mappings; add tests for id/name precedence and USER_COLL_NOT_FOUND on invalid collectionID.
  - Cast Prisma.JSONValue to Record<string, unknown> to safely spread.

<sup>Written for commit 18b05213e3898ffd4853fb5469cdefcb2ff6696d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



