### PR TITLE
fix(curl): handle output-control flags in curl import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1092,6 +1092,44 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl -G https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
+  {
+    command: `curl --silent --verbose https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -52,6 +52,8 @@ export const parseCurlCommand = (curlCommand: string) => {
       "v", // --verbose
       "k", // --insecure
       "L", // --location
+      "I", // --head
+      "G", // --get
       "N", // --no-buffer
       "f", // --fail
       "q", // --disable (.curlrc)
@@ -60,6 +62,21 @@ export const parseCurlCommand = (curlCommand: string) => {
       "0", // --http1.0
       "4", // --ipv4
       "6", // --ipv6
+      "compressed",
+      "silent",
+      "show-error",
+      "verbose",
+      "insecure",
+      "location",
+      "head",
+      "get",
+      "no-buffer",
+      "fail",
+      "disable",
+      "netrc",
+      "progress-bar",
+      "ipv4",
+      "ipv6",
     ],
   })
 


### PR DESCRIPTION
Fixes #5910

## What's going on

When you paste a curl command with flags like `-sS`, `-v`, or `-k`, the import fails with "cURL is not formatted properly". This happens because `yargs-parser` doesn't know these are boolean flags, so it treats the next argument as their value. If that next argument is the URL, it gets swallowed and the parser can't find it.

For example, `curl -sS https://example.com` gets parsed as:
```json
{ "_": ["curl"], "s": true, "S": "https://example.com" }
```

The URL ends up as the value of `-S` instead of in the positional args where `getURLObject` looks for it.

## Fix

Pass a `boolean` config to `yargs-parser` listing the curl flags that don't take arguments:

`-s`, `-S`, `-v`, `-k`, `-L`, `-N`, `-f`, `-q`, `-n`, `-#`, `-0`, `-4`, `-6`

These are all output/behavior flags that don't affect the HTTP request itself. After the fix:
```json
{ "_": ["curl", "https://example.com"], "s": true, "S": true }
```

## Tests

Added 3 test cases:
- `curl -sS <url>` (the exact case from the issue)
- `curl -sSL -k -H '...' <url>` (combined flags with headers)
- `curl -v <url>` (verbose flag)

All 32 tests pass (29 existing + 3 new).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes curl import failures by treating non-argument flags (short and long) as booleans so the URL isn’t swallowed. This resolves “cURL is not formatted properly” for commands using combined flags like -sS, -v, -k, -G, -I, and their long forms.

- **Bug Fixes**
  - Configure yargs-parser boolean flags: short (-s, -S, -v, -k, -L, -I, -G, -N, -f, -q, -n, -#, -0, -4, -6) and long (--silent, --show-error, --verbose, --insecure, --location, --head, --get, --no-buffer, --fail, --disable, --netrc, --progress-bar, --ipv4, --ipv6, --compressed).
  - Keeps the URL in positional args, enabling imports with combined flags.
  - Adds tests for -sS <url>, -sSL -k with headers, -v <url>, -G <url>, and --silent --verbose <url>.

<sup>Written for commit f4c54eeffb4f8d980789b2254feb8b7b7aa6da07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

