### PR TITLE
fix(common): handle File objects in HAR postData text resolution

### DIFF
--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -119,26 +119,26 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
   // "[object File]" which causes HTTPSnippet to throw and code generation to
   // fail entirely.
   if (req.body.contentType === "application/octet-stream") {
-  const body = req.body.body
+    const body = req.body.body
 
-  // Preserve string if it ever exists
-  if (typeof body === "string") {
+    // Preserve string if it ever exists
+    if (typeof body === "string") {
+      return {
+        mimeType: req.body.contentType,
+        text: body,
+      }
+    }
+
+    const pathOrName =
+      typeof File !== "undefined" && body instanceof File
+        ? (body as any).path || body.name || "<binary-file>"
+        : "<binary-file>"
+
     return {
       mimeType: req.body.contentType,
-      text: body,
+      text: `@${pathOrName}`,
     }
   }
-
-  const pathOrName =
-    typeof File !== "undefined" && body instanceof File
-      ? (body as any).path || body.name || "<binary-file>"
-      : "<binary-file>"
-
-  return {
-    mimeType: req.body.contentType,
-    text: `@${pathOrName}`,
-  }
-}
 
   return {
     mimeType: req.body.contentType, // Let's assume by default content type is JSON

--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -119,16 +119,26 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
   // "[object File]" which causes HTTPSnippet to throw and code generation to
   // fail entirely.
   if (req.body.contentType === "application/octet-stream") {
-    const file = req.body.body as File | Blob | null
-    const pathOrName =
-      typeof File !== "undefined" && file instanceof File
-        ? (file as any).path || file.name || "<binary-file>"
-        : "<binary-file>"
+  const body = req.body.body
+
+  // Preserve string if it ever exists
+  if (typeof body === "string") {
     return {
       mimeType: req.body.contentType,
-      text: `@${pathOrName}`,
+      text: body,
     }
   }
+
+  const pathOrName =
+    typeof File !== "undefined" && body instanceof File
+      ? (body as any).path || body.name || "<binary-file>"
+      : "<binary-file>"
+
+  return {
+    mimeType: req.body.contentType,
+    text: `@${pathOrName}`,
+  }
+}
 
   return {
     mimeType: req.body.contentType, // Let's assume by default content type is JSON

--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -114,6 +114,22 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
     }
   }
 
+  // For binary file uploads (application/octet-stream), req.body.body is a
+  // File/Blob object, NOT a string. Casting it to string would produce
+  // "[object File]" which causes HTTPSnippet to throw and code generation to
+  // fail entirely.
+  if (req.body.contentType === "application/octet-stream") {
+    const file = req.body.body as File | Blob | null
+    const pathOrName =
+      file instanceof File
+        ? (file as any).path || file.name || "<binary-file>"
+        : "<binary-file>"
+    return {
+      mimeType: req.body.contentType,
+      text: `@${pathOrName}`,
+    }
+  }
+
   return {
     mimeType: req.body.contentType, // Let's assume by default content type is JSON
     text: (req.body.body as string) ?? "",

--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -121,7 +121,7 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
   if (req.body.contentType === "application/octet-stream") {
     const file = req.body.body as File | Blob | null
     const pathOrName =
-      file instanceof File
+      typeof File !== "undefined" && file instanceof File
         ? (file as any).path || file.name || "<binary-file>"
         : "<binary-file>"
     return {

--- a/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/har.ts
@@ -114,29 +114,26 @@ const buildHarPostData = (req: HoppRESTRequest): Har.PostData | undefined => {
     }
   }
 
-  // For binary file uploads (application/octet-stream), req.body.body is a
-  // File/Blob object, NOT a string. Casting it to string would produce
-  // "[object File]" which causes HTTPSnippet to throw and code generation to
-  // fail entirely.
+  // application/octet-stream bodies are File | null; emit @filename for file uploads
   if (req.body.contentType === "application/octet-stream") {
-    const body = req.body.body
+    const file = req.body.body
 
-    // Preserve string if it ever exists
-    if (typeof body === "string") {
+    if (!file) {
       return {
         mimeType: req.body.contentType,
-        text: body,
+        text: "",
       }
     }
 
-    const pathOrName =
-      typeof File !== "undefined" && body instanceof File
-        ? (body as any).path || body.name || "<binary-file>"
-        : "<binary-file>"
+    // `path` exists in some desktop runtimes; `name` is the standard File field.
+    const filename =
+      "path" in file && typeof file.path === "string" && file.path
+        ? file.path
+        : file.name || "<binary-file>"
 
     return {
       mimeType: req.body.contentType,
-      text: `@${pathOrName}`,
+      text: `@${filename}`,
     }
   }
 


### PR DESCRIPTION
Closes #5808

Code snippet generation (cURL, etc.) crashed with a "Something went wrong" toast when the request body was `application/octet-stream`. The `File` object was being cast to string, producing `"[object File]"` which HTTPSnippet couldn't parse.

### What's changed

- Handle `application/octet-stream` in `buildHarPostData` — return `text: ""` when no file is attached, and `@<path|name>` for file uploads
- Use `"path" in file` check for desktop-specific file path, falling back to `file.name`

### Notes to reviewers

The `application/octet-stream` body is `File | null` per the Zod schema in `body.ts`. The null case (no file selected) now produces an empty snippet instead of a misleading `@<binary-file>` placeholder. The `path` property is Electron/Node-specific and not part of the standard DOM File API.