### PR TITLE
fix(desktop): add native Edit menu to enable clipboard shortcuts on Linux

### DIFF
--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -11,7 +11,6 @@ pub mod webview;
 
 use std::sync::OnceLock;
 
-use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
 use tauri::Emitter;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_window_state::StateFlags;
@@ -167,7 +166,10 @@ pub fn run() {
         .setup(|app| {
             // Set up native Edit menu to enable standard clipboard shortcuts (copy, paste, etc.)
             // Required on Linux where webkit2gtk does not handle these without menu items
-            if cfg!(target_os = "linux") {
+            #[cfg(target_os = "linux")]
+            {
+                use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
+
                 let handle = app.handle();
                 let edit_menu = Submenu::with_items(
                     handle,

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod webview;
 
 use std::sync::OnceLock;
 
+use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
 use tauri::Emitter;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_window_state::StateFlags;
@@ -164,6 +165,27 @@ pub fn run() {
 
     let app = tauri::Builder::default()
         .setup(|app| {
+            // Set up native Edit menu to enable clipboard shortcuts (Ctrl+V, etc.)
+            // Required on Linux where webkit2gtk does not handle these without menu items
+            let handle = app.handle();
+            let edit_menu = Submenu::with_items(
+                handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(handle, None)?,
+                    &PredefinedMenuItem::redo(handle, None)?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::cut(handle, None)?,
+                    &PredefinedMenuItem::copy(handle, None)?,
+                    &PredefinedMenuItem::paste(handle, None)?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::select_all(handle, None)?,
+                ],
+            )?;
+            let menu = Menu::with_items(handle, &[&edit_menu])?;
+            app.set_menu(menu)?;
+
             tauri::async_runtime::block_on(async {
                 if let Err(e) = setup_version_backup(app).await {
                     tracing::error!(error = %e, "Failed to setup version backup");

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -170,24 +170,35 @@ pub fn run() {
             {
                 use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
 
-                let handle = app.handle();
-                let edit_menu = Submenu::with_items(
-                    handle,
-                    "Edit",
-                    true,
-                    &[
-                        &PredefinedMenuItem::undo(handle, None)?,
-                        &PredefinedMenuItem::redo(handle, None)?,
-                        &PredefinedMenuItem::separator(handle)?,
-                        &PredefinedMenuItem::cut(handle, None)?,
-                        &PredefinedMenuItem::copy(handle, None)?,
-                        &PredefinedMenuItem::paste(handle, None)?,
-                        &PredefinedMenuItem::separator(handle)?,
-                        &PredefinedMenuItem::select_all(handle, None)?,
-                    ],
-                )?;
-                let menu = Menu::with_items(handle, &[&edit_menu])?;
-                app.set_menu(menu)?;
+                let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+                    let handle = app.handle();
+                    let edit_menu = Submenu::with_items(
+                        handle,
+                        "Edit",
+                        true,
+                        &[
+                            &PredefinedMenuItem::undo(handle, None)?,
+                            &PredefinedMenuItem::redo(handle, None)?,
+                            &PredefinedMenuItem::separator(handle)?,
+                            &PredefinedMenuItem::cut(handle, None)?,
+                            &PredefinedMenuItem::copy(handle, None)?,
+                            &PredefinedMenuItem::paste(handle, None)?,
+                            &PredefinedMenuItem::separator(handle)?,
+                            &PredefinedMenuItem::select_all(handle, None)?,
+                        ],
+                    )?;
+                    // NOTE: This menu bar will be visible on Linux. Removing it or hiding it
+                    // also removes the accelerator registrations and breaks clipboard shortcuts
+                    // (webkit2gtk requires native menu items to recognise Ctrl+C/V/X etc.).
+                    // See https://github.com/tauri-apps/tauri/issues/2397
+                    let menu = Menu::with_items(handle, &[&edit_menu])?;
+                    app.set_menu(menu)?;
+                    Ok(())
+                })();
+
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, "Failed to set up native Edit menu; clipboard shortcuts may not work");
+                }
             }
 
             tauri::async_runtime::block_on(async {

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -165,26 +165,28 @@ pub fn run() {
 
     let app = tauri::Builder::default()
         .setup(|app| {
-            // Set up native Edit menu to enable clipboard shortcuts (Ctrl+V, etc.)
+            // Set up native Edit menu to enable standard clipboard shortcuts (copy, paste, etc.)
             // Required on Linux where webkit2gtk does not handle these without menu items
-            let handle = app.handle();
-            let edit_menu = Submenu::with_items(
-                handle,
-                "Edit",
-                true,
-                &[
-                    &PredefinedMenuItem::undo(handle, None)?,
-                    &PredefinedMenuItem::redo(handle, None)?,
-                    &PredefinedMenuItem::separator(handle)?,
-                    &PredefinedMenuItem::cut(handle, None)?,
-                    &PredefinedMenuItem::copy(handle, None)?,
-                    &PredefinedMenuItem::paste(handle, None)?,
-                    &PredefinedMenuItem::separator(handle)?,
-                    &PredefinedMenuItem::select_all(handle, None)?,
-                ],
-            )?;
-            let menu = Menu::with_items(handle, &[&edit_menu])?;
-            app.set_menu(menu)?;
+            if cfg!(target_os = "linux") {
+                let handle = app.handle();
+                let edit_menu = Submenu::with_items(
+                    handle,
+                    "Edit",
+                    true,
+                    &[
+                        &PredefinedMenuItem::undo(handle, None)?,
+                        &PredefinedMenuItem::redo(handle, None)?,
+                        &PredefinedMenuItem::separator(handle)?,
+                        &PredefinedMenuItem::cut(handle, None)?,
+                        &PredefinedMenuItem::copy(handle, None)?,
+                        &PredefinedMenuItem::paste(handle, None)?,
+                        &PredefinedMenuItem::separator(handle)?,
+                        &PredefinedMenuItem::select_all(handle, None)?,
+                    ],
+                )?;
+                let menu = Menu::with_items(handle, &[&edit_menu])?;
+                app.set_menu(menu)?;
+            }
 
             tauri::async_runtime::block_on(async {
                 if let Err(e) = setup_version_backup(app).await {

--- a/packages/hoppscotch-desktop/src-tauri/src/server.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/server.rs
@@ -139,8 +139,7 @@ mod tests {
         assert_eq!(serialized["access_token"], "token_value");
         assert_eq!(serialized["refresh_token"], "refresh_value");
 
-        let deserialized: AuthTokensQuery =
-            serde_json::from_value(serialized).unwrap();
+        let deserialized: AuthTokensQuery = serde_json::from_value(serialized).unwrap();
         assert_eq!(deserialized.access_token, original.access_token);
         assert_eq!(deserialized.refresh_token, original.refresh_token);
     }


### PR DESCRIPTION
## Description

Fixes #5871

Paste (Ctrl+V) from the system clipboard does not work in the script editor (and other editors) on the Linux desktop app. The issue is that webkit2gtk, which Tauri v2 uses as the WebView backend on Linux, requires native Edit menu items with `PredefinedMenuItem` accelerators for clipboard keyboard shortcuts to function properly in the WebView.

### Root Cause

On Linux, webkit2gtk does not automatically connect standard clipboard keyboard shortcuts (Ctrl+V, Ctrl+C, Ctrl+X) to the system clipboard in the WebView. Without native menu items that register these accelerators, paste from external applications fails while internal clipboard (copy/paste within the app) continues to work — exactly matching the behavior reported in #5871.

### Fix

Added a native Edit menu with `PredefinedMenuItem` items (Undo, Redo, Cut, Copy, Paste, Select All) to the Tauri app setup. These predefined menu items register the standard keyboard accelerators with the underlying platform, enabling proper clipboard integration on Linux.

This is the standard approach recommended by the Tauri ecosystem for clipboard support on Linux ([tauri-apps/tauri#2397](https://github.com/tauri-apps/tauri/issues/2397)).

### Changes

- **`packages/hoppscotch-desktop/src-tauri/src/lib.rs`**: Added native Edit menu with `PredefinedMenuItem` items in the app setup

### Testing

- Verified the Rust code compiles without warnings (only pre-existing `bundle.zip`/`manifest.json` build artifact errors remain)
- No JavaScript changes required — the fix operates at the native Tauri level
- The Edit menu with clipboard accelerators enables Ctrl+V, Ctrl+C, Ctrl+X, Ctrl+A in the WebView on all platforms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Edit menu on Linux in the desktop app so copy, paste, cut, and select all work in WebView editors. Linux-only; macOS and Windows menus are unchanged.

- **Bug Fixes**
  - Desktop (Linux): Add `Edit` menu via Tauri `PredefinedMenuItem` (Undo, Redo, Cut, Copy, Paste, Select All) in `packages/hoppscotch-desktop/src-tauri/src/lib.rs` to register clipboard accelerators.
  - Compile-time gated with `#[cfg(target_os = "linux")]`; logs a warning if setup fails; updated comment to use platform-neutral wording.

<sup>Written for commit ba025dc949c006d6a213393046840584fb8a2274. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

