### PR TITLE
fix(common): persist OAuth2 code challenge method selection

### DIFF
--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -196,7 +196,10 @@ export const useOAuth2GrantTypes = (
                 }
               : null,
           (value) => {
-            if (!value) {
+            if (
+              !value ||
+              auth.value.grantTypeInfo.grantType !== "AUTHORIZATION_CODE"
+            ) {
               return
             }
 

--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -196,7 +196,7 @@ export const useOAuth2GrantTypes = (
                 }
               : null,
           (value) => {
-            if (!("codeVerifierMethod" in auth.value.grantTypeInfo) || !value) {
+            if (!value) {
               return
             }
 


### PR DESCRIPTION
## Description

Fixes #5899

When setting the OAuth2 PKCE code challenge method to "SHA-256" in collection authorization preferences, the selection was lost after saving and reopening.

## Root Cause

The `codeVerifierMethod` field in the `AuthCodeGrantTypeParams` Zod schema is defined as `.optional()`. When a collection was imported or created before this field was added, Zod's `.optional()` omits the property entirely from the parsed output (the key doesn't exist on the object).

In `useOAuth2GrantTypes.ts`, the `refWithCallbackOnChange` callback for the code challenge dropdown had a guard:

```ts
if (!("codeVerifierMethod" in auth.value.grantTypeInfo) || !value) {
  return
}
```

The `in` operator returns `false` when the property is absent (not just `undefined`), so the callback would silently bail out and never write the selected method back to the auth config. On reload, the initializer would fall through to the default `"plain"` value.

## Fix

Remove the `"codeVerifierMethod" in auth.value.grantTypeInfo` guard. This code only runs inside the `AUTHORIZATION_CODE` grant type block where `codeVerifierMethod` is always a valid field to set. The `!value` check is sufficient to prevent writes when PKCE is disabled.

## Testing

- All 679 existing tests pass (1 pre-existing unrelated failure in persistence service)
- All lint checks pass (0 errors, only pre-existing warnings)
- Type checking passes across all 14 workspace packages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the OAuth2 PKCE code challenge method selection in collection authorization settings. Drops the property-existence guard so SHA-256 or plain are saved for legacy collections, and adds an explicit AUTHORIZATION_CODE grant type check to only write when that grant is active.

<sup>Written for commit 51600c42210a55841d3a8645df19bca3ddac19b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

