### PR TITLE
fix(common): update documentation link for mock server

### DIFF
--- a/packages/hoppscotch-common/src/components/mockServer/MockServerDashboard.vue
+++ b/packages/hoppscotch-common/src/components/mockServer/MockServerDashboard.vue
@@ -22,7 +22,7 @@
       <span class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/documentation/features/mock-servers"
+          to="https://docs.hoppscotch.io/documentation/features/mock"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
+++ b/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
@@ -58,7 +58,7 @@
         />
         <HoppSmartAnchor
           blank
-          to="http://docs.hoppscotch.io"
+          to="https://docs.hoppscotch.io"
           :icon="IconBookOpenText"
           :label="t('app.read_documentation')"
         />


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- No linked issue -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR ensures documentation links related to mock servers.

### What's changed

- Updated the mock server documentation link in `MockServerDashboard.vue` points to `https://docs.hoppscotch.io/documentation/features/mock`, which matches the canonical “API Mocking” docs page.

### Notes to reviewers

- Scope is intentionally small and limited to documentation URL correctness.
- No functional behavior changes beyond the updated docs link target and protocol.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs links to the correct canonical pages and enforce HTTPS. No behavior changes, only link targets.

- **Bug Fixes**
  - Mock Server Dashboard: link updated from /features/mock-servers to /features/mock.
  - Admin setup (DataSharingAndNewsletter): docs link switched from http to https.

<sup>Written for commit d1b0fbec50e5320e136dfae304f96a9a5f70d42f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

