### PR TITLE
Improve browser network error message with CORS hint

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -670,8 +670,9 @@
   },
   "error": {
     "network": {
-      "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+     "heading": "Network Error",
+     "description": "Network connection failed. {message}: {cause}",
+     "cors_hint": "The request was blocked by the browser, likely due to CORS restrictions. Consider using Proxy or Agent mode."
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
@@ -87,11 +87,18 @@ export class BrowserKernelInterceptorService
               },
               description: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
-                  case "network":
+                  case "network": {
+                     const isUnknownCause = !error.cause
+
+                      const causeMessage = isUnknownCause
+                        ? t("error.network.cors_hint")
+                        : error.cause
+
                     return t("error.network.description", {
-                      message: error.message,
-                      cause: error.cause ?? t("error.unknown.cause"),
-                    })
+                    message: error.message,
+                     cause: causeMessage,
+                      })
+                   }
                   case "timeout":
                     return t("error.timeout.description", {
                       message: error.message,


### PR DESCRIPTION


This PR improves the browser network error message by making it clear when a request is likely blocked due to CORS restrictions.

before, the error message could be confusing for users, especially when the exact cause was not available.so now  This update adds a more helpful hint suggesting that the issue might be related to CORS and recommends using Proxy or Agent mode.

While working in Browser mode, users often encounter CORS-related issues. The earlier message did not clearly explain that the browser might be blocking the request. now this small improvement makes the error more informative and beginner friendly.

The changes we did is ...
- Updated the `en.json` translation to include a clearer CORS hint  nd 
- Improved browser preventer logic to display the hint when appropriate .



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies browser network errors by showing a CORS hint when the cause is unknown. Helps Browser mode users understand blocked requests and suggests Proxy or Agent mode.

- **New Features**
  - Browser interceptor uses a CORS hint as the cause when error.cause is missing.
  - Added error.network.cors_hint to en.json and wired it into the network error description.

<sup>Written for commit 4244e122c1cd1d46ef267b0879d5b545702f848b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

