### PR TITLE
fix(jsonc): prevent blank lines from commented JSON fields

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -1,4 +1,4 @@
-import { Node, parseTree, stripComments as stripComments_ } from "jsonc-parser"
+import { Node, parseTree} from "jsonc-parser"
 import jsoncParse from "~/helpers/jsoncParse"
 import { convertIndexToLineCh } from "../utils"
 import { LinterDefinition, LinterResult } from "./linter"

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -102,7 +102,7 @@ function stripCommentsAndCommas(text: string): string {
  */
 
 export function stripComments(jsonString: string) {
-  return stripCommentsAndCommas(stripComments_(jsonString) ?? jsonString)
+  return stripCommentsAndCommas(jsonString)
 }
 
 export default linter


### PR DESCRIPTION
Closes #5629

This PR fixes an issue where commented lines in JSON request bodies generate extra blank lines in the final request sent over the wire, particularly visible in the desktop app.

The issue was caused by the `stripComments` helper performing a redundant preprocessing step using `jsonc-parser.stripComments`. This function replaces comment text with whitespace to preserve character offsets, which can leave whitespace-only lines in the processed body when fallback paths are triggered.

Since `stripCommentsAndCommas` already parses JSONC using `jsonc-parser.parseTree` (which natively ignores comments), the additional preprocessing step is unnecessary and can lead to malformed whitespace.

### What's changed

- Removed the redundant `stripComments_` preprocessing step in `stripComments`.
- Passed the original JSONC string directly to `stripCommentsAndCommas`.
- Prevented whitespace-only lines from appearing in the final request body when comments are removed.

### Notes to reviewers

`stripCommentsAndCommas` already uses `jsonc-parser.parseTree`, which supports JSONC syntax including comments. Removing the `stripComments_` pre-pass simplifies the pipeline and avoids introducing whitespace padding from comment stripping.

Tested with:
- multiple commented lines
- inline comments
- trailing comma scenarios

This ensures the final request body remains correctly formatted without extra blank lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent extra blank lines in JSON request bodies when JSONC comments are used. stripComments now passes the original JSONC string to stripCommentsAndCommas, removing the redundant pre-pass that inserted whitespace-only lines and cleaning up the unused stripComments_ import.

<sup>Written for commit 1b8b3cd1e65d44f7e210e03c4ace519a84e5b2c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

