### PR TITLE
fix(common): use operation title as fallback in OpenAPI import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -120,16 +120,18 @@ type OpenAPIOperationType =
   | OpenAPIV3.OperationObject
   | OpenAPIV31.OperationObject
 
-// Resolves request name from OpenAPI operation: operationId > summary > title > fallback
-// NOTE: Unlike the previous `??`-based implementation, empty and whitespace-only strings
-// are now skipped (e.g. operationId = " " will fall through to the next candidate).
+// Resolve request name: operationId > summary > title > "Untitled Request"
 const getOpenAPIOperationName = (info: OpenAPIOperationType): string => {
   const title =
     objectHasProperty(info, "title") && typeof info.title === "string"
       ? info.title
       : undefined
 
-  const candidates: Array<string | undefined> = [info.operationId, info.summary, title]
+  const candidates: Array<string | undefined> = [
+    info.operationId,
+    info.summary,
+    title,
+  ]
 
   for (const candidate of candidates) {
     if (typeof candidate === "string") {

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -121,13 +121,15 @@ type OpenAPIOperationType =
   | OpenAPIV31.OperationObject
 
 // Resolves request name from OpenAPI operation: operationId > summary > title > fallback
+// NOTE: Unlike the previous `??`-based implementation, empty and whitespace-only strings
+// are now skipped (e.g. operationId = " " will fall through to the next candidate).
 const getOpenAPIOperationName = (info: OpenAPIOperationType): string => {
   const title =
     objectHasProperty(info, "title") && typeof info.title === "string"
       ? info.title
       : undefined
 
-  const candidates: Array<unknown> = [info.operationId, info.summary, title]
+  const candidates: Array<string | undefined> = [info.operationId, info.summary, title]
 
   for (const candidate of candidates) {
     if (typeof candidate === "string") {

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -121,11 +121,25 @@ type OpenAPIOperationType =
   | OpenAPIV31.OperationObject
 
 // Resolves request name from OpenAPI operation: operationId > summary > title > fallback
-const getOpenAPIOperationName = (info: OpenAPIOperationType): string =>
-  info.operationId ??
-  info.summary ??
-  (info as any).title ??
-  "Untitled Request"
+const getOpenAPIOperationName = (info: OpenAPIOperationType): string => {
+  const title =
+    objectHasProperty(info, "title") && typeof info.title === "string"
+      ? info.title
+      : undefined
+
+  const candidates: Array<unknown> = [info.operationId, info.summary, title]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim()
+      if (trimmed !== "") {
+        return trimmed
+      }
+    }
+  }
+
+  return "Untitled Request"
+}
 
 // Removes the OpenAPI Path Templating to the Hoppscotch Templating (<< ? >>)
 const replaceOpenApiPathTemplating = flow(

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -120,6 +120,13 @@ type OpenAPIOperationType =
   | OpenAPIV3.OperationObject
   | OpenAPIV31.OperationObject
 
+// Resolves request name from OpenAPI operation: operationId > summary > title > fallback
+const getOpenAPIOperationName = (info: OpenAPIOperationType): string =>
+  info.operationId ??
+  info.summary ??
+  (info as any).title ??
+  "Untitled Request"
+
 // Removes the OpenAPI Path Templating to the Hoppscotch Templating (<< ? >>)
 const replaceOpenApiPathTemplating = flow(
   S.replace(/{/g, "<<"),
@@ -1039,7 +1046,7 @@ const convertPathToHoppReqs = (
         }
       } = {
         request: makeRESTRequest({
-          name: info.operationId ?? info.summary ?? "Untitled Request",
+          name: getOpenAPIOperationName(info),
           description: info.description ?? null,
           method: method.toUpperCase(),
           endpoint,
@@ -1067,7 +1074,7 @@ const convertPathToHoppReqs = (
             doc,
             info,
             makeHoppRESTResponseOriginalRequest({
-              name: info.operationId ?? info.summary ?? "Untitled Request",
+              name: getOpenAPIOperationName(info),
               auth: parseOpenAPIAuth(doc, info),
               body: parseOpenAPIBody(doc, info),
               endpoint,


### PR DESCRIPTION

### What's changed

- [x] Extracted a `getOperationName` helper that centralises request name resolution during OpenAPI/Swagger import
- [x] Extended the fallback chain from `operationId → summary → "Untitled Request"` to `operationId → summary → title → "Untitled Request"`
- [x] Applied the helper to both `makeRESTRequest` and `makeHoppRESTResponseOriginalRequest` call sites in `convertPathToHoppReqs`
- [x] Used the existing `objectHasProperty` type guard to safely access `title` without introducing `any` casts

### Notes to reviewers

**Problem:** When importing an OpenAPI/Swagger spec where operations define `title` but omit both `operationId` and `summary`, every request shows as "Untitled Request". Several code-gen tools (e.g. certain Swagger generators) emit `title` on the operation object as a substitute for `summary`.

**Why `title`?** While `title` is not part of the official OpenAPI Operation Object schema, it appears in real-world specs often enough to warrant a fallback. The fix uses a safe runtime check (`objectHasProperty`) so it is a no-op for conforming specs that already have `operationId` or `summary`.

**Scope:** Single file change in `packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts`. No new dependencies, no API changes.

**Before:**
```
operationId ?? summary ?? "Untitled Request"
```

**After:**
```
operationId ?? summary ?? title ?? "Untitled Request"
```

---

## Summary by cubic

Ensure operation "title" is used as a fallback when "summary" is missing during OpenAPI import, so imported requests have better names.
Request names now resolve as: operationId > summary > title > "Untitled Request".

<sup>Written for commit 20948b388154bf8e8ea94e1b04b1d92278d0880c. Summary will update on new commits.</sup>