### PR TITLE
feat: improve network error message with CORS explanation

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -743,6 +743,8 @@
     "no_results_found": "No matches found",
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
+    "cors_likely_cause": "This is likely a CORS (Cross-Origin Resource Sharing) error",
+    "cors_explanation": "Browsers block requests to different domains for security. Use the browser extension or proxy to bypass this restriction.",
     "proxy_error": "Proxy error",
     "same_email_address": "Updated email address is same as the current email address",
     "same_profile_name": "Updated profile name is same as the current profile name",

--- a/packages/hoppscotch-common/src/components/settings/InterceptorErrorPlaceholder.vue
+++ b/packages/hoppscotch-common/src/components/settings/InterceptorErrorPlaceholder.vue
@@ -6,6 +6,16 @@
   >
     <template #body>
       <div class="my-1 flex flex-col items-center text-secondaryLight">
+        <div
+          class="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-left text-sm"
+        >
+          <p class="font-semibold text-amber-600 dark:text-amber-400">
+            {{ t("error.cors_likely_cause") }}
+          </p>
+          <p class="mt-1 text-secondaryLight">
+            {{ t("error.cors_explanation") }}
+          </p>
+        </div>
         <span>
           {{ t("error.please_install_extension") }}
         </span>


### PR DESCRIPTION
## Summary
Improves the user experience when encountering network failures by adding a clear explanation that CORS is likely the cause.

## Problem
When users make requests to APIs from different origins, browsers block these requests due to CORS policies. The current error message ("Network fail") doesn't explain why this happens or how to fix it, leading to confusion especially for new users.

## Solution
- Added a highlighted info box in the error placeholder explaining CORS as a likely cause
- Added new internationalization keys for the CORS explanation
- Suggests using the browser extension or proxy as solutions

## Screenshots
The error now shows:
> **This is likely a CORS (Cross-Origin Resource Sharing) error**
> Browsers block requests to different domains for security. Use the browser extension or proxy to bypass this restriction.

## Test plan
- [x] Verify the new message appears on network failures
- [x] Verify styling matches the existing UI (amber warning colors)
- [x] Verify i18n keys are properly added

## Related
This addresses a common pain point for new Hoppscotch users who don't understand why their API requests fail in the browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a highlighted CORS explanation to the network error placeholder so users understand why requests fail and how to fix them. Includes new i18n strings and warning styling that suggests using the browser extension or proxy.

- **New Features**
  - Show amber info box in InterceptorErrorPlaceholder explaining CORS as the likely cause.
  - Add i18n keys: error.cors_likely_cause and error.cors_explanation.

<sup>Written for commit 70838c95978f23185fee4af59196a94c5d324d50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

