### PR TITLE
fix(shortcuts): support non-English keyboard layouts by using Keyboar…

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -307,36 +307,32 @@ function generateKeybindingString(ev: KeyboardEvent): ShortcutKey | null {
 }
 
 function getPressedKey(ev: KeyboardEvent): Key | null {
-  // Sometimes the property code is not available on the KeyboardEvent object
   const key = (ev.key ?? "").toLowerCase()
+  const code = ev.code ?? ""
 
-  // Check arrow keys
+  // Use event.code for letters and digits so shortcuts work
+  // across different keyboard layouts (e.g., Russian)
+  if (code.startsWith("Key")) {
+    return code.slice(3).toLowerCase() as Key
+  }
+
+  if (code.startsWith("Digit")) {
+    return code.slice(5) as Key
+  }
+
+  // Arrow keys (ArrowUp → up)
   if (key.startsWith("arrow")) {
     return key.slice(5) as Key
   }
 
-  // Check for Tab key
   if (key === "tab") return "tab"
-
-  // Check for Delete key
   if (key === "delete") return "delete"
-
   if (key === "backspace") return "backspace"
 
-  // Check letter keys
-  const isLetter = key.length === 1 && key >= "a" && key <= "z"
-  if (isLetter) return key as Key
-
-  // Check if number keys
-  const isDigit = key.length === 1 && key >= "0" && key <= "9"
-  if (isDigit) return key as Key
-
-  // Check if slash, period or enter
+  // Punctuation and enter
   if (key === "/" || key === "." || key === "enter") return key
-
   if (key === "[" || key === "]") return key
 
-  // If no other cases match, this is not a valid key
   return null
 }
 

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -320,6 +320,11 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
     return code.slice(5) as Key
   }
 
+   // Handle numpad digits (Numpad0–Numpad9)
+  if (code.startsWith("Numpad") && code.length === 7) {
+    return code.slice(6) as Key
+  }
+
   // Arrow keys (ArrowUp → up)
   if (key.startsWith("arrow")) {
     return key.slice(5) as Key

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -317,6 +317,9 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
   }
 
   if (code.startsWith("Digit")) {
+    if (key === "/" || key === "." || key === "[" || key === "]") {
+      return key as Key
+    }
     return code.slice(5) as Key
   }
 


### PR DESCRIPTION
Closes #5944 

This PR fixes an issue where keyboard shortcuts do not work when the system keyboard layout is set to a non-English language (for example Russian). The problem occurs because the shortcuts rely on KeyboardEvent.key, which changes depending on the active keyboard layout.

To make shortcuts layout-independent, this change uses KeyboardEvent.code for detecting letter and digit keys.

What's changed

Updated the getPressedKey function in keybindings.ts.

Use KeyboardEvent.code instead of KeyboardEvent.key for detecting letter and digit keys.

Ensures shortcuts work correctly regardless of keyboard layout.

Kept existing logic for special keys such as arrows, punctuation, tab, delete, and backspace.

Notes to reviewers

KeyboardEvent.key depends on the active keyboard layout, which causes shortcuts to fail when users switch to layouts like Russian or German.
KeyboardEvent.code represents the physical key on the keyboard, making shortcuts consistent across different layouts while preserving existing behavior for special keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard shortcuts on non-English layouts by using KeyboardEvent.code for letters and digits, including numpad. Prevents shortcuts from breaking when switching to layouts like Russian or German.

- **Bug Fixes**
  - Updated getPressedKey in keybindings.ts to detect letters/digits via event.code (Key*/Digit*) and support numpad digits (Numpad0–9).
  - Adjusted precedence: use event.code first; fall back to event.key for arrows, tab, delete, backspace, punctuation, and enter, prioritizing punctuation over Digit codes when present.

<sup>Written for commit 637e48368327a4769842d2361addab4972899e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

