### PR TITLE
Fix hotkeys using event.key instead of event.code for non-English keyboards

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -307,7 +307,16 @@ function generateKeybindingString(ev: KeyboardEvent): ShortcutKey | null {
 }
 
 function getPressedKey(ev: KeyboardEvent): Key | null {
-  // Sometimes the property code is not available on the KeyboardEvent object
+  // For letter keys, use ev.code which is keyboard layout independent
+  // ev.key returns the character produced which varies by keyboard layout
+  const code = ev.code ?? ""
+
+  // Check for letter keys using code (KeyA, KeyB, etc.)
+  if (code.startsWith("Key") && code.length === 4) {
+    return code[3].toLowerCase() as Key
+  }
+
+  // For other keys, fall back to ev.key
   const key = (ev.key ?? "").toLowerCase()
 
   // Check arrow keys
@@ -323,13 +332,10 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
 
   if (key === "backspace") return "backspace"
 
-  // Check letter keys
-  const isLetter = key.length === 1 && key >= "a" && key <= "z"
-  if (isLetter) return key as Key
-
-  // Check if number keys
-  const isDigit = key.length === 1 && key >= "0" && key <= "9"
-  if (isDigit) return key as Key
+  // Check if number keys using code (Digit0, Digit1, etc.)
+  if (code.startsWith("Digit") && code.length === 6) {
+    return code[5] as Key
+  }
 
   // Check if slash, period or enter
   if (key === "/" || key === "." || key === "enter") return key

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -281,7 +281,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "q"
+          e.code === "KeyQ"
         ) {
           // Ctrl/Cmd + Q - Quit Application
           e.preventDefault()
@@ -292,7 +292,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "t"
+          e.code === "KeyT"
         ) {
           // Ctrl/Cmd + T - New Tab
           e.preventDefault()
@@ -303,7 +303,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "w"
+          e.code === "KeyW"
         ) {
           // Ctrl/Cmd + W - Close Tab
           e.preventDefault()
@@ -314,7 +314,7 @@ async function initApp() {
           isCtrlOrCmd &&
           e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "t"
+          e.code === "KeyT"
         ) {
           // Ctrl/Cmd + Shift + T - Reopen Tab
           e.preventDefault()


### PR DESCRIPTION
Fixes #5944. Keyboard shortcuts were using event.key which returns the character produced by a key press, varying by keyboard layout. This broke shortcuts for users with non-English keyboard layouts (e.g., Russian). Changed to use event.code which identifies the physical key position, making shortcuts work consistently across all keyboard layouts.

Changes:
- keybindings.ts: Updated getPressedKey() to use event.code for letter and digit keys
- main.ts: Changed hotkey checks from event.key.toLowerCase() to event.code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make keyboard shortcuts layout-agnostic by switching from event.key to event.code. Fixes #5944 and restores Ctrl/Cmd+Q/T/W (and Shift+T) on non-English keyboards.

- **Bug Fixes**
  - keybindings.ts: getPressedKey now uses ev.code for letters (KeyA–KeyZ) and digits (Digit0–9), with ev.key fallback for arrows, backspace, slash, period, and enter.
  - main.ts: Hotkey checks compare e.code ("KeyQ", "KeyT", "KeyW") with Ctrl/Cmd modifiers.

<sup>Written for commit fcc90f78b3f9e27f6446dcb9d618e19c0f82312b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

