### PR TITLE
fix: resolve invalid environment validation when publishing docs in personal workspace

### DIFF
--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -463,6 +463,12 @@ export const USER_ENVIRONMENT_UPDATE_FAILED =
   'user_environment/user_env_update_failed' as const;
 
 /**
+ * User environment not found for the user
+ * (UserEnvironmentsService)
+ */
+export const USER_ENVIRONMENT_NOT_FOUND = 'user_environment/not_found' as const;
+
+/**
  * User environment invalid environment name
  * (UserEnvironmentsService)
  */
@@ -977,8 +983,8 @@ export const PUBLISHED_DOCS_DELETION_FAILED = 'published_docs/deletion_failed';
  * Published Docs invalid environment
  * (PublishedDocsService)
  */
-export const PUBLISHED_DOCS_INVALID_ENVIRONMENT =
-  'published_docs/invalid_environment';
+export const PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS =
+  'published_docs/forbidden_environment_access';
 
 /**
  * Published Docs not found

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -1491,7 +1491,7 @@ describe('createPublishedDoc - environment support', () => {
       userUid: user.uid,
     } as any);
     mockPrisma.publishedDocs.findFirst.mockResolvedValueOnce(null);
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(envData as any);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(envData as any);
     mockPrisma.publishedDocs.create.mockResolvedValueOnce({
       ...userPublishedDoc,
       environmentID: 'env_1',
@@ -1537,7 +1537,7 @@ describe('createPublishedDoc - environment support', () => {
       teamID: 'team_1',
     } as any);
     mockPrisma.publishedDocs.findFirst.mockResolvedValueOnce(null);
-    mockPrisma.teamEnvironment.findFirst.mockResolvedValueOnce(envData as any);
+    mockPrisma.teamEnvironment.findUnique.mockResolvedValueOnce(envData as any);
     mockPrisma.publishedDocs.create.mockResolvedValueOnce({
       ...teamPublishedDoc,
       environmentID: 'team_env_1',
@@ -1568,7 +1568,7 @@ describe('createPublishedDoc - environment support', () => {
       userUid: user.uid,
     } as any);
     mockPrisma.publishedDocs.findFirst.mockResolvedValueOnce(null);
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.createPublishedDoc(
       { ...createArgs, environmentID: 'invalid_env' },
@@ -1593,7 +1593,7 @@ describe('createPublishedDoc - environment support', () => {
       teamID: 'team_1',
     } as any);
     mockPrisma.publishedDocs.findFirst.mockResolvedValueOnce(null);
-    mockPrisma.teamEnvironment.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.teamEnvironment.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.createPublishedDoc(
       teamArgs,
@@ -1640,7 +1640,7 @@ describe('updatePublishedDoc - environment support', () => {
     };
 
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(userPublishedDoc);
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(envData as any);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(envData as any);
     mockPrisma.publishedDocs.update.mockResolvedValueOnce({
       ...userPublishedDoc,
       environmentID: 'env_2',
@@ -1701,7 +1701,7 @@ describe('updatePublishedDoc - environment support', () => {
 
   test('should return error when updating with invalid environment ID', async () => {
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(userPublishedDoc);
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.updatePublishedDoc(
       userPublishedDoc.id,
@@ -1743,7 +1743,7 @@ describe('updatePublishedDoc - environment support', () => {
 
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(teamPublishedDoc);
     mockPrisma.team.findFirst.mockResolvedValueOnce({ id: 'team_1' } as any);
-    mockPrisma.teamEnvironment.findFirst.mockResolvedValueOnce(envData as any);
+    mockPrisma.teamEnvironment.findUnique.mockResolvedValueOnce(envData as any);
     mockPrisma.publishedDocs.update.mockResolvedValueOnce({
       ...teamPublishedDoc,
       environmentID: 'team_env_1',
@@ -1796,7 +1796,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
     mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(envData as any);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(envData as any);
 
     const result = await publishedDocsService.getPublishedDocBySlugPublic(
       'slug-collection-1',
@@ -1894,7 +1894,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
       E.right(collectionData as any),
     );
     // Environment not found — fetchEnvironment returns Left
-    mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.userEnvironment.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.getPublishedDocBySlugPublic(
       'slug-collection-1',

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -4,10 +4,12 @@ import {
   PUBLISHED_DOCS_CREATION_FAILED,
   PUBLISHED_DOCS_DELETION_FAILED,
   PUBLISHED_DOCS_INVALID_COLLECTION,
-  PUBLISHED_DOCS_INVALID_ENVIRONMENT,
+  PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS,
   PUBLISHED_DOCS_NOT_FOUND,
   PUBLISHED_DOCS_UPDATE_FAILED,
+  TEAM_ENVIRONMENT_NOT_FOUND,
   TEAM_INVALID_ID,
+  USER_ENVIRONMENT_NOT_FOUND,
 } from 'src/errors';
 import * as E from 'fp-ts/Either';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -1575,7 +1577,7 @@ describe('createPublishedDoc - environment support', () => {
       user,
     );
 
-    expect(result).toEqualLeft(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    expect(result).toEqualLeft(USER_ENVIRONMENT_NOT_FOUND);
   });
 
   test('should return error when team environment ID is invalid', async () => {
@@ -1600,7 +1602,7 @@ describe('createPublishedDoc - environment support', () => {
       user,
     );
 
-    expect(result).toEqualLeft(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    expect(result).toEqualLeft(TEAM_ENVIRONMENT_NOT_FOUND);
   });
 
   test('should create published doc without environment when environmentID is not provided', async () => {
@@ -1709,7 +1711,7 @@ describe('updatePublishedDoc - environment support', () => {
       user,
     );
 
-    expect(result).toEqualLeft(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    expect(result).toEqualLeft(USER_ENVIRONMENT_NOT_FOUND);
   });
 
   test('should not change environment when environmentID is not provided in update args', async () => {
@@ -1901,7 +1903,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
       '1.0.0',
     );
 
-    expect(result).toEqualLeft(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    expect(result).toEqualLeft(USER_ENVIRONMENT_NOT_FOUND);
   });
 
   test('should return null environment fields when no environment is associated', async () => {

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -96,27 +96,48 @@ export class PublishedDocsService {
    * Fetch environment by ID based on workspace type
    * Returns the environment name and variables, or an error if not found
    */
-  private async fetchEnvironment(
-    environmentID: string,
-    workspaceType: WorkspaceType,
-    workspaceID: string,
-  ): Promise<E.Either<string, { name: string; variables: JsonValue } | null>> {
-    if (workspaceType === WorkspaceType.TEAM) {
-      const env = await this.prisma.teamEnvironment.findFirst({
-        where: { id: environmentID, teamID: workspaceID },
-      });
-      if (!env) return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
-      return E.right({ name: env.name, variables: env.variables });
-    } else if (workspaceType === WorkspaceType.USER) {
-      const env = await this.prisma.userEnvironment.findFirst({
-        where: { id: environmentID, userUid: workspaceID },
-      });
-      if (!env) return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
-      return E.right({ name: env.name ?? '', variables: env.variables });
+ private async fetchEnvironment(
+  environmentID: string,
+  workspaceType: WorkspaceType,
+  workspaceID: string,
+): Promise<E.Either<string, { name: string; variables: JsonValue } | null>> {
+
+  // TEAM workspace environment
+  if (workspaceType === WorkspaceType.TEAM) {
+    const env = await this.prisma.teamEnvironment.findUnique({
+      where: { id: environmentID },
+    });
+
+    // Validate environment exists and belongs to the correct team
+    if (!env || env.teamID !== workspaceID) {
+      return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
     }
 
-    return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    return E.right({
+      name: env.name,
+      variables: env.variables,
+    });
   }
+
+  // USER workspace environment
+  if (workspaceType === WorkspaceType.USER) {
+    const env = await this.prisma.userEnvironment.findUnique({
+      where: { id: environmentID },
+    });
+
+    // Validate environment exists and belongs to the correct user
+    if (!env || env.userUid !== workspaceID) {
+      return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    }
+
+    return E.right({
+      name: env.name ?? '',
+      variables: env.variables,
+    });
+  }
+
+  return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+}
 
   /**
    * Check if user has access to a team with specific roles

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -100,7 +100,7 @@ export class PublishedDocsService {
   environmentID: string,
   workspaceType: WorkspaceType,
   workspaceID: string,
-): Promise<E.Either<string, { name: string; variables: JsonValue } | null>> {
+): Promise<E.Either<string, { name: string; variables: JsonValue }>> {
 
   // TEAM workspace environment
   if (workspaceType === WorkspaceType.TEAM) {

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -96,48 +96,47 @@ export class PublishedDocsService {
    * Fetch environment by ID based on workspace type
    * Returns the environment name and variables, or an error if not found
    */
- private async fetchEnvironment(
-  environmentID: string,
-  workspaceType: WorkspaceType,
-  workspaceID: string,
-): Promise<E.Either<string, { name: string; variables: JsonValue }>> {
+  private async fetchEnvironment(
+    environmentID: string,
+    workspaceType: WorkspaceType,
+    workspaceID: string,
+  ): Promise<E.Either<string, { name: string; variables: JsonValue }>> {
+    // TEAM workspace environment
+    if (workspaceType === WorkspaceType.TEAM) {
+      const env = await this.prisma.teamEnvironment.findUnique({
+        where: { id: environmentID },
+      });
 
-  // TEAM workspace environment
-  if (workspaceType === WorkspaceType.TEAM) {
-    const env = await this.prisma.teamEnvironment.findUnique({
-      where: { id: environmentID },
-    });
+      // Validate environment exists and belongs to the correct team
+      if (!env || env.teamID !== workspaceID) {
+        return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+      }
 
-    // Validate environment exists and belongs to the correct team
-    if (!env || env.teamID !== workspaceID) {
-      return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+      return E.right({
+        name: env.name,
+        variables: env.variables,
+      });
     }
 
-    return E.right({
-      name: env.name,
-      variables: env.variables,
-    });
-  }
+    // USER workspace environment
+    if (workspaceType === WorkspaceType.USER) {
+      const env = await this.prisma.userEnvironment.findUnique({
+        where: { id: environmentID },
+      });
 
-  // USER workspace environment
-  if (workspaceType === WorkspaceType.USER) {
-    const env = await this.prisma.userEnvironment.findUnique({
-      where: { id: environmentID },
-    });
+      // Validate environment exists and belongs to the correct user
+      if (!env || env.userUid !== workspaceID) {
+        return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+      }
 
-    // Validate environment exists and belongs to the correct user
-    if (!env || env.userUid !== workspaceID) {
-      return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+      return E.right({
+        name: env.name ?? '',
+        variables: env.variables,
+      });
     }
 
-    return E.right({
-      name: env.name ?? '',
-      variables: env.variables,
-    });
+    return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
   }
-
-  return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
-}
 
   /**
    * Check if user has access to a team with specific roles
@@ -389,10 +388,8 @@ export class PublishedDocsService {
         );
         if (E.isLeft(envResult)) return E.left(envResult.left);
 
-        if (E.isRight(envResult) && envResult.right) {
-          environmentName = envResult.right.name;
-          environmentVariables = envResult.right.variables;
-        }
+        environmentName = envResult.right.name;
+        environmentVariables = envResult.right.variables;
       }
 
       docToReturn = {
@@ -598,10 +595,9 @@ export class PublishedDocsService {
           workspaceID,
         );
         if (E.isLeft(envResult)) return E.left(envResult.left);
-        if (envResult.right) {
-          environmentName = envResult.right.name;
-          environmentVariables = envResult.right.variables;
-        }
+
+        environmentName = envResult.right.name;
+        environmentVariables = envResult.right.variables;
       }
 
       // Attempt to create the published document
@@ -718,11 +714,10 @@ export class PublishedDocsService {
             publishedDocs.workspaceID,
           );
           if (E.isLeft(envResult)) return E.left(envResult.left);
-          if (envResult.right) {
-            environmentID = args.environmentID;
-            environmentName = envResult.right.name;
-            environmentVariables = envResult.right.variables;
-          }
+
+          environmentID = args.environmentID;
+          environmentName = envResult.right.name;
+          environmentVariables = envResult.right.variables;
         }
       }
 

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -13,12 +13,14 @@ import {
   PUBLISHED_DOCS_CREATION_FAILED,
   PUBLISHED_DOCS_DELETION_FAILED,
   PUBLISHED_DOCS_INVALID_COLLECTION,
-  PUBLISHED_DOCS_INVALID_ENVIRONMENT,
+  PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS,
   PUBLISHED_DOCS_NOT_FOUND,
   PUBLISHED_DOCS_UPDATE_FAILED,
+  TEAM_ENVIRONMENT_NOT_FOUND,
   TEAM_INVALID_COLL_ID,
   TEAM_INVALID_ID,
   USER_COLL_NOT_FOUND,
+  USER_ENVIRONMENT_NOT_FOUND,
 } from 'src/errors';
 import * as E from 'fp-ts/Either';
 import { PublishedDocs, PublishedDocsVersion } from './published-docs.model';
@@ -106,11 +108,11 @@ export class PublishedDocsService {
       const env = await this.prisma.teamEnvironment.findUnique({
         where: { id: environmentID },
       });
+      if (!env) return E.left(TEAM_ENVIRONMENT_NOT_FOUND);
 
       // Validate environment exists and belongs to the correct team
-      if (!env || env.teamID !== workspaceID) {
-        return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
-      }
+      if (env.teamID !== workspaceID)
+        return E.left(PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS);
 
       return E.right({
         name: env.name,
@@ -123,10 +125,11 @@ export class PublishedDocsService {
       const env = await this.prisma.userEnvironment.findUnique({
         where: { id: environmentID },
       });
+      if (!env) return E.left(USER_ENVIRONMENT_NOT_FOUND);
 
       // Validate environment exists and belongs to the correct user
-      if (!env || env.userUid !== workspaceID) {
-        return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+      if (env.userUid !== workspaceID) {
+        return E.left(PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS);
       }
 
       return E.right({
@@ -135,7 +138,7 @@ export class PublishedDocsService {
       });
     }
 
-    return E.left(PUBLISHED_DOCS_INVALID_ENVIRONMENT);
+    return E.left(PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS);
   }
 
   /**


### PR DESCRIPTION
Closes #5952

What's changed

Fixed an issue where publishing documentation in a personal workspace with an environment selected resulted in the error published_docs/invalid_environment.

Updated the fetchEnvironment method in published-docs.service.ts to fetch environments by ID first, and then validate workspace ownership in code.

This prevents false negatives caused by overly strict Prisma query filters while maintaining correct access validation.

Notes to reviewers

The previous implementation queried environments using both id and workspace ownership in the Prisma where clause. In some cases this returned null even when the environment existed.

The new implementation retrieves the environment by ID and then validates ownership (teamID or userUid) explicitly.

This keeps the authorization checks intact while resolving the error when publishing docs from personal workspaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes environment validation for published docs in personal and team workspaces by fetching environments by ID and checking ownership. Replaces the generic invalid error with precise not-found/forbidden errors. Closes #5952.

- **Bug Fixes**
  - Use `findUnique(id)` for `userEnvironment` and `teamEnvironment`, then validate `userUid`/`teamID`.
  - Return `USER_ENVIRONMENT_NOT_FOUND`/`TEAM_ENVIRONMENT_NOT_FOUND` or `PUBLISHED_DOCS_FORBIDDEN_ENVIRONMENT_ACCESS` instead of a single invalid error.
  - `fetchEnvironment` now always returns env data; callers set name/variables in create/update/get flows, and tests are updated.

<sup>Written for commit 4fcc81a5e7aded1ac69458eca1aa2ec0c17b056a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

