### PR TITLE
fix: prevent modal content cutoff in tauri by removing fixed viewport…

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -8,7 +8,7 @@
     @close="hideModal"
   >
     <template #body>
-      <div class="w-full h-[80vh] overflow-hidden">
+      <div class="w-full h-full overflow-auto">
         <div class="flex h-full">
           <div class="flex-1 flex">
             <CollectionsDocumentationPreview


### PR DESCRIPTION
This fixes an issue where the documentation modal content was cut off in Tauri.

Previously the modal body used a fixed height:

<div class="w-full h-[80vh] overflow-hidden">

This could conflict with the modal container’s own height limits in Tauri, causing the bottom portion of the modal to become inaccessible even when scrolling.

The change replaces the fixed height with:

<div class="w-full h-full overflow-auto">

This allows the content to inherit the modal height and enables proper scrolling without clipping.

Fixes #5938

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents documentation modal content from being cut off in Tauri by removing the fixed viewport height and enabling scroll. Fixes #5938.

- **Bug Fixes**
  - Documentation modal body now uses h-full overflow-auto instead of h-[80vh] overflow-hidden, allowing content to inherit modal height and scroll in Tauri.

<sup>Written for commit 694f5a5bfe0132e8c23ea1c35ebcc8732ce76ad6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

