### PR TITLE
fix(common): prevent open redirect in enter page

### DIFF
--- a/packages/hoppscotch-common/src/pages/__tests__/enter-redirect.spec.ts
+++ b/packages/hoppscotch-common/src/pages/__tests__/enter-redirect.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { getSafeRedirectUrl } from "../enter-redirect"
+
+const ROOT = "hoppscotch.io"
+
+describe("getSafeRedirectUrl", () => {
+  it("allows a valid org subdomain", () => {
+    const result = getSafeRedirectUrl("acme.hoppscotch.io/enter", ROOT)
+    expect(result).not.toBeNull()
+    expect(result!.hostname).toBe("acme.hoppscotch.io")
+  })
+
+  it("allows the root domain itself", () => {
+    const result = getSafeRedirectUrl("hoppscotch.io/enter", ROOT)
+    expect(result).not.toBeNull()
+    expect(result!.hostname).toBe("hoppscotch.io")
+  })
+
+  it("rejects an external domain", () => {
+    expect(getSafeRedirectUrl("example.com", ROOT)).toBeNull()
+  })
+
+  it("rejects a domain that ends with the root but is not a subdomain", () => {
+    expect(getSafeRedirectUrl("evil-hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects backslashes (WHATWG normalization bypass)", () => {
+    expect(getSafeRedirectUrl("acme.hoppscotch.io\\@example.com", ROOT)).toBeNull()
+  })
+
+  it("rejects percent-encoded backslashes via URL parse failure", () => {
+    expect(getSafeRedirectUrl("%5C%5Cexample.com", ROOT)).toBeNull()
+  })
+
+  it("rejects auth-parameter attacks (@)", () => {
+    const result = getSafeRedirectUrl("hoppscotch.io@example.com", ROOT)
+    expect(result).toBeNull()
+  })
+
+  it("rejects percent-encoded null bytes via URL parse failure", () => {
+    expect(getSafeRedirectUrl("example.com%00.hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects empty input", () => {
+    expect(getSafeRedirectUrl("", ROOT)).toBeNull()
+  })
+
+  it("returns null when rootDomain is undefined", () => {
+    expect(getSafeRedirectUrl("acme.hoppscotch.io", undefined)).toBeNull()
+  })
+
+  it("returns null when rootDomain is empty string", () => {
+    expect(getSafeRedirectUrl("acme.hoppscotch.io", "")).toBeNull()
+  })
+
+  it("preserves path and query from the redirect value", () => {
+    const result = getSafeRedirectUrl("acme.hoppscotch.io/enter?foo=bar", ROOT)
+    expect(result).not.toBeNull()
+    expect(result!.pathname).toBe("/enter")
+    expect(result!.searchParams.get("foo")).toBe("bar")
+  })
+})

--- a/packages/hoppscotch-common/src/pages/__tests__/enter-redirect.spec.ts
+++ b/packages/hoppscotch-common/src/pages/__tests__/enter-redirect.spec.ts
@@ -24,11 +24,31 @@ describe("getSafeRedirectUrl", () => {
     expect(getSafeRedirectUrl("evil-hoppscotch.io", ROOT)).toBeNull()
   })
 
-  it("rejects backslashes (WHATWG normalization bypass)", () => {
-    expect(getSafeRedirectUrl("acme.hoppscotch.io\\@example.com", ROOT)).toBeNull()
+  it("rejects a domain that contains the root as an interior label", () => {
+    expect(
+      getSafeRedirectUrl("example.com.hoppscotch.io.attacker.com", ROOT)
+    ).toBeNull()
   })
 
-  it("rejects percent-encoded backslashes via URL parse failure", () => {
+  it("rejects backslashes (WHATWG normalization bypass)", () => {
+    expect(
+      getSafeRedirectUrl("acme.hoppscotch.io\\@example.com", ROOT)
+    ).toBeNull()
+  })
+
+  it("rejects tab characters (WHATWG strip bypass)", () => {
+    expect(getSafeRedirectUrl("evil.com\tacme.hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects newline characters (WHATWG strip bypass)", () => {
+    expect(getSafeRedirectUrl("evil.com\nacme.hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects carriage-return characters (WHATWG strip bypass)", () => {
+    expect(getSafeRedirectUrl("evil.com\racme.hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects percent-encoded backslashes", () => {
     expect(getSafeRedirectUrl("%5C%5Cexample.com", ROOT)).toBeNull()
   })
 
@@ -37,7 +57,17 @@ describe("getSafeRedirectUrl", () => {
     expect(result).toBeNull()
   })
 
-  it("rejects percent-encoded null bytes via URL parse failure", () => {
+  it("rejects userinfo on an allowed hostname", () => {
+    expect(
+      getSafeRedirectUrl("acme.hoppscotch.io@hoppscotch.io", ROOT)
+    ).toBeNull()
+  })
+
+  it("rejects userinfo with credentials on an allowed hostname", () => {
+    expect(getSafeRedirectUrl("user:pass@hoppscotch.io", ROOT)).toBeNull()
+  })
+
+  it("rejects percent-encoded null bytes", () => {
     expect(getSafeRedirectUrl("example.com%00.hoppscotch.io", ROOT)).toBeNull()
   })
 

--- a/packages/hoppscotch-common/src/pages/enter-redirect.ts
+++ b/packages/hoppscotch-common/src/pages/enter-redirect.ts
@@ -4,11 +4,14 @@ export function getSafeRedirectUrl(
 ): URL | null {
   if (!rootDomain) return null
 
-  // Reject backslashes to prevent WHATWG URL parser \ -> / normalization bypass
-  if (rawRedirect.includes("\\")) return null
+  // Reject characters the WHATWG URL parser normalizes or strips silently:
+  // backslash (\ -> /), tab, newline, carriage-return
+  if (/[\\\t\r\n]/.test(rawRedirect)) return null
 
   try {
     const target = new URL("https://" + rawRedirect)
+
+    if (target.username || target.password) return null
 
     const isAllowed =
       target.hostname.endsWith("." + rootDomain) ||

--- a/packages/hoppscotch-common/src/pages/enter-redirect.ts
+++ b/packages/hoppscotch-common/src/pages/enter-redirect.ts
@@ -1,0 +1,21 @@
+export function getSafeRedirectUrl(
+  rawRedirect: string,
+  rootDomain: string | undefined
+): URL | null {
+  if (!rootDomain) return null
+
+  // Reject backslashes to prevent WHATWG URL parser \ -> / normalization bypass
+  if (rawRedirect.includes("\\")) return null
+
+  try {
+    const target = new URL("https://" + rawRedirect)
+
+    const isAllowed =
+      target.hostname.endsWith("." + rootDomain) ||
+      target.hostname === rootDomain
+
+    return isAllowed ? target : null
+  } catch {
+    return null
+  }
+}

--- a/packages/hoppscotch-common/src/pages/enter.vue
+++ b/packages/hoppscotch-common/src/pages/enter.vue
@@ -29,18 +29,46 @@ export default defineComponent({
   beforeMount() {
     initializeApp()
   },
+  methods: {
+    getSafeRedirectUrl(rawRedirect: string): URL | null {
+      // Reject backslashes to prevent WHATWG URL parser \ -> / normalization bypass
+      if (rawRedirect.includes("\\")) return null
+
+      try {
+        const target = new URL("https://" + rawRedirect)
+        const rootDomain = platform.organization?.getRootDomain()
+        if (!rootDomain) return null
+
+        const isAllowed =
+          target.hostname.endsWith("." + rootDomain) ||
+          target.hostname === rootDomain
+
+        return isAllowed ? target : null
+      } catch {
+        return null
+      }
+    },
+  },
   async mounted() {
     const { redirect, ...queryParams } = this.route.query
 
-    if (redirect && Object.keys(queryParams).length) {
-      const url = new URL(("https://" + redirect) as string)
+    // Redirect param is only generated for cloud org subdomains (not the default instance)
+    if (platform.organization && typeof redirect === "string") {
+      const redirectTarget = this.getSafeRedirectUrl(redirect)
 
-      Object.entries(queryParams).forEach(([key, value]) => {
-        url.searchParams.set(key, value as string)
-      })
+      if (
+        redirectTarget &&
+        platform.auth.isSignInWithEmailLink(window.location.href)
+      ) {
+        Object.entries(queryParams).forEach(([key, value]) => {
+          if (typeof value === "string") {
+            redirectTarget.searchParams.set(key, value)
+          }
+        })
 
-      window.location.href = url.href
-      return
+        window.location.href = redirectTarget.href
+        return
+      }
     }
 
     this.signingInWithEmail = true

--- a/packages/hoppscotch-common/src/pages/enter.vue
+++ b/packages/hoppscotch-common/src/pages/enter.vue
@@ -33,8 +33,12 @@ export default defineComponent({
   async mounted() {
     const { redirect, ...queryParams } = this.route.query
 
-    // Redirect param is only generated for cloud org subdomains (not the default instance)
-    if (platform.organization && typeof redirect === "string") {
+    // Org subdomain magic-link flow: redirect back to the originating subdomain
+    if (
+      platform.organization &&
+      !platform.organization.isDefaultCloudInstance &&
+      typeof redirect === "string"
+    ) {
       const redirectTarget = getSafeRedirectUrl(
         redirect,
         platform.organization.getRootDomain()

--- a/packages/hoppscotch-common/src/pages/enter.vue
+++ b/packages/hoppscotch-common/src/pages/enter.vue
@@ -12,6 +12,7 @@ import { defineComponent } from "vue"
 import { useRoute } from "vue-router"
 import { initializeApp } from "~/helpers/app"
 import { platform } from "~/platform"
+import { getSafeRedirectUrl } from "./enter-redirect"
 
 export default defineComponent({
   setup() {
@@ -29,32 +30,15 @@ export default defineComponent({
   beforeMount() {
     initializeApp()
   },
-  methods: {
-    getSafeRedirectUrl(rawRedirect: string): URL | null {
-      // Reject backslashes to prevent WHATWG URL parser \ -> / normalization bypass
-      if (rawRedirect.includes("\\")) return null
-
-      try {
-        const target = new URL("https://" + rawRedirect)
-        const rootDomain = platform.organization?.getRootDomain()
-        if (!rootDomain) return null
-
-        const isAllowed =
-          target.hostname.endsWith("." + rootDomain) ||
-          target.hostname === rootDomain
-
-        return isAllowed ? target : null
-      } catch {
-        return null
-      }
-    },
-  },
   async mounted() {
     const { redirect, ...queryParams } = this.route.query
 
     // Redirect param is only generated for cloud org subdomains (not the default instance)
     if (platform.organization && typeof redirect === "string") {
-      const redirectTarget = this.getSafeRedirectUrl(redirect)
+      const redirectTarget = getSafeRedirectUrl(
+        redirect,
+        platform.organization.getRootDomain()
+      )
 
       if (
         redirectTarget &&


### PR DESCRIPTION
Addresses [GHSA-27pm-c9ch-746q](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-27pm-c9ch-746q).

Closes FE-1164.

The `redirect` query parameter on `/enter` was passed to `new URL()` without validation, allowing redirects to arbitrary external domains.


### What's changed

- Gate the redirect block behind `platform.organization` and `!isDefaultCloudInstance`, so deployments without org-subdomain support and the default cloud instance skip this path.
- Add `isSignInWithEmailLink` guard so `/enter` only redirects during an actual magic-link auth flow, preventing use as a generic redirector.
- Reject WHATWG-normalised characters (backslash, tab, newline, carriage-return) before URL parsing to prevent parser bypass vectors.
- Reject URLs with userinfo (`target.username` / `target.password`) to block phishing-pattern redirects.
- Extract redirect validation into a colocated helper (`enter-redirect.ts`).
- Add 18 unit tests covering representative allow/deny and bypass cases.

### Notes to reviewers

This preserves the intended cloud org magic-link flow where the user lands on the root domain and is redirected back to the organization subdomain after validation.

Deployments without org-subdomain support, and the default cloud instance, skip this redirect path.

Validate magic link flows for SH and cloud (default instance and org subdomain) to confirm no regression in sign-in behaviour.

| Input | Result |
|---|---|
| `?redirect=example.com` | Blocked |
| `?redirect=hoppscotch.io@example.com` | Blocked |
| `?redirect=acme.hoppscotch.io@hoppscotch.io` | Blocked (userinfo) |
| `?redirect=evil.com%0aacme.hoppscotch.io` | Blocked (control char) |
| `?redirect=example.com.hoppscotch.io.attacker.com` | Blocked (subdomain-confusion) |
| `?redirect=acme.hoppscotch.io/enter` | Allowed |