### PR TITLE
fix(common): merge path-level parameters in OpenAPI import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -1032,6 +1032,25 @@ const convertPathToHoppReqs = (
           ? openAPIUrl + openAPIPath.slice(1)
           : openAPIUrl + openAPIPath
 
+      // Merge path-level parameters with operation-level parameters.
+      // Per the OpenAPI spec, operation-level parameters override path-level
+      // parameters that share the same name and location (in).
+      const pathLevelParams =
+        (pathObj.parameters as OpenAPIParamsType[] | undefined) ?? []
+      const operationParams =
+        (info.parameters as OpenAPIParamsType[] | undefined) ?? []
+
+      const mergedParams = [
+        ...pathLevelParams.filter(
+          (pathParam) =>
+            !operationParams.some(
+              (opParam) =>
+                opParam.name === pathParam.name && opParam.in === pathParam.in
+            )
+        ),
+        ...operationParams,
+      ]
+
       const res: {
         request: HoppRESTRequest
         metadata: {
@@ -1045,12 +1064,8 @@ const convertPathToHoppReqs = (
           endpoint,
 
           // We don't need to worry about reference types as the Dereferencing pass should remove them
-          params: parseOpenAPIParams(
-            (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-          ),
-          headers: parseOpenAPIHeaders(
-            (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-          ),
+          params: parseOpenAPIParams(mergedParams),
+          headers: parseOpenAPIHeaders(mergedParams),
 
           auth: parseOpenAPIAuth(doc, info),
 
@@ -1059,9 +1074,7 @@ const convertPathToHoppReqs = (
           preRequestScript: "",
           testScript: "",
 
-          requestVariables: parseOpenAPIVariables(
-            (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-          ),
+          requestVariables: parseOpenAPIVariables(mergedParams),
 
           responses: parseOpenAPIResponses(
             doc,
@@ -1072,16 +1085,10 @@ const convertPathToHoppReqs = (
               body: parseOpenAPIBody(doc, info),
               endpoint,
               // We don't need to worry about reference types as the Dereferencing pass should remove them
-              params: parseOpenAPIParams(
-                (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-              ),
-              headers: parseOpenAPIHeaders(
-                (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-              ),
+              params: parseOpenAPIParams(mergedParams),
+              headers: parseOpenAPIHeaders(mergedParams),
               method: method.toUpperCase(),
-              requestVariables: parseOpenAPIVariables(
-                (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-              ),
+              requestVariables: parseOpenAPIVariables(mergedParams),
             })
           ),
         }),


### PR DESCRIPTION
## What does this PR do?

Fixes the OpenAPI import to correctly handle path-level parameters. Previously, only operation-level parameters were being extracted, so endpoints like `/resource/{classUnitType}/{classUnitCode}` would lose their path variables and render as `/resource//` after import.

## Why?

I was trying to import an OpenAPI 3.0 spec that had path parameters defined at the path item level (which is valid per the OpenAPI specification). All the path variables were missing from the imported requests — the URL showed empty segments instead of the variable placeholders.

In the OpenAPI spec, parameters can be defined both at the path item level (shared across all operations) and at the operation level (specific to GET, POST, etc.). The spec says operation-level parameters should override path-level ones with the same name and location.

## Changes

- Modified `convertPathToHoppReqs` in the OpenAPI import helper to merge `pathObj.parameters` (path-level) with `info.parameters` (operation-level)
- Operation-level parameters take precedence when there is a conflict (same name + same location)
- The merged parameter list is used for query params, headers, and request variables extraction
- Applied the same fix to the response original request construction

## Testing

- Verified all existing tests pass (680 tests in hoppscotch-common)
- TypeScript type checking passes
- ESLint passes with no new warnings
- Tested with the OpenAPI spec from the issue:
  ```yaml
  paths:
    /availabilityclassifications/{classUnitType}/{classUnitCode}:
      parameters:
        - name: classUnitType
          in: path
          required: true
          schema:
            type: string
        - name: classUnitCode
          in: path
          required: true
          schema:
            type: string
      get:
        summary: Test
        responses:
          '200':
            description: OK
  ```
  After the fix, the endpoint correctly shows `/availabilityclassifications/<<classUnitType>>/<<classUnitCode>>` with both variables in `requestVariables`.

## Related Issues

Closes #5860

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAPI import in `hoppscotch-common` to merge path-level and operation-level parameters. Preserves path variables in endpoints, with operation-level params overriding path-level ones.

- **Bug Fixes**
  - Merge `pathObj.parameters` with `info.parameters` before parsing.
  - Use the merged list for query params, headers, and `requestVariables`.
  - Apply the same logic when building the response’s original request.
  - Closes #5860.

<sup>Written for commit 1b1670671c21fc6848ad5a9f9163db9ecd6d7fad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

