### PR TITLE
fix(common): prevent stored XSS in team member overflow tooltip

### DIFF
--- a/packages/hoppscotch-common/assets/themes/tippy-themes.scss
+++ b/packages/hoppscotch-common/assets/themes/tippy-themes.scss
@@ -64,6 +64,15 @@
     }
   }
 
+  // Override truncation for multiline member-list tooltips
+  .tippy-box[data-theme~="member-list"] {
+    .tippy-content {
+      @apply whitespace-pre-line;
+      @apply block;
+      @apply overflow-auto;
+    }
+  }
+
   .tippy-box[data-theme~="popover"] {
     @apply bg-popover;
     @apply border-solid;

--- a/packages/hoppscotch-common/src/components/teams/MemberStack.vue
+++ b/packages/hoppscotch-common/src/components/teams/MemberStack.vue
@@ -15,7 +15,7 @@
     </div>
     <button
       v-if="props.showCount && props.teamMembers.length > maxMembersSoftLimit"
-      v-tippy="{ theme: 'tooltip', allowHTML: true }"
+      v-tippy="{ theme: 'tooltip member-list' }"
       :title="remainingSlicedMembers"
       class="text-[8px] z-10 inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-full bg-dividerDark text-secondaryDark ring-2 ring-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primaryDark"
       tabindex="0"
@@ -73,9 +73,9 @@ const remainingSlicedMembers = computed(
       .slice(maxMembersSoftLimit)
       .slice(0, maxMembersHardLimit)
       .map((member) => getUserWithRole(member as TeamMember))
-      .join(`,<br>`) +
+      .join(",\n") +
     (props.teamMembers.length - (maxMembersSoftLimit + maxMembersHardLimit) > 0
-      ? `,<br>${t("team.more_members", {
+      ? `,\n${t("team.more_members", {
           count:
             props.teamMembers.length -
             (maxMembersSoftLimit + maxMembersHardLimit),


### PR DESCRIPTION
Addresses [GHSA-vw93-4m6p-ccm9](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-vw93-4m6p-ccm9).
Closes FE-1165.

The team member overflow tooltip rendered user-controlled content as HTML, which allowed stored XSS in workspaces with 4+ members.

### What's changed

- Removed `allowHTML: true` from the `v-tippy` directive so content renders as plain text.
- Replaced `<br>` join separators with `\n` for newline-separated tooltip entries.
- Added `member-list` tippy theme variant with `white-space: pre-line` to preserve multiline rendering without HTML.

### Notes to reviewers

No intended visual change for typical member lists: the overflow tooltip continues to render as before, but display names are now treated as plain text.

Manual verification: use a team workspace with 4+ members where one member’s display name contains HTML markup. The overflow tooltip should render that markup as literal text rather than interpreting it as HTML.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stored XSS in the team member overflow tooltip by rendering member names as plain text and preserving multiline safely. Addresses FE-1165 and GHSA-vw93-4m6p-ccm9.

- **Bug Fixes**
  - Removed `allowHTML` from `v-tippy`; tooltip content is now plain text.
  - Switched `<br>` joins to "\n" and added a `member-list` tippy theme with `white-space: pre-line` to keep line breaks without HTML.
  - No visual changes expected; any markup in display names now appears as literal text.

<sup>Written for commit 94573eb84307742075b9c60c3c41966df4e82e8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

