### PR TITLE
fix(import): include scheme in OpenAPI v2 base URL

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -988,7 +988,8 @@ const parseOpenAPIUrl = (
     // add base url variable to each request
     const host = doc.host?.trim() || "<<baseUrl>>"
     const basePath = doc.basePath?.trim() || ""
-    return `${host}${basePath}`
+    const scheme = doc.schemes?.[0] ?? "https"
+    return `${scheme}://${host}${basePath}`
   }
 
   /**

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -986,8 +986,9 @@ const parseOpenAPIUrl = (
   if (objectHasProperty(doc, "swagger")) {
     // TODO: dynamically add doc.host, doc.basePath value as variables in the environment if available. or notify user to add it.
     // add base url variable to each request
-    const host = doc.host?.trim() || "<<baseUrl>>"
+    const host = doc.host?.trim() || ""
     const basePath = doc.basePath?.trim() || ""
+    if (!host) return "<<baseUrl>>"
     const scheme = doc.schemes?.[0] ?? "https"
     return `${scheme}://${host}${basePath}`
   }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -989,7 +989,7 @@ const parseOpenAPIUrl = (
     const host = doc.host?.trim() || ""
     const basePath = doc.basePath?.trim() || ""
     if (!host) return "<<baseUrl>>"
-    const scheme = doc.schemes?.[0] ?? "https"
+    const scheme = doc.schemes?.[0] || "https"
     return `${scheme}://${host}${basePath}`
   }
 


### PR DESCRIPTION
### Description

When importing Swagger 2.0 (OpenAPI v2) specifications, the base URL is currently built from only `host` and `basePath`, completely ignoring the `schemes` array. This produces URLs like `api.example.com/v1` instead of `https://api.example.com/v1`.

For example, given this Swagger 2.0 spec:
```yaml
host: petstore.swagger.io
basePath: /v2
schemes:
  - https
```

The importer currently generates: `petstore.swagger.io/v2`
Expected: `https://petstore.swagger.io/v2`

### Changes

In `parseOpenAPIUrl`, read the first entry from `doc.schemes` (falling back to `https` when the array is absent or empty) and prepend it to the constructed URL.

### Testing

- All 680 existing tests in `hoppscotch-common` pass
- Full typecheck passes across all packages
- Lint passes (0 errors, only pre-existing warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the scheme when constructing the base URL for Swagger 2.0 (OpenAPI v2) imports. Imported requests now use the correct protocol (e.g., https://petstore.swagger.io/v2).

- **Bug Fixes**
  - Prefix base URL with the first `schemes` entry; fall back to `https` when the array is missing or the entry is empty.
  - When `host` is missing, return `<<baseUrl>>` without a scheme to avoid double-scheme URLs after substitution.

<sup>Written for commit c9859f868e517f7022c34b2d96241e8152a1fad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

