### PR TITLE
fix(realtime): track manual vs server-initiated disconnects

### DIFF
--- a/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
@@ -122,7 +122,8 @@ export class SIOConnection {
   }
 
   private handleError(error: unknown, type: SIOErrorType) {
-    this.disconnect()
+    this.socket?.close()
+    this.connectionState$.next("DISCONNECTED")
     this.addEvent({
       time: Date.now(),
       type: "ERROR",

--- a/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
@@ -44,6 +44,7 @@ export class SIOConnection {
   connectionState$: BehaviorSubject<ConnectionState>
   event$: Subject<SIOEvent> = new Subject()
   socket: SIOClient | undefined
+  private manualDisconnect = false
   constructor() {
     this.connectionState$ = new BehaviorSubject<ConnectionState>("DISCONNECTED")
   }
@@ -106,8 +107,9 @@ export class SIOConnection {
         this.addEvent({
           type: "DISCONNECTED",
           time: Date.now(),
-          manual: true,
+          manual: this.manualDisconnect,
         })
+        this.manualDisconnect = false
       })
     } catch (error) {
       this.handleError(error, "CONNECTION")
@@ -158,6 +160,7 @@ export class SIOConnection {
   }
 
   disconnect() {
+    this.manualDisconnect = true
     this.socket?.close()
     this.connectionState$.next("DISCONNECTED")
   }

--- a/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
@@ -41,7 +41,7 @@ export class SSEConnection {
         }
         this.sse.onerror = (e) => {
           this.handleError(e)
-          this.stop()
+          this.stop(false)
         }
         this.sse.addEventListener(eventType, ({ data }) => {
           this.addEvent({
@@ -77,13 +77,13 @@ export class SSEConnection {
     })
   }
 
-  stop() {
+  stop(manual = true) {
     this.sse?.close()
     this.connectionState$.next("STOPPED")
     this.addEvent({
       type: "STOPPED",
       time: Date.now(),
-      manual: true,
+      manual,
     })
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
@@ -18,6 +18,7 @@ export class WSConnection {
   connectionState$: BehaviorSubject<ConnectionState>
   event$: Subject<WSEvent> = new Subject()
   socket: WebSocket | undefined
+  private manualDisconnect = false
 
   constructor() {
     this.connectionState$ = new BehaviorSubject<ConnectionState>("DISCONNECTED")
@@ -54,8 +55,9 @@ export class WSConnection {
         this.addEvent({
           type: "DISCONNECTED",
           time: Date.now(),
-          manual: true,
+          manual: this.manualDisconnect,
         })
+        this.manualDisconnect = false
       }
 
       this.socket.onmessage = ({ data }) => {
@@ -98,6 +100,7 @@ export class WSConnection {
   }
 
   disconnect() {
+    this.manualDisconnect = true
     this.socket?.close()
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
@@ -100,7 +100,13 @@ export class WSConnection {
   }
 
   disconnect() {
+    if (!this.socket) {
+      // Ensure stale manualDisconnect state is not carried over
+      this.manualDisconnect = false
+      return
+    }
+
     this.manualDisconnect = true
-    this.socket?.close()
+    this.socket.close()
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
@@ -80,7 +80,7 @@ export class WSConnection {
   }
 
   private handleError(error: WSErrorMessage) {
-    this.disconnect()
+    this.socket?.close()
     this.addEvent({
       time: Date.now(),
       type: "ERROR",


### PR DESCRIPTION
### Description

Closes #5987

Socket.IO, WebSocket, and SSE connections all hardcode `manual: true` on disconnect/stop events, making it impossible for the UI to distinguish between user-initiated disconnects and unexpected server-side connection drops.

MQTT already handles this correctly with a `manualDisconnect` flag — this PR brings the same pattern to the other three realtime protocols.

### Changes

**SIOConnection.ts & WSConnection.ts:**
- Added a `private manualDisconnect = false` flag
- Set it to `true` only in the user-facing `disconnect()` method
- Read and reset the flag in the disconnect/close event handler

**SSEConnection.ts:**
- Added a `manual` parameter to `stop()` (defaults to `true` for backward compatibility with the existing UI call `sse.value.stop()`)
- Internal error handler now calls `this.stop(false)` to correctly mark error-triggered stops as non-manual

### Testing

- All 680 existing tests in hoppscotch-common pass
- Full typecheck passes across all packages
- Lint passes (0 errors, only pre-existing warnings)
- Follows the exact same pattern already used and tested in `MQTTConnection.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes realtime disconnect events to correctly flag user-initiated vs server-side drops, so the UI can distinguish intentional disconnects from unexpected failures. Aligns Socket.IO, WebSocket, and SSE with the existing MQTT pattern.

- **Bug Fixes**
  - Socket.IO/WebSocket: add `manualDisconnect`; set only in `disconnect()`, read/reset in the close handler; error handlers now close sockets directly without toggling the flag; WebSocket `disconnect()` now resets the flag if no socket is present to avoid stale state.
  - SSE: add `stop(manual = true)`; internal error path calls `stop(false)` to mark non-manual stops.
  - Backward compatible: default `stop()` behavior unchanged for existing UI calls.

<sup>Written for commit bf75f5009b292f00d3432ddb8fb2d6c77ca5315c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

