### PR TITLE
fix(import): handle allOf in OpenAPI example body generation

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
@@ -108,11 +108,11 @@ const generateRequestBodyExampleFromSchemaObject = (
   }
 
   // For oneOf / anyOf, pick the first schema to generate an example
-  if (schemaObject.oneOf)
+  if (schemaObject.oneOf && schemaObject.oneOf.length > 0)
     return generateRequestBodyExampleFromSchemaObject(
       schemaObject.oneOf[0] as OpenAPIV3.SchemaObject
     )
-  if (schemaObject.anyOf)
+  if (schemaObject.anyOf && schemaObject.anyOf.length > 0)
     return generateRequestBodyExampleFromSchemaObject(
       schemaObject.anyOf[0] as OpenAPIV3.SchemaObject
     )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
@@ -76,22 +76,30 @@ const generateRequestBodyExampleFromSchemaObject = (
 ): RequestBodyExample => {
   if (schemaObject.example) return schemaObject.example as RequestBodyExample
 
-  // Merge all sub-schemas for allOf (used for inheritance / composition)
+  // Merge all sub-schemas for allOf (used for inheritance / composition).
+  // Constraint-only sub-schemas (e.g. those that only set "required")
+  // produce "" because they have no type — skip them to avoid replacing
+  // already-merged properties.
   if (schemaObject.allOf) {
     return schemaObject.allOf.reduce<RequestBodyExample>(
       (merged, subSchema) => {
         const sub = generateRequestBodyExampleFromSchemaObject(
           subSchema as OpenAPIV3.SchemaObject
         )
-        if (
+        const isMergedObject =
           typeof merged === "object" &&
           merged !== null &&
-          !Array.isArray(merged) &&
-          typeof sub === "object" &&
-          sub !== null &&
-          !Array.isArray(sub)
-        ) {
+          !Array.isArray(merged)
+        const isSubObject =
+          typeof sub === "object" && sub !== null && !Array.isArray(sub)
+
+        if (isMergedObject && isSubObject) {
           return { ...merged, ...sub }
+        }
+        // Keep the accumulated object if the sub-schema produced
+        // a non-object value (e.g. "" from a constraint-only schema)
+        if (isMergedObject && !isSubObject) {
+          return merged
         }
         return sub
       },

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v3.ts
@@ -74,10 +74,32 @@ const generateArrayRequestBodyExample = (
 const generateRequestBodyExampleFromSchemaObject = (
   schemaObject: OpenAPIV3.SchemaObject
 ): RequestBodyExample => {
-  // TODO: Handle schema objects with allof
   if (schemaObject.example) return schemaObject.example as RequestBodyExample
 
-  // If request body can be oneof or allof several schema, choose the first schema to generate an example
+  // Merge all sub-schemas for allOf (used for inheritance / composition)
+  if (schemaObject.allOf) {
+    return schemaObject.allOf.reduce<RequestBodyExample>(
+      (merged, subSchema) => {
+        const sub = generateRequestBodyExampleFromSchemaObject(
+          subSchema as OpenAPIV3.SchemaObject
+        )
+        if (
+          typeof merged === "object" &&
+          merged !== null &&
+          !Array.isArray(merged) &&
+          typeof sub === "object" &&
+          sub !== null &&
+          !Array.isArray(sub)
+        ) {
+          return { ...merged, ...sub }
+        }
+        return sub
+      },
+      {}
+    )
+  }
+
+  // For oneOf / anyOf, pick the first schema to generate an example
   if (schemaObject.oneOf)
     return generateRequestBodyExampleFromSchemaObject(
       schemaObject.oneOf[0] as OpenAPIV3.SchemaObject

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
@@ -106,22 +106,28 @@ const generateRequestBodyExampleFromSchemaObject = (
   if (schemaObject.examples)
     return schemaObject.examples[0] as RequestBodyExample
 
-  // Merge all sub-schemas for allOf (used for inheritance / composition)
+  // Merge all sub-schemas for allOf (used for inheritance / composition).
+  // Constraint-only sub-schemas (e.g. those that only set "required")
+  // produce "" because they have no type — skip them to avoid replacing
+  // already-merged properties.
   if (schemaObject.allOf) {
     return schemaObject.allOf.reduce<RequestBodyExample>(
       (merged, subSchema) => {
         const sub = generateRequestBodyExampleFromSchemaObject(
           subSchema as OpenAPIV31.SchemaObject
         )
-        if (
+        const isMergedObject =
           typeof merged === "object" &&
           merged !== null &&
-          !Array.isArray(merged) &&
-          typeof sub === "object" &&
-          sub !== null &&
-          !Array.isArray(sub)
-        ) {
+          !Array.isArray(merged)
+        const isSubObject =
+          typeof sub === "object" && sub !== null && !Array.isArray(sub)
+
+        if (isMergedObject && isSubObject) {
           return { ...merged, ...sub }
+        }
+        if (isMergedObject && !isSubObject) {
+          return merged
         }
         return sub
       },

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
@@ -136,11 +136,11 @@ const generateRequestBodyExampleFromSchemaObject = (
   }
 
   // For oneOf / anyOf, pick the first schema to generate an example
-  if (schemaObject.oneOf)
+  if (schemaObject.oneOf && schemaObject.oneOf.length > 0)
     return generateRequestBodyExampleFromSchemaObject(
       schemaObject.oneOf[0] as OpenAPIV31.SchemaObject
     )
-  if (schemaObject.anyOf)
+  if (schemaObject.anyOf && schemaObject.anyOf.length > 0)
     return generateRequestBodyExampleFromSchemaObject(
       schemaObject.anyOf[0] as OpenAPIV31.SchemaObject
     )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v31.ts
@@ -102,10 +102,43 @@ const generateArrayRequestBodyExample = (
 const generateRequestBodyExampleFromSchemaObject = (
   schemaObject: OpenAPIV31.SchemaObject
 ): RequestBodyExample => {
-  // TODO: Handle schema objects with oneof or anyof
   if (schemaObject.example) return schemaObject.example as RequestBodyExample
   if (schemaObject.examples)
     return schemaObject.examples[0] as RequestBodyExample
+
+  // Merge all sub-schemas for allOf (used for inheritance / composition)
+  if (schemaObject.allOf) {
+    return schemaObject.allOf.reduce<RequestBodyExample>(
+      (merged, subSchema) => {
+        const sub = generateRequestBodyExampleFromSchemaObject(
+          subSchema as OpenAPIV31.SchemaObject
+        )
+        if (
+          typeof merged === "object" &&
+          merged !== null &&
+          !Array.isArray(merged) &&
+          typeof sub === "object" &&
+          sub !== null &&
+          !Array.isArray(sub)
+        ) {
+          return { ...merged, ...sub }
+        }
+        return sub
+      },
+      {}
+    )
+  }
+
+  // For oneOf / anyOf, pick the first schema to generate an example
+  if (schemaObject.oneOf)
+    return generateRequestBodyExampleFromSchemaObject(
+      schemaObject.oneOf[0] as OpenAPIV31.SchemaObject
+    )
+  if (schemaObject.anyOf)
+    return generateRequestBodyExampleFromSchemaObject(
+      schemaObject.anyOf[0] as OpenAPIV31.SchemaObject
+    )
+
   if (!schemaObject.type) return ""
   if (isSchemaTypePrimitive(schemaObject.type))
     return generatePrimitiveRequestBodyExample(


### PR DESCRIPTION
### Description

Closes #5988

When importing OpenAPI specs that use `allOf` for schema composition (a very common pattern for inheritance and mixins), the example body generator produced an empty string because `allOf` was not handled.

For example, this schema:
```yaml
allOf:
  - $ref: '#/components/schemas/BaseAnimal'
  - type: object
    properties:
      breed:
        type: string
```

Previously generated: `""` (empty)
Now generates: `{"name": "string", "age": 0, "breed": "string"}`

### Changes

**v3.ts (OpenAPI 3.0):**
- Added `allOf` handling that merges all sub-schema properties into a single object
- Replaced the TODO comment with working implementation

**v31.ts (OpenAPI 3.1):**
- Added the same `allOf` handling
- Also added the missing `oneOf`/`anyOf` handling (had a TODO noting the gap)

The merge strategy: iterate sub-schemas left to right, generate examples for each, and spread-merge object results. Later schemas override earlier ones for conflicting keys, consistent with how `allOf` works in JSON Schema.

### Testing

- All 680 existing tests in hoppscotch-common pass
- Full typecheck passes across all packages
- Lint passes (0 errors, only pre-existing warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty example bodies when importing OpenAPI specs that use `allOf` by merging composed schemas and preserving merged objects when a sub-schema has no type. Also adds default handling for `oneOf`/`anyOf` in 3.0/3.1 to pick the first option and guards against empty arrays.

- **Bug Fixes**
  - OpenAPI 3.0/3.1: merge `allOf` sub-schemas left-to-right; later keys override earlier; skip non-object results so constraint-only sub-schemas don’t wipe merged objects.
  - OpenAPI 3.0/3.1: handle `oneOf`/`anyOf` by generating from the first schema; guard against empty arrays to prevent runtime errors.
  - Example bodies now include inherited/mixed-in properties instead of an empty string.

<sup>Written for commit e77e8123e72afef344cf329ca91cf9b1926f21d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

