### PR TITLE
fix(rest): handle malformed JSON in shared URL parameters

### DIFF
--- a/packages/hoppscotch-common/src/helpers/RESTExtURLParams.ts
+++ b/packages/hoppscotch-common/src/helpers/RESTExtURLParams.ts
@@ -2,6 +2,14 @@ import { FormDataKeyValue, HoppRESTRequest } from "@hoppscotch/data"
 import { getDefaultRESTRequest } from "./rest/default"
 import { isJSONContentType } from "./utils/contenttypes"
 
+const safeJSONParse = <T>(value: string, fallback: T): T => {
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
 /**
  * Handles translations for all the hopp.io REST Shareable URL params
  */
@@ -32,11 +40,11 @@ function parseV0ExtURL(
   }
 
   if (urlParams.headers && typeof urlParams.headers === "string") {
-    resolvedReq.headers = JSON.parse(urlParams.headers)
+    resolvedReq.headers = safeJSONParse(urlParams.headers, resolvedReq.headers)
   }
 
   if (urlParams.params && typeof urlParams.params === "string") {
-    resolvedReq.params = JSON.parse(urlParams.params)
+    resolvedReq.params = safeJSONParse(urlParams.params, resolvedReq.params)
   }
 
   if (urlParams.httpUser && typeof urlParams.httpUser === "string") {
@@ -60,7 +68,7 @@ function parseV0ExtURL(
     if (urlParams.contentType === "multipart/form-data") {
       resolvedReq.body = {
         contentType: "multipart/form-data",
-        body: JSON.parse(urlParams.bodyParams || "[]").map(
+        body: safeJSONParse<any[]>(urlParams.bodyParams || "[]", []).map(
           (x: any) =>
             <FormDataKeyValue>{
               active: x.active,
@@ -100,11 +108,11 @@ function parseV1ExtURL(
   const resolvedReq = initialReq ?? getDefaultRESTRequest()
 
   if (urlParams.headers && typeof urlParams.headers === "string") {
-    resolvedReq.headers = JSON.parse(urlParams.headers)
+    resolvedReq.headers = safeJSONParse(urlParams.headers, resolvedReq.headers)
   }
 
   if (urlParams.params && typeof urlParams.params === "string") {
-    resolvedReq.params = JSON.parse(urlParams.params)
+    resolvedReq.params = safeJSONParse(urlParams.params, resolvedReq.params)
   }
 
   if (urlParams.method && typeof urlParams.method === "string") {
@@ -116,7 +124,7 @@ function parseV1ExtURL(
   }
 
   if (urlParams.body && typeof urlParams.body === "string") {
-    resolvedReq.body = JSON.parse(urlParams.body)
+    resolvedReq.body = safeJSONParse(urlParams.body, resolvedReq.body)
   }
 
   return resolvedReq


### PR DESCRIPTION
## Description

`translateExtURLParams` in `RESTExtURLParams.ts` calls `JSON.parse()` on URL parameters from shared links without any error handling. If a shared URL is truncated, corrupted, or manually edited with invalid JSON, the entire request loader crashes with an unhandled exception.

This affects both the V0 and V1 shared URL formats — headers, params, body, and bodyParams are all parsed without protection.

## Changes

- Added a `safeJSONParse` helper that wraps `JSON.parse` in a try-catch and returns a fallback value on failure
- Replaced all 5 bare `JSON.parse` calls with `safeJSONParse`, falling back to the request's existing defaults

## How to reproduce the original issue

1. Open Hoppscotch
2. Navigate to a shared URL like `https://hopp.sh/r/...` with a truncated or invalid `headers` or `params` query param (e.g. `?v=1&headers=%7B%22broken`)
3. The app crashes instead of loading the request with default values

## Test plan

- Manually tested with valid shared URLs (no behavior change)
- Tested with intentionally malformed JSON in headers/params/body query params — now gracefully loads request with defaults

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely parse shared REST URL parameters to prevent crashes from malformed JSON. V0 and V1 URLs now fall back to request defaults when `headers`, `params`, `body`, or `bodyParams` are invalid.

- **Bug Fixes**
  - Added `safeJSONParse` to wrap `JSON.parse` with a fallback.
  - Replaced five vulnerable parses in shared URL handling with safe parsing.
  - Valid URLs behave the same; malformed values load with defaults.

<sup>Written for commit 18c877a709d4ea40570b7e224857e0be9148a5ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

