### PR TITLE
fix: increase width of data structure drawer

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
@@ -2,7 +2,7 @@
   <HoppSmartSlideOver
     :show="show"
     :title="t('response.data_schema')"
-    class="!max-w-[1000px]"
+    class="data-schema-drawer"
     @close="close()"
   >
     <template #content>
@@ -281,3 +281,9 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   t("filename.response_interface")
 )
 </script>
+
+<style scoped>
+.data-schema-drawer :deep(aside) {
+  @apply !w-[36rem] !max-w-[100vw];
+}
+</style>

--- a/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
@@ -2,10 +2,14 @@
   <HoppSmartSlideOver
     :show="show"
     :title="t('response.data_schema')"
+    class="!max-w-[1000px]"
     @close="close()"
   >
     <template #content>
-      <div v-if="response" class="flex flex-col px-4 flex-1 overflow-y-auto">
+      <div
+        v-if="response"
+        class="flex flex-col px-4 flex-1 overflow-y-auto max-w-none"
+      >
         <div class="flex flex-col">
           <tippy
             interactive
@@ -104,7 +108,7 @@
             </div>
           </div>
           <div
-            class="h-full relative w-full flex flex-col flex-1 rounded-b border-t border-dividerLight"
+            class="h-full relative w-full flex flex-col flex-1 rounded-b border-t border-dividerLight max-w-none"
           >
             <div ref="generatedCode" class="absolute inset-0"></div>
           </div>


### PR DESCRIPTION
Fixes #5999

The data structure / response interface drawer was too narrow,
which made generated code harder to read.

This PR increases the max width of the drawer to improve readability
while keeping the layout behavior unchanged.

Tested locally on the development server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the data structure/response interface drawer and removed inner width caps to improve generated code readability without changing layout behavior.

- **Bug Fixes**
  - Applied a scoped style on `HoppSmartSlideOver` in `ResponseInterface.vue` via `.data-schema-drawer` to widen the slide-over (36rem, capped at viewport width).
  - Added `max-w-none` to content and code containers so they use the full drawer width.

<sup>Written for commit 9761c6ba9bd1875c2fce81bad2eb4d7f953bc9db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

