### PR TITLE
fix(backend): prevent stored XSS via mock server responses and cross-team request moves

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-request.guard.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-request.guard.ts
@@ -103,6 +103,7 @@ export class MockRequestGuard implements CanActivate {
     // but the mock server ID comes from the subdomain, not the path
     const subdomainId = this.extractFromSubdomain(host);
     if (subdomainId) {
+      (request as any).isSubdomainAccess = true;
       return subdomainId;
     }
 
@@ -111,6 +112,7 @@ export class MockRequestGuard implements CanActivate {
     // Route pattern: /mock/mock-server-id/...
     const routeId = this.extractFromRoute(path);
     if (routeId) {
+      (request as any).isSubdomainAccess = false;
       return routeId;
     }
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
@@ -35,6 +35,7 @@ export class MockServerController {
     // Mock server ID and info are attached by the guard
     const mockServerId = (req as any).mockServerId as string;
     const mockServer = (req as any).mockServer as MockServer;
+    const isSubdomainAccess = (req as any).isSubdomainAccess === true;
 
     if (!mockServerId) {
       return res.status(HttpStatus.NOT_FOUND).json({
@@ -99,7 +100,10 @@ export class MockServerController {
             if (!securityHeaderBlocklist.has(key.toLowerCase())) {
               const rawValue = headers[key];
               // Only allow string and number values to prevent type bypass attacks
-              if (typeof rawValue === 'string' || typeof rawValue === 'number') {
+              if (
+                typeof rawValue === 'string' ||
+                typeof rawValue === 'number'
+              ) {
                 res.setHeader(key, rawValue);
               }
             }
@@ -116,26 +120,27 @@ export class MockServerController {
         );
       }
 
-      // Prevent XSS: downgrade script-capable content types to text/plain
-      const activeContentTypes = new Set([
-        'text/html',
-        'application/xhtml+xml',
-        'image/svg+xml',
-        'text/xml',
-        'application/xml',
-        'application/javascript',
-        'text/javascript',
-        'text/xsl',
-      ]);
-      const rawContentType = res.getHeader('Content-Type');
-      if (typeof rawContentType === 'string') {
-        // Normalize: trim, strip parameters (e.g. charset), lowercase
-        const mimeType = rawContentType.split(';')[0].trim().toLowerCase();
-        if (
-          activeContentTypes.has(mimeType) ||
-          mimeType.endsWith('+xml')
-        ) {
-          res.setHeader('Content-Type', 'text/plain');
+      // Prevent XSS on path-based (same-origin) requests by downgrading
+      // script-capable content types to text/plain.
+      // Subdomain-based requests are on a different origin, so HTML is safe.
+      if (!isSubdomainAccess) {
+        const activeContentTypes = new Set([
+          'application/javascript',
+          'application/xhtml+xml',
+          'application/xml',
+          'image/svg+xml',
+          'text/html',
+          'text/javascript',
+          'text/xml',
+          'text/xsl',
+        ]);
+        const rawContentType = res.getHeader('Content-Type');
+        if (typeof rawContentType === 'string') {
+          // Normalize: trim, strip parameters (e.g. charset), lowercase
+          const mimeType = rawContentType.split(';')[0].trim().toLowerCase();
+          if (activeContentTypes.has(mimeType) || mimeType.endsWith('+xml')) {
+            res.setHeader('Content-Type', 'text/plain');
+          }
         }
       }
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
@@ -89,6 +89,7 @@ export class MockServerController {
         'x-content-type-options',
         'x-frame-options',
         'content-disposition',
+        'set-cookie',
       ]);
 
       if (mockResponse.headers) {
@@ -96,7 +97,11 @@ export class MockServerController {
           const headers = JSON.parse(mockResponse.headers);
           Object.keys(headers).forEach((key) => {
             if (!securityHeaderBlocklist.has(key.toLowerCase())) {
-              res.setHeader(key, headers[key]);
+              const rawValue = headers[key];
+              // Only allow string and number values to prevent type bypass attacks
+              if (typeof rawValue === 'string' || typeof rawValue === 'number') {
+                res.setHeader(key, rawValue);
+              }
             }
           });
         } catch (error) {
@@ -111,22 +116,27 @@ export class MockServerController {
         );
       }
 
-      // Prevent XSS: downgrade active content types to text/plain
-      const activeContentTypes = [
+      // Prevent XSS: downgrade script-capable content types to text/plain
+      const activeContentTypes = new Set([
         'text/html',
         'application/xhtml+xml',
         'image/svg+xml',
         'text/xml',
         'application/xml',
-      ];
-      const currentContentType = res.getHeader('Content-Type');
-      if (
-        typeof currentContentType === 'string' &&
-        activeContentTypes.some((ct) =>
-          currentContentType.toLowerCase().startsWith(ct),
-        )
-      ) {
-        res.setHeader('Content-Type', 'text/plain');
+        'application/javascript',
+        'text/javascript',
+        'text/xsl',
+      ]);
+      const rawContentType = res.getHeader('Content-Type');
+      if (typeof rawContentType === 'string') {
+        // Normalize: trim, strip parameters (e.g. charset), lowercase
+        const mimeType = rawContentType.split(';')[0].trim().toLowerCase();
+        if (
+          activeContentTypes.has(mimeType) ||
+          mimeType.endsWith('+xml')
+        ) {
+          res.setHeader('Content-Type', 'text/plain');
+        }
       }
 
       // Only set Content-Type if not already set

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
@@ -15,6 +15,27 @@ import { MockRequestGuard } from './mock-request.guard';
 import { MockServer } from 'src/generated/prisma/client';
 import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 
+/** Security-sensitive headers that mock responses must not override. */
+const SECURITY_HEADER_BLOCKLIST = new Set([
+  'content-security-policy',
+  'x-content-type-options',
+  'x-frame-options',
+  'content-disposition',
+  'set-cookie',
+]);
+
+/** MIME types that can execute scripts and must be downgraded on same-origin (subpath) responses. */
+const ACTIVE_CONTENT_TYPES = new Set([
+  'application/javascript',
+  'application/xhtml+xml',
+  'application/xml',
+  'image/svg+xml',
+  'text/html',
+  'text/javascript',
+  'text/xml',
+  'text/xsl',
+]);
+
 /**
  * Mock server controller with dual routing support:
  * 1. Subdomain pattern: mock-server-id.mock.hopp.io/product
@@ -85,29 +106,27 @@ export class MockServerController {
 
       // Set response headers if any, but exclude security-sensitive headers
       // that could be abused for XSS
-      const securityHeaderBlocklist = new Set([
-        'content-security-policy',
-        'x-content-type-options',
-        'x-frame-options',
-        'content-disposition',
-        'set-cookie',
-      ]);
-
       if (mockResponse.headers) {
         try {
           const headers = JSON.parse(mockResponse.headers);
-          Object.keys(headers).forEach((key) => {
-            if (!securityHeaderBlocklist.has(key.toLowerCase())) {
-              const rawValue = headers[key];
-              // Only allow string and number values to prevent type bypass attacks
-              if (
-                typeof rawValue === 'string' ||
-                typeof rawValue === 'number'
-              ) {
-                res.setHeader(key, rawValue);
+          if (
+            headers !== null &&
+            typeof headers === 'object' &&
+            !Array.isArray(headers)
+          ) {
+            Object.keys(headers).forEach((key) => {
+              if (!SECURITY_HEADER_BLOCKLIST.has(key.toLowerCase())) {
+                const rawValue = headers[key];
+                // Only allow string and number values to prevent type bypass attacks
+                if (
+                  typeof rawValue === 'string' ||
+                  typeof rawValue === 'number'
+                ) {
+                  res.setHeader(key, String(rawValue));
+                }
               }
-            }
-          });
+            });
+          }
         } catch (error) {
           console.error('Error parsing response headers:', error);
         }
@@ -124,21 +143,11 @@ export class MockServerController {
       // script-capable content types to text/plain.
       // Subdomain-based requests are on a different origin, so HTML is safe.
       if (!isSubdomainAccess) {
-        const activeContentTypes = new Set([
-          'application/javascript',
-          'application/xhtml+xml',
-          'application/xml',
-          'image/svg+xml',
-          'text/html',
-          'text/javascript',
-          'text/xml',
-          'text/xsl',
-        ]);
         const rawContentType = res.getHeader('Content-Type');
         if (typeof rawContentType === 'string') {
           // Normalize: trim, strip parameters (e.g. charset), lowercase
           const mimeType = rawContentType.split(';')[0].trim().toLowerCase();
-          if (activeContentTypes.has(mimeType) || mimeType.endsWith('+xml')) {
+          if (ACTIVE_CONTENT_TYPES.has(mimeType) || mimeType.endsWith('+xml')) {
             res.setHeader('Content-Type', 'text/plain');
           }
         }
@@ -167,8 +176,13 @@ export class MockServerController {
       }
       // Security headers to prevent XSS via mock responses
       res.setHeader('X-Content-Type-Options', 'nosniff');
-      res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
-      res.setHeader('X-Frame-Options', 'DENY');
+      if (!isSubdomainAccess) {
+        res.setHeader(
+          'Content-Security-Policy',
+          "default-src 'none'; sandbox",
+        );
+        res.setHeader('X-Frame-Options', 'DENY');
+      }
 
       // Send response
       return res.status(mockResponse.statusCode).send(mockResponse.body);

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
@@ -82,13 +82,22 @@ export class MockServerController {
 
       const mockResponse = result.right;
 
-      // Set response headers if any
+      // Set response headers if any, but exclude security-sensitive headers
+      // that could be abused for XSS
+      const securityHeaderBlocklist = new Set([
+        'content-security-policy',
+        'x-content-type-options',
+        'x-frame-options',
+        'content-disposition',
+      ]);
+
       if (mockResponse.headers) {
         try {
           const headers = JSON.parse(mockResponse.headers);
           Object.keys(headers).forEach((key) => {
-            console.log('Setting header:', key, headers[key]);
-            res.setHeader(key, headers[key]);
+            if (!securityHeaderBlocklist.has(key.toLowerCase())) {
+              res.setHeader(key, headers[key]);
+            }
           });
         } catch (error) {
           console.error('Error parsing response headers:', error);
@@ -100,6 +109,24 @@ export class MockServerController {
         await new Promise((resolve) =>
           setTimeout(resolve, mockServer.delayInMs),
         );
+      }
+
+      // Prevent XSS: downgrade active content types to text/plain
+      const activeContentTypes = [
+        'text/html',
+        'application/xhtml+xml',
+        'image/svg+xml',
+        'text/xml',
+        'application/xml',
+      ];
+      const currentContentType = res.getHeader('Content-Type');
+      if (
+        typeof currentContentType === 'string' &&
+        activeContentTypes.some((ct) =>
+          currentContentType.toLowerCase().startsWith(ct),
+        )
+      ) {
+        res.setHeader('Content-Type', 'text/plain');
       }
 
       // Only set Content-Type if not already set
@@ -123,8 +150,10 @@ export class MockServerController {
 
         res.setHeader('Content-Type', defaultContentType);
       }
-      // Security headers
+      // Security headers to prevent XSS via mock responses
       res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+      res.setHeader('X-Frame-Options', 'DENY');
 
       // Send response
       return res.status(mockResponse.statusCode).send(mockResponse.body);

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
@@ -489,9 +489,8 @@ describe('findRequestAndNextRequest', () => {
       nextRequestID: null,
     };
 
-    mockPrisma.teamRequest.findFirst
-      .mockResolvedValueOnce(dbTeamRequests[0])
-      .mockResolvedValueOnce(null);
+    mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(dbTeamRequests[0]);
+    mockPrisma.teamCollection.findUnique.mockResolvedValueOnce(teamCollection);
 
     const result = (teamRequestService as any).findRequestAndNextRequest(
       args.srcCollID,

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
@@ -481,7 +481,7 @@ describe('findRequestAndNextRequest', () => {
       nextRequest: dbTeamRequests[4],
     });
   });
-  test('Should resolve right if the request and next request null', () => {
+  test('Should resolve right if the request and next request null', async () => {
     const args: MoveTeamRequestArgs = {
       srcCollID: teamRequests[0].collectionID,
       destCollID: teamRequests[4].collectionID,
@@ -492,17 +492,61 @@ describe('findRequestAndNextRequest', () => {
     mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(dbTeamRequests[0]);
     mockPrisma.teamCollection.findUnique.mockResolvedValueOnce(teamCollection);
 
-    const result = (teamRequestService as any).findRequestAndNextRequest(
+    const result = await (teamRequestService as any).findRequestAndNextRequest(
       args.srcCollID,
       args.requestID,
       args.destCollID,
       args.nextRequestID,
     );
 
-    expect(result).resolves.toEqualRight({
+    expect(result).toEqualRight({
       request: dbTeamRequests[0],
       nextRequest: null,
     });
+  });
+  test('Should resolve left if the destination collection does not exist when nextRequestID is null', async () => {
+    const args: MoveTeamRequestArgs = {
+      srcCollID: teamRequests[0].collectionID,
+      destCollID: 'non-existent-coll',
+      requestID: teamRequests[0].id,
+      nextRequestID: null,
+    };
+
+    mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(dbTeamRequests[0]);
+    mockPrisma.teamCollection.findUnique.mockResolvedValueOnce(null);
+
+    const result = await (teamRequestService as any).findRequestAndNextRequest(
+      args.srcCollID,
+      args.requestID,
+      args.destCollID,
+      args.nextRequestID,
+    );
+
+    expect(result).toEqualLeft(TEAM_INVALID_COLL_ID);
+  });
+  test('Should resolve left if the destination collection belongs to a different team when nextRequestID is null', async () => {
+    const args: MoveTeamRequestArgs = {
+      srcCollID: teamRequests[0].collectionID,
+      destCollID: 'cross-team-coll',
+      requestID: teamRequests[0].id,
+      nextRequestID: null,
+    };
+
+    mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(dbTeamRequests[0]);
+    mockPrisma.teamCollection.findUnique.mockResolvedValueOnce({
+      ...teamCollection,
+      id: 'cross-team-coll',
+      teamID: 'different-team-id',
+    });
+
+    const result = await (teamRequestService as any).findRequestAndNextRequest(
+      args.srcCollID,
+      args.requestID,
+      args.destCollID,
+      args.nextRequestID,
+    );
+
+    expect(result).toEqualLeft(TEAM_REQ_INVALID_TARGET_COLL_ID);
   });
   test('Should resolve left if the request is not found', () => {
     const args: MoveTeamRequestArgs = {

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -383,8 +383,9 @@ export class TeamRequestService {
     } else {
       // When nextRequestID is null, validate that the destination collection
       // belongs to the same team as the request to prevent cross-team moves
-      const destCollection = await this.prisma.teamCollection.findFirst({
+      const destCollection = await this.prisma.teamCollection.findUnique({
         where: { id: destCollID },
+        select: { teamID: true },
       });
       if (!destCollection) return E.left(TEAM_INVALID_COLL_ID);
 

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -380,6 +380,17 @@ export class TeamRequestService {
       ) {
         return E.left(TEAM_REQ_INVALID_TARGET_COLL_ID);
       }
+    } else {
+      // When nextRequestID is null, validate that the destination collection
+      // belongs to the same team as the request to prevent cross-team moves
+      const destCollection = await this.prisma.teamCollection.findFirst({
+        where: { id: destCollID },
+      });
+      if (!destCollection) return E.left(TEAM_INVALID_COLL_ID);
+
+      if (destCollection.teamID !== request.teamID) {
+        return E.left(TEAM_REQ_INVALID_TARGET_COLL_ID);
+      }
     }
 
     return E.right({ request, nextRequest });

--- a/packages/hoppscotch-sh-admin/locales/en.json
+++ b/packages/hoppscotch-sh-admin/locales/en.json
@@ -137,7 +137,10 @@
       "description": "Configure mock server settings used to host example responses.",
       "wildcard_domain": "Wildcard Domain",
       "wildcard_domain_description": "This field requires a full wildcard domain format. The input must start with an asterisk (*) followed by a dot (.) and then the domain name.",
-      "wildcard_domain_example": "Example: *.mock.domain.com"
+      "wildcard_domain_example": "Example: *.mock.domain.com",
+      "subpath_content_type_notice_prefix": "When using a subpath (instead of a wildcard subdomain), responses with the following content types will be served as",
+      "subpath_content_type_text_plain": "text/plain",
+      "subpath_content_type_notice_suffix": "to help prevent XSS:"
     },
     "update_failure": "Failed to update server configurations"
   },

--- a/packages/hoppscotch-sh-admin/locales/en.json
+++ b/packages/hoppscotch-sh-admin/locales/en.json
@@ -138,9 +138,9 @@
       "wildcard_domain": "Wildcard Domain",
       "wildcard_domain_description": "This field requires a full wildcard domain format. The input must start with an asterisk (*) followed by a dot (.) and then the domain name.",
       "wildcard_domain_example": "Example: *.mock.domain.com",
-      "subpath_content_type_notice_prefix": "When using a subpath (instead of a wildcard subdomain), responses with the following content types will be served as",
+      "subpath_content_type_notice_prefix": "If you are not using a wildcard domain for the mock server (i.e., using a subpath instead), responses with the following content types are automatically served as",
       "subpath_content_type_text_plain": "text/plain",
-      "subpath_content_type_notice_suffix": "to help prevent XSS:"
+      "subpath_content_type_notice_suffix": "to help prevent XSS attacks:"
     },
     "update_failure": "Failed to update server configurations"
   },

--- a/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
@@ -102,6 +102,7 @@ const sanitizedContentTypes = [
   'application/javascript',
   'application/xhtml+xml',
   'application/xml',
+  'application/*+xml (all +xml subtypes)',
   'image/svg+xml',
   'text/html',
   'text/javascript',

--- a/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
@@ -14,7 +14,7 @@
 
       <div class="space-y-4 py-4">
         <div>
-          <label class="block text-sm font-medium text-secondaryDark mb-1">
+          <label class="block text-sm font-medium text-secondaryDark mb-2">
             {{ t('configs.mock_server.wildcard_domain') }}
           </label>
           <HoppSmartInput
@@ -24,12 +24,34 @@
             class="!bg-primaryLight border border-divider rounded"
             input-styles="!border-0"
           />
-          <p class="text-secondaryLight text-sm mt-2">
+          <p class="text-secondaryLight mt-4">
             {{ t('configs.mock_server.wildcard_domain_description') }}
           </p>
-          <p class="text-secondaryLight text-sm mt-1 font-mono">
+          <p class="text-secondaryLight mt-1 font-mono font-bold">
             {{ t('configs.mock_server.wildcard_domain_example') }}
           </p>
+        </div>
+
+        <div
+          class="flex items-start p-3 bg-primaryLight border border-divider shadow-sm rounded text-sm gap-3"
+        >
+          <icon-lucide-info
+            class="svg-icons text-secondaryLight flex-shrink-0 mt-0.5"
+          />
+          <div>
+            <p class="text-secondaryDark text-xs ">
+              {{ t('configs.mock_server.subpath_content_type_notice_prefix') }}
+              <code
+                class="font-mono font-semibold text-xs  text-yellow-500 "
+              >
+                {{ t('configs.mock_server.subpath_content_type_text_plain') }}
+              </code>
+              {{ t('configs.mock_server.subpath_content_type_notice_suffix') }}
+            </p>
+            <p class="font-mono text-xs text-secondaryLight leading-relaxed mt-1">
+              {{ sanitizedContentTypes.join(', ') }}
+            </p>
+          </div>
         </div>
       </div>
     </div>
@@ -43,6 +65,7 @@ import { useI18n } from '~/composables/i18n';
 import { ServerConfigs } from '~/helpers/configs';
 
 const t = useI18n();
+
 
 const props = defineProps<{
   config: ServerConfigs;
@@ -71,4 +94,18 @@ const mockFields = computed({
     } else workingConfigs.value.mockServerConfigs.fields = v as any;
   },
 });
+
+
+// Content types that are served as text/plain when using subpath-based mock URLs (instead of wildcard subdomains) to prevent XSS.
+// This list should be kept in sync with the backend guard in packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+const sanitizedContentTypes = [
+  'application/javascript',
+  'application/xhtml+xml',
+  'application/xml',
+  'image/svg+xml',
+  'text/html',
+  'text/javascript',
+  'text/xml',
+  'text/xsl',
+];
 </script>

--- a/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/MockServerConfig.vue
@@ -39,16 +39,16 @@
             class="svg-icons text-secondaryLight flex-shrink-0 mt-0.5"
           />
           <div>
-            <p class="text-secondaryDark text-xs ">
+            <p class="text-secondaryDark text-xs">
               {{ t('configs.mock_server.subpath_content_type_notice_prefix') }}
-              <code
-                class="font-mono font-semibold text-xs  text-yellow-500 "
-              >
+              <code class="font-mono font-semibold text-xs text-yellow-500">
                 {{ t('configs.mock_server.subpath_content_type_text_plain') }}
               </code>
               {{ t('configs.mock_server.subpath_content_type_notice_suffix') }}
             </p>
-            <p class="font-mono text-xs text-secondaryLight leading-relaxed mt-1">
+            <p
+              class="font-mono text-xs text-secondaryLight leading-relaxed mt-1"
+            >
               {{ sanitizedContentTypes.join(', ') }}
             </p>
           </div>
@@ -65,7 +65,6 @@ import { useI18n } from '~/composables/i18n';
 import { ServerConfigs } from '~/helpers/configs';
 
 const t = useI18n();
-
 
 const props = defineProps<{
   config: ServerConfigs;
@@ -95,14 +94,14 @@ const mockFields = computed({
   },
 });
 
-
 // Content types that are served as text/plain when using subpath-based mock URLs (instead of wildcard subdomains) to prevent XSS.
-// This list should be kept in sync with the backend guard in packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
+// This list should be kept in sync with the backend sanitization logic in
+// packages/hoppscotch-backend/src/mock-server/mock-server.controller.ts
 const sanitizedContentTypes = [
   'application/javascript',
   'application/xhtml+xml',
   'application/xml',
-  'application/*+xml (all +xml subtypes)',
+  '*+xml (other +xml subtypes)',
   'image/svg+xml',
   'text/html',
   'text/javascript',


### PR DESCRIPTION
Closes BE-735, FE-1170
Addresses [GHSA-wj4r-hr4h-g98v](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-wj4r-hr4h-g98v).


### What's changed

Fixes two security vulnerabilities in the backend:

1. **Stored XSS via path-based mock server responses** — An attacker could craft a mock example with a script-capable `Content-Type` and a malicious HTML/JS body. When mock responses are served through the path-based backend URL (`<backend-origin>/mock/<id>/...`), the browser treats them as same-origin with the backend, allowing authenticated actions with the victim's backend session.

2. Cross-team request move via `moveRequest` mutation — When `nextRequestID` was null, the `moveRequest` mutation skipped destination team validation, allowing an EDITOR/OWNER of Team A to move requests into Team B's collections.

#### Changes
**Mock server XSS prevention** `mock-server.controller.ts`
1. Downgrade active content types on path-based mock responses: `text/html`, JavaScript/XML families, and all `+xml` MIME types are forcibly replaced with `text/plain`
2. Security header blocklist: user-defined mock response headers can no longer override `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Content-Disposition`, or `Set-Cookie`
3. Restrictive response headers on path-based access: add `Content-Security-Policy: default-src 'none'; sandbox` and `X-Frame-Options: DENY`
4. Keep subdomain-based mock responses unrestricted by design, since they execute on a different origin and do not share host-only backend auth cookies

**Cross-team move prevention** `team-request.service.ts`
1. When nextRequestID is null, the destination collection is now fetched and its teamID is compared against the request's teamID
2. Returns TEAM_INVALID_COLL_ID if the destination collection doesn't exist
3. Returns TEAM_REQ_INVALID_TARGET_COLL_ID if the destination collection belongs to a different teamd


### Notes to reviewers
Nil



<\!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stored XSS in mock server responses and blocks cross‑team request moves when `nextRequestID` is null. Addresses BE-735/GHSA-wj4r-hr4h-g98v with origin‑aware Content‑Type and CSP handling, stricter header filtering, and destination collection validation.

- **Bug Fixes**
  - Mock server: mark subdomain vs subpath in the guard; on subpath (same‑origin), downgrade script‑capable types (HTML/XML/SVG/JS and all `+xml`) to `text/plain`; set `X-Content-Type-Options: nosniff` always; apply `Content-Security-Policy: default-src 'none'; sandbox` and `X-Frame-Options: DENY` only on subpath responses.
  - Mock server headers: ignore non‑object payloads; only accept string/number values; block overriding `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Content-Disposition`, and `Set-Cookie`.
  - Request moves: when `nextRequestID` is null, use `findUnique` to verify `destCollID` exists and team matches; return `TEAM_INVALID_COLL_ID` or `TEAM_REQ_INVALID_TARGET_COLL_ID`.

- **New Features**
  - Admin: add a notice in Mock Server settings explaining that subpath mock URLs serve active content types as `text/plain` (including `application/*+xml`) and list affected types; clarify wording for better guidance.

<sup>Written for commit 4f714d43fa6113f223930646b2c7c2db3e9d1bc0. Summary will update on new commits.</sup>

<\!-- End of auto-generated description by cubic. -->