### PR TITLE
fix: keyboard shortcuts on non-English layouts

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -307,36 +307,55 @@ function generateKeybindingString(ev: KeyboardEvent): ShortcutKey | null {
 }
 
 function getPressedKey(ev: KeyboardEvent): Key | null {
-  // Sometimes the property code is not available on the KeyboardEvent object
   const key = (ev.key ?? "").toLowerCase()
+  const code = ev.code ?? ""
 
-  // Check arrow keys
+  // Use event.code for letters and digits so shortcuts work regardless of
+  // the active keyboard layout (Cyrillic, CJK, Dvorak, etc). event.key
+  // returns the character produced by the layout, event.code returns the
+  // physical key position.
+  //
+  // TODO: Several component-level keydown handlers still use event.key
+  //       (spotlight, EnvInput, SchemaSearch, AI modals). Those need the
+  //       same migration but are lower priority since they only check
+  //       arrow/Enter/Escape which are layout-stable.
+
+  // Letter keys (KeyA–KeyZ)
+  if (code.startsWith("Key") && code.length === 4) {
+    return code[3].toLowerCase() as Key
+  }
+
+  // Arrow keys (ArrowUp → up, etc)
   if (key.startsWith("arrow")) {
     return key.slice(5) as Key
   }
 
-  // Check for Tab key
   if (key === "tab") return "tab"
-
-  // Check for Delete key
   if (key === "delete") return "delete"
-
   if (key === "backspace") return "backspace"
 
-  // Check letter keys
-  const isLetter = key.length === 1 && key >= "a" && key <= "z"
-  if (isLetter) return key as Key
-
-  // Check if number keys
-  const isDigit = key.length === 1 && key >= "0" && key <= "9"
-  if (isDigit) return key as Key
-
-  // Check if slash, period or enter
+  // Punctuation and special keys checked before digit codes because some
+  // layouts produce these characters from physical digit keys (e.g. AZERTY
+  // produces [ via AltGr+5 which has code "Digit5").
   if (key === "/" || key === "." || key === "enter") return key
-
   if (key === "[" || key === "]") return key
 
-  // If no other cases match, this is not a valid key
+  // Digit keys (Digit0–Digit9)
+  if (code.startsWith("Digit") && code.length === 6) {
+    return code[5] as Key
+  }
+
+  // Numpad digits (Numpad0–Numpad9), only when NumLock is on.
+  // When NumLock is off the physical keys act as navigation (Home, End, etc)
+  // but event.code still returns Numpad0-Numpad9.
+  if (
+    code.startsWith("Numpad") &&
+    code.length === 7 &&
+    ev.getModifierState("NumLock")
+  ) {
+    return code.slice(6) as Key
+  }
+
   return null
 }
 

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -325,6 +325,12 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
     return code[3].toLowerCase() as Key
   }
 
+  // ev.code can be empty in synthetic events or older environments. Fall back
+  // to ev.key for ASCII letters so shortcuts don't silently stop working.
+  // This reintroduces layout-dependence for that edge case, but that's better
+  // than dropping the shortcut entirely.
+  if (!code && key.length === 1 && key >= "a" && key <= "z") return key as Key
+
   // Arrow keys (ArrowUp → up, etc)
   if (key.startsWith("arrow")) {
     return key.slice(5) as Key
@@ -333,6 +339,9 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
   if (key === "tab") return "tab"
   if (key === "delete") return "delete"
   if (key === "backspace") return "backspace"
+
+  // Shift+/ produces "?" on most layouts but the shortcut is registered as "/"
+  if (key === "?") return "/"
 
   // Punctuation and special keys checked before digit codes because some
   // layouts produce these characters from physical digit keys (e.g. AZERTY

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -281,7 +281,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "q"
+          e.code === "KeyQ"
         ) {
           // Ctrl/Cmd + Q - Quit Application
           e.preventDefault()
@@ -292,7 +292,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "t"
+          e.code === "KeyT"
         ) {
           // Ctrl/Cmd + T - New Tab
           e.preventDefault()
@@ -303,7 +303,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "w"
+          e.code === "KeyW"
         ) {
           // Ctrl/Cmd + W - Close Tab
           e.preventDefault()
@@ -314,7 +314,7 @@ async function initApp() {
           isCtrlOrCmd &&
           e.shiftKey &&
           !e.altKey &&
-          e.key.toLowerCase() === "t"
+          e.code === "KeyT"
         ) {
           // Ctrl/Cmd + Shift + T - Reopen Tab
           e.preventDefault()
@@ -347,7 +347,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          (e.key === "9" || e.code === "Digit9")
+          e.code === "Digit9"
         ) {
           // Ctrl/Cmd + Alt + 9 - First Tab
           e.preventDefault()
@@ -358,7 +358,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          (e.key === "0" || e.code === "Digit0")
+          e.code === "Digit0"
         ) {
           // Ctrl/Cmd + Alt + 0 - Last Tab
           e.preventDefault()

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -277,12 +277,7 @@ async function initApp() {
         const isCtrlOrCmd = e.ctrlKey || e.metaKey
         let shortcutEvent: string | null = null
 
-        if (
-          isCtrlOrCmd &&
-          !e.shiftKey &&
-          !e.altKey &&
-          e.code === "KeyQ"
-        ) {
+        if (isCtrlOrCmd && !e.shiftKey && !e.altKey && e.code === "KeyQ") {
           // Ctrl/Cmd + Q - Quit Application
           e.preventDefault()
           e.stopPropagation()


### PR DESCRIPTION
 On non-English keyboard layouts (Cyrillic, CJK, etc), `event.key` returns
 the character produced by the active layout rather than the physical key
 position. So pressing the physical "Q" key on a Russian layout returns
 "й" and the Ctrl+Q shortcut never fires.
 
 Closes #5944

 This switches getPressedKey() in `keybindings.ts` from `event.key` to
 `event.code` for letter and digit keys. `event.code` identifies the
 physical key (KeyQ, Digit1, etc) regardless of the active layout.

 Also adds numpad digit support (Numpad0 through Numpad9) so shortcuts
 bound to number keys work from the numpad.

 The same `event.key` issue existed in selfhost-web's `main.ts` where
 desktop-specific shortcuts (Ctrl+Q/T/W, Ctrl+Shift+T) are registered
 via a capture-phase keydown listener. Those four checks now use
 `event.code` as well.

 Arrow keys, Tab, Delete, Backspace, Enter, slash, period, and brackets
 still use `event.key` since those return the same value regardless of
 layout. Several component-level handlers (spotlight, EnvInput,
 SchemaSearch) also use `event.key` for navigation keys and are left as-is
 for the same reason, tracked as a follow-up.

 Consolidates #5958 and #5959.

 Co-Authored-By: sahilkhan09k <sahilkhan392005@gmail.com>
 Co-Authored-By: 04cb <0x04cb@gmail.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard shortcuts on non-English layouts by using physical key positions (`event.code`) for letters and digits. Adds numpad digit support and makes desktop shortcuts layout-agnostic.

- **Bug Fixes**
  - In `hoppscotch-common`: use `event.code` for letters/digits; fallback to `event.key` for ASCII letters when `code` is missing; map `?` to `/`; support `Numpad0–9` when NumLock is on; keep layout-stable keys on `event.key` (arrows, Tab, Delete, Backspace, Enter, `/`, `.`, `[`, `]`).
  - In `hoppscotch-selfhost-web`: switch desktop shortcuts (Ctrl/Cmd+Q/T/W, Ctrl/Cmd+Shift+T, Ctrl/Cmd+Alt+9/0) to `event.code` only.

<sup>Written for commit 2e988c44003dda641c902844ad97017dbfbe65a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



