### PR TITLE
fix(common): persist OAuth2 PKCE code challenge method selection

### DIFF
--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -196,7 +196,10 @@ export const useOAuth2GrantTypes = (
                 }
               : null,
           (value) => {
-            if (!("codeVerifierMethod" in auth.value.grantTypeInfo) || !value) {
+            if (
+              auth.value.grantTypeInfo.grantType !== "AUTHORIZATION_CODE" ||
+              !value
+            ) {
               return
             }
 


### PR DESCRIPTION
## Summary

Fixes #5899

The PKCE code challenge method dropdown (Plain / SHA-256) in OAuth 2.0 Authorization Code collection settings was not being saved. After selecting "SHA-256" and reopening the preferences, the setting would revert to "Plain".

### Root cause

The `codeVerifierMethod` field is defined as `.optional()` in the Zod schema (`AuthCodeGrantTypeParams` in `packages/hoppscotch-data/src/rest/v/3.ts`). When the field has never been set, Zod omits it from the parsed object entirely. The change callback in `useOAuth2GrantTypes.ts` used `"codeVerifierMethod" in auth.value.grantTypeInfo` as a guard, which returned `false` when the property didn't exist yet, causing the callback to return early without saving the user's selection.

### Fix

Replaced the property-existence check (`"codeVerifierMethod" in auth.value.grantTypeInfo`) with a grant-type check (`grantType !== "AUTHORIZATION_CODE"`). This correctly guards against writing to the wrong grant type while still allowing the `codeVerifierMethod` field to be set for the first time.

## Test plan

- [ ] Create or open a collection with OAuth 2.0 Authorization Code auth
- [ ] Enable the PKCE checkbox
- [ ] Change the code challenge method from "Plain" to "SHA-256"
- [ ] Close and reopen the collection auth preferences
- [ ] Verify the code challenge method is still set to "SHA-256"
- [ ] Verify that generating a token with SHA-256 PKCE works correctly
- [ ] Verify that switching back to "Plain" also persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the PKCE code challenge method selection (Plain/SHA-256) in OAuth 2.0 Authorization Code settings. The dropdown no longer resets to Plain after reopening.

- **Bug Fixes**
  - Replaced an optional-field check with a grant-type check to allow saving `codeVerifierMethod` for `AUTHORIZATION_CODE` even when it wasn’t previously set.

<sup>Written for commit dbd5033a88418958eee61bbf4819b0e1a1db40d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

