### PR TITLE
feat(common): add missing tooltips to icon-only buttons

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -77,7 +77,10 @@
     "verify": "Verify",
     "enable": "Enable",
     "disable": "Disable",
-    "assign": "Assign"
+    "assign": "Assign",
+    "toggle_details": "Toggle details",
+    "positive_feedback": "Good response",
+    "negative_feedback": "Bad response"
   },
   "activity_logs": {
     "ACTIVITY_LOG_DELETE": "Activity log has been deleted",

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
@@ -99,6 +99,8 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
           <p>{{ t("ai_experiments.feedback_cta_text_long") }}</p>
           <template v-if="!isSubmitFeedbackPending">
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.positive_feedback')"
               :icon="IconThumbsUp"
               outline
               @click="
@@ -112,6 +114,8 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             />
 
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.negative_feedback')"
               :icon="IconThumbsDown"
               outline
               @click="

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyPreRequestModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyPreRequestModal.vue
@@ -65,6 +65,8 @@
           <p>{{ t("ai_experiments.feedback_cta_text_long") }}</p>
           <template v-if="!isSubmitFeedbackPending">
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.positive_feedback')"
               :icon="IconThumbsUp"
               outline
               @click="
@@ -77,6 +79,8 @@
               "
             />
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.negative_feedback')"
               :icon="IconThumbsDown"
               outline
               @click="

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyTestScriptModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyTestScriptModal.vue
@@ -65,6 +65,8 @@
           <p>{{ t("ai_experiments.feedback_cta_text_long") }}</p>
           <template v-if="!isSubmitFeedbackPending">
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.positive_feedback')"
               :icon="IconThumbsUp"
               outline
               @click="
@@ -77,6 +79,8 @@
               "
             />
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.negative_feedback')"
               :icon="IconThumbsDown"
               outline
               @click="

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -87,6 +87,8 @@
             :on-shown="() => downloadableLinksRef.focus()"
           >
             <HoppButtonSecondary
+              v-tippy="{ theme: 'tooltip' }"
+              :title="t('action.download_file')"
               :icon="IconDownload"
               class="rounded hover:bg-primaryDark focus-visible:bg-primaryDark"
             />

--- a/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
+++ b/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
@@ -42,6 +42,8 @@
           @click="copyQuery(entry.payload)"
         />
         <HoppButtonSecondary
+          v-tippy="{ theme: 'tooltip' }"
+          :title="t('action.toggle_details')"
           :icon="IconChevronDown"
           class="transform"
           :class="{ 'rotate-180': !minimized }"


### PR DESCRIPTION
## Summary
- Add `v-tippy` tooltips to icon-only `HoppButtonSecondary` components that were missing them
- **Download button** in app Header — now shows "Download file" on hover
- **Toggle details chevron** in realtime LogEntry — now shows "Toggle details"
- **Thumbs up/down feedback buttons** in all 3 AI experiment modals (ModifyTestScript, ModifyPreRequest, ModifyBody) — now shows "Good response" / "Bad response"
- Added corresponding i18n locale keys: `action.toggle_details`, `action.positive_feedback`, `action.negative_feedback`

## Why
Icon-only buttons without tooltips force users to click them to discover their function. Since most icon buttons in Hoppscotch already have tooltips via `v-tippy`, the missing ones stood out as inconsistencies. This improves both discoverability and accessibility.

Related to #5915

## Test plan
- [ ] Hover over the download icon in the header bar — tooltip "Download file" should appear
- [ ] Hover over the chevron button in realtime log entries — tooltip "Toggle details" should appear
- [ ] Open an AI experiment modal, hover over thumbs up/down buttons — tooltips should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `v-tippy` tooltips to icon-only `HoppButtonSecondary` buttons to make their purpose clear on hover. Improves discoverability and accessibility across the header, realtime logs, and AI modals.

- **New Features**
  - Header download button: tooltip "Download file"
  - Realtime log details chevron: tooltip "Toggle details"
  - AI modals thumbs up/down: tooltips "Good response" / "Bad response"
  - Locale keys added: `action.toggle_details`, `action.positive_feedback`, `action.negative_feedback`

<sup>Written for commit c0fecadc2bce441892e101c79cd78e448e4db283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

