### PR TITLE
fix(openapi): map custom json content types to supported types

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -396,17 +396,36 @@ const parseOpenAPIHeaders = (params: OpenAPIParamsType[]): HoppRESTHeader[] =>
     )
   )
 
+const getSupportedContentType = (
+  contentType: string
+): keyof typeof knownContentTypes | null => {
+  if (contentType in knownContentTypes) {
+    return contentType as keyof typeof knownContentTypes
+  }
+
+  if (contentType.match(/application\/.*\+json/)) {
+    return "application/json"
+  }
+
+  if (contentType.match(/application\/.*\+xml/)) {
+    return "application/xml"
+  }
+
+  return null
+}
+
 const parseOpenAPIV2Body = (op: OpenAPIV2.OperationObject): HoppRESTReqBody => {
   const obj = (op.consumes ?? [])[0] as string | undefined
 
-  // Not a content-type Hoppscotch supports
-  if (!obj || !(obj in knownContentTypes))
-    return { contentType: null, body: null }
+  if (!obj) return { contentType: null, body: null }
+
+  const supportedContentType = getSupportedContentType(obj)
+  if (!supportedContentType) return { contentType: null, body: null }
 
   // For form data types, extract form fields
   if (
-    obj === "multipart/form-data" ||
-    obj === "application/x-www-form-urlencoded"
+    supportedContentType === "multipart/form-data" ||
+    supportedContentType === "application/x-www-form-urlencoded"
   ) {
     const formDataValues = pipe(
       (op.parameters ?? []) as OpenAPIV2.Parameter[],
@@ -427,12 +446,12 @@ const parseOpenAPIV2Body = (op: OpenAPIV2.OperationObject): HoppRESTReqBody => {
       )
     )
 
-    return obj === "application/x-www-form-urlencoded"
+    return supportedContentType === "application/x-www-form-urlencoded"
       ? {
-          contentType: obj,
+          contentType: supportedContentType,
           body: formDataValues.map(({ key }) => `${key}: `).join("\n"),
         }
-      : { contentType: obj, body: formDataValues }
+      : { contentType: supportedContentType, body: formDataValues }
   }
 
   // For other content types (JSON, XML, etc.)
@@ -444,14 +463,14 @@ const parseOpenAPIV2Body = (op: OpenAPIV2.OperationObject): HoppRESTReqBody => {
     const result = generateRequestBodyExampleFromOpenAPIV2Body(op)
     if (result) {
       return {
-        contentType: obj as any,
+        contentType: supportedContentType as any,
         body: result,
       }
     }
   }
 
   // Fallback to empty body for textual content types
-  return { contentType: obj as any, body: "" }
+  return { contentType: supportedContentType as any, body: "" }
 }
 
 const parseOpenAPIV3BodyFormData = (
@@ -506,15 +525,15 @@ const parseOpenAPIV3Body = (
     OpenAPIV3.MediaTypeObject | OpenAPIV31.MediaTypeObject,
   ] = objs[0]
 
-  if (!(contentType in knownContentTypes))
-    return { contentType: null, body: null }
+  const supportedType = getSupportedContentType(contentType)
+  if (!supportedType) return { contentType: null, body: null }
 
   // Handle form data types
   if (
-    contentType === "multipart/form-data" ||
-    contentType === "application/x-www-form-urlencoded"
+    supportedType === "multipart/form-data" ||
+    supportedType === "application/x-www-form-urlencoded"
   )
-    return parseOpenAPIV3BodyFormData(contentType, media)
+    return parseOpenAPIV3BodyFormData(supportedType, media)
 
   // For other content types (JSON, XML, etc.), try to generate sample from schema
   if (media.schema) {
@@ -527,7 +546,7 @@ const parseOpenAPIV3Body = (
       }
 
       return {
-        contentType,
+        contentType: supportedType,
         body:
           typeof sampleBody === "string"
             ? sampleBody
@@ -537,7 +556,7 @@ const parseOpenAPIV3Body = (
       // If we can't generate a sample, check for examples
       if (media.example !== undefined) {
         return {
-          contentType,
+          contentType: supportedType,
           body:
             typeof media.example === "string"
               ? media.example
@@ -545,14 +564,14 @@ const parseOpenAPIV3Body = (
         } as HoppRESTReqBody
       }
       // Fallback to empty body
-      return { contentType, body: "" } as HoppRESTReqBody
+      return { contentType: supportedType, body: "" } as HoppRESTReqBody
     }
   }
 
   // Check for examples if no schema
   if (media.example !== undefined) {
     return {
-      contentType,
+      contentType: supportedType,
       body:
         typeof media.example === "string"
           ? media.example
@@ -568,7 +587,7 @@ const parseOpenAPIV3Body = (
     // Skip if this is an unresolved reference
     if (firstExample && "$ref" in firstExample) {
       // Reference wasn't dereferenced, return empty body
-      return { contentType, body: "" } as HoppRESTReqBody
+      return { contentType: supportedType, body: "" } as HoppRESTReqBody
     }
 
     // Handle Example Object (with value property) or direct value
@@ -576,7 +595,7 @@ const parseOpenAPIV3Body = (
       "value" in firstExample ? firstExample.value : firstExample
 
     return {
-      contentType,
+      contentType: supportedType,
       body:
         typeof exampleValue === "string"
           ? exampleValue
@@ -585,7 +604,7 @@ const parseOpenAPIV3Body = (
   }
 
   // Fallback to empty body for textual content types
-  return { contentType, body: "" } as HoppRESTReqBody
+  return { contentType: supportedType, body: "" } as HoppRESTReqBody
 }
 
 const isOpenAPIV3Operation = (

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -403,11 +403,11 @@ const getSupportedContentType = (
     return contentType as keyof typeof knownContentTypes
   }
 
-  if (contentType.match(/application\/.*\+json/)) {
+  if (/^application\/.+\+json$/.test(contentType)) {
     return "application/json"
   }
 
-  if (contentType.match(/application\/.*\+xml/)) {
+  if (/^application\/.+\+xml$/.test(contentType)) {
     return "application/xml"
   }
 
@@ -1051,6 +1051,32 @@ const convertPathToHoppReqs = (
           ? openAPIUrl + openAPIPath.slice(1)
           : openAPIUrl + openAPIPath
 
+      const body = parseOpenAPIBody(doc, info)
+      const headers = parseOpenAPIHeaders(
+        (info.parameters as OpenAPIParamsType[] | undefined) ?? []
+      )
+
+      // Add original content type header if it differs from the mapped body content type
+      const originalContentType = isOpenAPIV3Operation(doc, info)
+        ? (Object.keys((info.requestBody as any)?.content ?? {})[0] ?? null)
+        : ((info as OpenAPIV2.OperationObject).consumes?.[0] ?? null)
+
+      if (
+        originalContentType &&
+        body.contentType &&
+        originalContentType !== body.contentType
+      ) {
+        // Only add if not already present in headers
+        if (!headers.some((h) => h.key.toLowerCase() === "content-type")) {
+          headers.push({
+            key: "Content-Type",
+            value: originalContentType,
+            description: "Original Content-Type from OpenAPI spec",
+            active: true,
+          })
+        }
+      }
+
       const res: {
         request: HoppRESTRequest
         metadata: {
@@ -1067,13 +1093,11 @@ const convertPathToHoppReqs = (
           params: parseOpenAPIParams(
             (info.parameters as OpenAPIParamsType[] | undefined) ?? []
           ),
-          headers: parseOpenAPIHeaders(
-            (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-          ),
+          headers,
 
           auth: parseOpenAPIAuth(doc, info),
 
-          body: parseOpenAPIBody(doc, info),
+          body,
 
           preRequestScript: "",
           testScript: "",
@@ -1088,15 +1112,13 @@ const convertPathToHoppReqs = (
             makeHoppRESTResponseOriginalRequest({
               name: info.operationId ?? info.summary ?? "Untitled Request",
               auth: parseOpenAPIAuth(doc, info),
-              body: parseOpenAPIBody(doc, info),
+              body,
               endpoint,
               // We don't need to worry about reference types as the Dereferencing pass should remove them
               params: parseOpenAPIParams(
                 (info.parameters as OpenAPIParamsType[] | undefined) ?? []
               ),
-              headers: parseOpenAPIHeaders(
-                (info.parameters as OpenAPIParamsType[] | undefined) ?? []
-              ),
+              headers,
               method: method.toUpperCase(),
               requestVariables: parseOpenAPIVariables(
                 (info.parameters as OpenAPIParamsType[] | undefined) ?? []

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -399,15 +399,17 @@ const parseOpenAPIHeaders = (params: OpenAPIParamsType[]): HoppRESTHeader[] =>
 const getSupportedContentType = (
   contentType: string
 ): keyof typeof knownContentTypes | null => {
-  if (contentType in knownContentTypes) {
-    return contentType as keyof typeof knownContentTypes
+  const normalized = contentType.trim().toLowerCase().split(";")[0].trim()
+
+  if (Object.hasOwn(knownContentTypes, normalized)) {
+    return normalized as keyof typeof knownContentTypes
   }
 
-  if (/^application\/.+\+json$/.test(contentType)) {
+  if (/^application\/.+\+json$/.test(normalized)) {
     return "application/json"
   }
 
-  if (/^application\/.+\+xml$/.test(contentType)) {
+  if (/^application\/.+\+xml$/.test(normalized)) {
     return "application/xml"
   }
 
@@ -1056,7 +1058,10 @@ const convertPathToHoppReqs = (
         (info.parameters as OpenAPIParamsType[] | undefined) ?? []
       )
 
-      // Add original content type header if it differs from the mapped body content type
+      // Preserve the original content type as an explicit header when it differs
+      // from the mapped body content type (e.g. application/vnd.custom+json mapped
+      // to application/json for editor support). The explicit header reliably
+      // overrides the body-derived Content-Type at request time.
       const originalContentType = isOpenAPIV3Operation(doc, info)
         ? (Object.keys((info.requestBody as any)?.content ?? {})[0] ?? null)
         : ((info as OpenAPIV2.OperationObject).consumes?.[0] ?? null)
@@ -1066,14 +1071,30 @@ const convertPathToHoppReqs = (
         body.contentType &&
         originalContentType !== body.contentType
       ) {
-        // Only add if not already present in headers
-        if (!headers.some((h) => h.key.toLowerCase() === "content-type")) {
+        // Add or update Content-Type header:
+        // - If no Content-Type header exists, add one.
+        // - If a Content-Type header exists but is inactive or has an empty value,
+        //   update it with the original content type and activate it.
+        const existingContentTypeHeader = headers.find(
+          (h) => h.key.toLowerCase() === "content-type"
+        )
+        if (!existingContentTypeHeader) {
           headers.push({
             key: "Content-Type",
             value: originalContentType,
             description: "Original Content-Type from OpenAPI spec",
             active: true,
           })
+        } else if (
+          !existingContentTypeHeader.active ||
+          !existingContentTypeHeader.value
+        ) {
+          existingContentTypeHeader.value = originalContentType
+          if (!existingContentTypeHeader.description) {
+            existingContentTypeHeader.description =
+              "Original Content-Type from OpenAPI spec"
+          }
+          existingContentTypeHeader.active = true
         }
       }
 
@@ -1112,7 +1133,7 @@ const convertPathToHoppReqs = (
             makeHoppRESTResponseOriginalRequest({
               name: info.operationId ?? info.summary ?? "Untitled Request",
               auth: parseOpenAPIAuth(doc, info),
-              body,
+              body: cloneDeep(body),
               endpoint,
               // We don't need to worry about reference types as the Dereferencing pass should remove them
               params: parseOpenAPIParams(


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6018

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR updates the OpenAPI importer to properly recognize schemas and generate request body templates for endpoints with custom JSON (e.g. `application/custom+json`, `application/vnd.api+json`) and custom XML media types.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- Added a [getSupportedContentType](cci:1://file:///Users/sivasai/Dev/hoppscotch/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts:398:0-414:1) helper in [packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts](https://github.com/sivasai9849/hoppscotch/blob/fix/issue-6018/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts) to dynamically identify custom `application/*+json` and `application/*+xml` media types.
- Updated [parseOpenAPIV2Body](cci:1://file:///Users/sivasai/Dev/hoppscotch/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts:416:0-473:1) and [parseOpenAPIV3Body](cci:1://file:///Users/sivasai/Dev/hoppscotch/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts:506:0-607:1) to map these dynamically recognized formats accurately into the strict [HoppRESTReqBody](cci:2://file:///Users/sivasai/Dev/hoppscotch/packages/hoppscotch-data/src/rest/v/10/body.ts:39:0-39:61) types supported by the UI (falling back to `application/json` or `application/xml` for syntax highlighting purposes).
- The raw `Content-Type` header parsed from the OpenAPI spec remains unmodified and accurate to the original schema.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Previously, because custom content types were not found within the strict array of `knownContentTypes`, the importer would silently discard the entire request body object. This enhancement ensures that Hoppscotch handles real-world specs utilizing custom content-type API semantics gracefully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenAPI importer now recognizes custom JSON/XML media types and generates request body templates instead of dropping them. It also keeps the original `Content-Type` header when the mapped type differs.

- **Bug Fixes**
  - Added `getSupportedContentType` to normalize and map `application/*+json` → `application/json` and `application/*+xml` → `application/xml` (trim/lowercase/strip params; safe match with `Object.hasOwn`).
  - Updated OpenAPI v2/v3 body parsers to use mapped types for examples and form data.
  - When mapped type differs, add or activate the original `Content-Type` header from the spec without overwriting an active non-empty value.
  - Use `cloneDeep(body)` for `originalRequest` to avoid shared mutable state.

<sup>Written for commit bce7c546007513ecc17f64fdc449ec8e732b57aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

