### PR TITLE
fix(common): track manual disconnect flag in realtime connections

### DIFF
--- a/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
@@ -44,6 +44,8 @@ export class SIOConnection {
   connectionState$: BehaviorSubject<ConnectionState>
   event$: Subject<SIOEvent> = new Subject()
   socket: SIOClient | undefined
+  private manualDisconnect = false
+
   constructor() {
     this.connectionState$ = new BehaviorSubject<ConnectionState>("DISCONNECTED")
   }
@@ -106,8 +108,9 @@ export class SIOConnection {
         this.addEvent({
           type: "DISCONNECTED",
           time: Date.now(),
-          manual: true,
+          manual: this.manualDisconnect,
         })
+        this.manualDisconnect = false
       })
     } catch (error) {
       this.handleError(error, "CONNECTION")
@@ -120,7 +123,7 @@ export class SIOConnection {
   }
 
   private handleError(error: unknown, type: SIOErrorType) {
-    this.disconnect()
+    this.closeConnection()
     this.addEvent({
       time: Date.now(),
       type: "ERROR",
@@ -157,8 +160,18 @@ export class SIOConnection {
     })
   }
 
-  disconnect() {
-    this.socket?.close()
+  private closeConnection() {
+    if (!this.socket) {
+      this.manualDisconnect = false
+      this.connectionState$.next("DISCONNECTED")
+      return
+    }
+    this.socket.close()
     this.connectionState$.next("DISCONNECTED")
+  }
+
+  disconnect() {
+    this.manualDisconnect = true
+    this.closeConnection()
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
@@ -15,6 +15,8 @@ export class SSEConnection {
   connectionState$: BehaviorSubject<ConnectionState>
   event$: Subject<SSEEvent> = new Subject()
   sse: EventSource | undefined
+  private manualStop = false
+
   constructor() {
     this.connectionState$ = new BehaviorSubject<ConnectionState>("STOPPED")
   }
@@ -41,7 +43,7 @@ export class SSEConnection {
         }
         this.sse.onerror = (e) => {
           this.handleError(e)
-          this.stop()
+          this.closeConnection()
         }
         this.sse.addEventListener(eventType, ({ data }) => {
           this.addEvent({
@@ -77,13 +79,19 @@ export class SSEConnection {
     })
   }
 
-  stop() {
+  private closeConnection() {
     this.sse?.close()
     this.connectionState$.next("STOPPED")
     this.addEvent({
       type: "STOPPED",
       time: Date.now(),
-      manual: true,
+      manual: this.manualStop,
     })
+    this.manualStop = false
+  }
+
+  stop() {
+    this.manualStop = true
+    this.closeConnection()
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
@@ -18,6 +18,7 @@ export class WSConnection {
   connectionState$: BehaviorSubject<ConnectionState>
   event$: Subject<WSEvent> = new Subject()
   socket: WebSocket | undefined
+  private manualDisconnect = false
 
   constructor() {
     this.connectionState$ = new BehaviorSubject<ConnectionState>("DISCONNECTED")
@@ -54,8 +55,9 @@ export class WSConnection {
         this.addEvent({
           type: "DISCONNECTED",
           time: Date.now(),
-          manual: true,
+          manual: this.manualDisconnect,
         })
+        this.manualDisconnect = false
       }
 
       this.socket.onmessage = ({ data }) => {
@@ -78,7 +80,7 @@ export class WSConnection {
   }
 
   private handleError(error: WSErrorMessage) {
-    this.disconnect()
+    this.closeConnection()
     this.addEvent({
       time: Date.now(),
       type: "ERROR",
@@ -97,7 +99,20 @@ export class WSConnection {
     })
   }
 
+  private closeConnection() {
+    if (
+      !this.socket ||
+      this.socket.readyState === WebSocket.CLOSING ||
+      this.socket.readyState === WebSocket.CLOSED
+    ) {
+      this.manualDisconnect = false
+      return
+    }
+    this.socket.close()
+  }
+
   disconnect() {
-    this.socket?.close()
+    this.manualDisconnect = true
+    this.closeConnection()
   }
 }


### PR DESCRIPTION
Closes #5987

Socket.IO, WebSocket, and SSE connections all hardcode `manual: true` on disconnect/stop events, making it impossible for users to distinguish between intentional disconnects and unexpected server-initiated ones. MQTT already handles this correctly with a `manualDisconnect` flag.

### What's changed

- [x] Added `manualDisconnect` flag to `SIOConnection.ts` — set to `true` only when `disconnect()` is called by the user, used in the `disconnect` event handler, and reset after use
- [x] Added `manualDisconnect` flag to `WSConnection.ts` — same pattern, set in `disconnect()`, read in `onclose`, reset after use
- [x] Added `manualStop` flag to `SSEConnection.ts` — extracted shared logic into private `closeConnection()` method so `onerror` emits `manual: false` while user-called `stop()` emits `manual: true`

All three files now follow the same pattern already used by `MQTTConnection.ts` (lines 53, 135–150, 283).

### Notes to reviewers

- Zero API changes — the `manual` field type (`boolean`) in each event type is unchanged
- The SSE fix required a small refactor: `stop()` now delegates to a private `closeConnection()` so the error handler path doesn't incorrectly mark disconnects as manual

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual disconnect/stop flags for `Socket.IO`, `WebSocket`, and `SSE`, and guards redundant `WebSocket` closes so clients can tell user- vs server-initiated closures and connection state doesn’t get stuck. Matches `MQTTConnection` behavior; addresses #5987 and #6025.

- **Bug Fixes**
  - SIOConnection and WSConnection: add manualDisconnect; set only in disconnect(); errors use closeConnection(); reset after DISCONNECTED and when no socket.
  - WSConnection: guard closeConnection() when the socket is CLOSING/CLOSED so the flag resets even if onclose won’t fire, preventing stale connectionState$.
  - SSEConnection: add manualStop; stop() sets it; onerror uses closeConnection() so STOPPED emits manual: false; reset after emit.

<sup>Written for commit 7d119d41db0157ce4f0e0ceecb2822f4e440213d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

