### PR TITLE
test: add timeout handling case to getResourceContents in CLI

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -237,7 +237,7 @@ describe("getters", () => {
         },
       ];
 
-      test.each(cases)("$description", ({ args, axiosMock, expected }) => {
+      test.each(cases)("$description", async ({ args, axiosMock, expected }) => {
         const { code, response } = axiosMock;
         const axiosErrMessage = code ?? response?.data?.reason;
 
@@ -253,10 +253,10 @@ describe("getters", () => {
           )
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", () => {
+      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
         const expected = {
           code: "INVALID_SERVER_URL",
           data: args.serverUrl,
@@ -269,10 +269,10 @@ describe("getters", () => {
           })
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", () => {
+      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
         const expected = {
           code: "UNKNOWN_ERROR",
           data: new Error("UNKNOWN_ERROR"),
@@ -282,7 +282,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
     });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -223,6 +223,18 @@ describe("getters", () => {
             data: "test-environment-id-or-path",
           },
         },
+        {
+          description:
+            "Promise rejects with the code `UNKNOWN_ERROR` if the network call fails with a timeout error (ETIMEDOUT)",
+          args,
+          axiosMock: {
+            code: "ETIMEDOUT",
+          },
+          expected: {
+            code: "UNKNOWN_ERROR",
+            data: new AxiosError("ETIMEDOUT", "ETIMEDOUT"),
+          },
+        },
       ];
 
       test.each(cases)("$description", ({ args, axiosMock, expected }) => {

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -249,6 +249,8 @@ export const getResourceContents = async (
         ) {
           throw error({ code: "INVALID_SERVER_URL", data: resolvedServerUrl });
         }
+
+        throw error({ code: "UNKNOWN_ERROR", data: err });
       } else {
         throw error({ code: "UNKNOWN_ERROR", data: err });
       }

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -249,11 +249,9 @@ export const getResourceContents = async (
         ) {
           throw error({ code: "INVALID_SERVER_URL", data: resolvedServerUrl });
         }
-
-        throw error({ code: "UNKNOWN_ERROR", data: err });
-      } else {
-        throw error({ code: "UNKNOWN_ERROR", data: err });
       }
+
+      throw error({ code: "UNKNOWN_ERROR", data: err });
     }
   }
 


### PR DESCRIPTION
This PR addresses the "Revisit existing unit tests for the CLI" issue by adding a critical edge case for the `getResourceContents` utility. 

**Added:**
- A test case for handling `ETIMEDOUT` errors in the network layer. This ensures that the CLI tool correctly identifies and handles timeout scenarios, reporting them as `UNKNOWN_ERROR` with the appropriate error context, rather than failing unexpectedly. 

This improves the reliability of the CLI when fetching remote collections or environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a timeout (ETIMEDOUT) test for `getResourceContents` in `hoppscotch-cli`, fixes async test assertions to await rejections, and ensures unhandled Axios errors are consistently rethrown as `UNKNOWN_ERROR` with the original error after specific checks. Aligns with the “Revisit existing unit tests for the CLI” task.

<sup>Written for commit e9399e775afa76cfd1bb6021f766f7fa96f2b17e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

