### PR TITLE
test(cli): add coverage for collection variable priority in getResolvedVariables

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -275,14 +275,14 @@ describe("getters", () => {
       test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
         const expected = {
           code: "UNKNOWN_ERROR",
-          data: new Error("UNKNOWN_ERROR"),
+          data: expect.objectContaining({ message: "UNKNOWN_ERROR" }),
         };
 
         vi.spyOn(axios, "get").mockImplementation(() =>
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        await expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
       });
     });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -237,7 +237,7 @@ describe("getters", () => {
         },
       ];
 
-      test.each(cases)("$description", ({ args, axiosMock, expected }) => {
+      test.each(cases)("$description", async ({ args, axiosMock, expected }) => {
         const { code, response } = axiosMock;
         const axiosErrMessage = code ?? response?.data?.reason;
 
@@ -253,10 +253,10 @@ describe("getters", () => {
           )
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", () => {
+      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
         const expected = {
           code: "INVALID_SERVER_URL",
           data: args.serverUrl,
@@ -269,10 +269,10 @@ describe("getters", () => {
           })
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", () => {
+      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
         const expected = {
           code: "UNKNOWN_ERROR",
           data: new Error("UNKNOWN_ERROR"),
@@ -282,7 +282,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
     });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -253,7 +253,7 @@ describe("getters", () => {
           )
         );
 
-        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
       test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
@@ -269,7 +269,7 @@ describe("getters", () => {
           })
         );
 
-        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
       test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
@@ -282,7 +282,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
     });
 
@@ -405,6 +405,38 @@ describe("getters", () => {
           workspaceAccessHelpers.transformWorkspaceCollections
         ).toBeCalled();
         expect(readJsonFileSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    test("Promise rejects with the code  if the network call fails with a timeout error (ETIMEDOUT)", async () => {
+      const args = {
+        accessToken: "token",
+        collection: "https://example.com/collection.json",
+      };
+
+      vi.spyOn(axios, "get").mockImplementation(() =>
+        Promise.reject(new AxiosError("ETIMEDOUT", "ETIMEDOUT"))
+      );
+
+      await expect(getResourceContents(args)).rejects.toMatchObject({
+        code: "UNKNOWN_ERROR",
+        data: expect.objectContaining({ code: "ETIMEDOUT" }),
+      });
+    });
+
+    test("Promise rejects with the code `UNKNOWN_ERROR` if the network call fails with a timeout error (ETIMEDOUT)", async () => {
+      const args = {
+        accessToken: "token",
+        collection: "https://example.com/collection.json",
+      };
+
+      vi.spyOn(axios, "get").mockImplementation(() =>
+        Promise.reject(new AxiosError("ETIMEDOUT", "ETIMEDOUT"))
+      );
+
+      await expect(getResourceContents(args)).rejects.toMatchObject({
+        code: "UNKNOWN_ERROR",
+        data: expect.objectContaining({ code: "ETIMEDOUT" }),
       });
     });
   });

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -568,12 +568,6 @@ describe("getters", () => {
           secret: false,
         },
         {
-          key: "SHARED_KEY_II",
-          currentValue: "environment-variable-shared-value-II",
-          initialValue: "environment-variable-shared-value-II",
-          secret: false,
-        },
-        {
           key: "ENV_VAR_III",
           currentValue: "collection-variable-value-III",
           initialValue: "collection-variable-value-III",
@@ -583,6 +577,12 @@ describe("getters", () => {
           key: "COLL_VAR_VI",
           currentValue: "collection-variable-value-VI",
           initialValue: "collection-variable-value-VI",
+          secret: false,
+        },
+        {
+          key: "SHARED_KEY_II",
+          currentValue: "environment-variable-shared-value-II",
+          initialValue: "environment-variable-shared-value-II",
           secret: false,
         },
         {

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -232,7 +232,7 @@ describe("getters", () => {
           },
           expected: {
             code: "UNKNOWN_ERROR",
-            data: new AxiosError("ETIMEDOUT", "ETIMEDOUT"),
+            data: expect.objectContaining({ code: "ETIMEDOUT" }),
           },
         },
       ];
@@ -253,7 +253,7 @@ describe("getters", () => {
           )
         );
 
-        await expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
       });
 
       test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
@@ -269,7 +269,7 @@ describe("getters", () => {
           })
         );
 
-        await expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
       });
 
       test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
@@ -282,7 +282,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        await expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toMatchObject(expected);
       });
     });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -408,22 +408,6 @@ describe("getters", () => {
       });
     });
 
-    test("Promise rejects with the code  if the network call fails with a timeout error (ETIMEDOUT)", async () => {
-      const args = {
-        accessToken: "token",
-        collection: "https://example.com/collection.json",
-      };
-
-      vi.spyOn(axios, "get").mockImplementation(() =>
-        Promise.reject(new AxiosError("ETIMEDOUT", "ETIMEDOUT"))
-      );
-
-      await expect(getResourceContents(args)).rejects.toMatchObject({
-        code: "UNKNOWN_ERROR",
-        data: expect.objectContaining({ code: "ETIMEDOUT" }),
-      });
-    });
-
     test("Promise rejects with the code `UNKNOWN_ERROR` if the network call fails with a timeout error (ETIMEDOUT)", async () => {
       const args = {
         accessToken: "token",

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -407,22 +407,6 @@ describe("getters", () => {
         expect(readJsonFileSpy).not.toHaveBeenCalled();
       });
     });
-
-    test("Promise rejects with the code `UNKNOWN_ERROR` if the network call fails with a timeout error (ETIMEDOUT)", async () => {
-      const args = {
-        accessToken: "token",
-        collection: "https://example.com/collection.json",
-      };
-
-      vi.spyOn(axios, "get").mockImplementation(() =>
-        Promise.reject(new AxiosError("ETIMEDOUT", "ETIMEDOUT"))
-      );
-
-      await expect(getResourceContents(args)).rejects.toMatchObject({
-        code: "UNKNOWN_ERROR",
-        data: expect.objectContaining({ code: "ETIMEDOUT" }),
-      });
-    });
   });
 
   describe("getResolvedVariables", () => {

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -223,6 +223,18 @@ describe("getters", () => {
             data: "test-environment-id-or-path",
           },
         },
+        {
+          description:
+            "Promise rejects with the code `UNKNOWN_ERROR` if the network call fails with a timeout error (ETIMEDOUT)",
+          args,
+          axiosMock: {
+            code: "ETIMEDOUT",
+          },
+          expected: {
+            code: "UNKNOWN_ERROR",
+            data: new AxiosError("ETIMEDOUT", "ETIMEDOUT"),
+          },
+        },
       ];
 
       test.each(cases)("$description", ({ args, axiosMock, expected }) => {

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -515,5 +515,81 @@ describe("getters", () => {
         getResolvedVariables(requestVariables, environmentVariables)
       ).toEqual(expected);
     });
+
+    test("Priority logic: Request variables > Collection variables > Environment variables", () => {
+      const collectionVariables = [
+        {
+          key: "SHARED_KEY_I",
+          initialValue: "collection-variable-shared-value-I",
+          currentValue: "collection-variable-shared-value-I",
+          secret: false,
+        },
+        {
+          key: "ENV_VAR_III",
+          initialValue: "collection-variable-value-III",
+          currentValue: "collection-variable-value-III",
+          secret: false,
+        },
+        {
+          key: "COLL_VAR_VI",
+          initialValue: "collection-variable-value-VI",
+          currentValue: "collection-variable-value-VI",
+          secret: false,
+        },
+      ];
+
+      const expected = [
+        {
+          key: "SHARED_KEY_I",
+          currentValue: "request-variable-shared-value-I",
+          initialValue: "request-variable-shared-value-I",
+          secret: false,
+        },
+        {
+          key: "REQUEST_VAR_III",
+          currentValue: "request-variable-value-III",
+          initialValue: "request-variable-value-III",
+          secret: false,
+        },
+        {
+          key: "SHARED_KEY_II",
+          currentValue: "environment-variable-shared-value-II",
+          initialValue: "environment-variable-shared-value-II",
+          secret: false,
+        },
+        {
+          key: "ENV_VAR_III",
+          currentValue: "collection-variable-value-III",
+          initialValue: "collection-variable-value-III",
+          secret: false,
+        },
+        {
+          key: "COLL_VAR_VI",
+          currentValue: "collection-variable-value-VI",
+          initialValue: "collection-variable-value-VI",
+          secret: false,
+        },
+        {
+          key: "ENV_VAR_IV",
+          currentValue: "environment-variable-value-IV",
+          initialValue: "environment-variable-value-IV",
+          secret: false,
+        },
+        {
+          key: "ENV_VAR_V",
+          currentValue: "environment-variable-value-V",
+          initialValue: "environment-variable-value-V",
+          secret: false,
+        },
+      ];
+
+      expect(
+        getResolvedVariables(
+          requestVariables,
+          environmentVariables,
+          collectionVariables
+        )
+      ).toEqual(expected);
+    });
   });
 });

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -249,6 +249,8 @@ export const getResourceContents = async (
         ) {
           throw error({ code: "INVALID_SERVER_URL", data: resolvedServerUrl });
         }
+
+        throw error({ code: "UNKNOWN_ERROR", data: err });
       } else {
         throw error({ code: "UNKNOWN_ERROR", data: err });
       }

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -249,11 +249,9 @@ export const getResourceContents = async (
         ) {
           throw error({ code: "INVALID_SERVER_URL", data: resolvedServerUrl });
         }
-
-        throw error({ code: "UNKNOWN_ERROR", data: err });
-      } else {
-        throw error({ code: "UNKNOWN_ERROR", data: err });
       }
+
+      throw error({ code: "UNKNOWN_ERROR", data: err });
     }
   }
 


### PR DESCRIPTION
This PR adds missing unit test coverage for collection variables in the Hoppscotch CLI's `getResolvedVariables` utility. It ensures that variables correctly follow the priority order: Request Variables > Collection Variables > Environment Variables. Fixes #4136.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests for `getResolvedVariables` to enforce variable priority (Request > Collection > Environment), and hardens `getResourceContents` error handling for timeouts and unhandled `AxiosError`s. Fixes #4136.

- **Bug Fixes**
  - `getResourceContents`: keep `INVALID_SERVER_URL` for non‑JSON responses; otherwise always throw `UNKNOWN_ERROR` with the original error (e.g., `ETIMEDOUT`).
  - Tests: add collection-variable priority test; include `ETIMEDOUT` in parameterized cases; make `UNKNOWN_ERROR` assertions robust with partial matching; use async `await expect(...).rejects`.

<sup>Written for commit 28c36ca0a475cfe92b019d7b97c5377a1dc6eb63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

