### PR TITLE
feat(common): enhance response pane functionality with collapsible feature

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1229,10 +1229,13 @@
   "response": {
     "audio": "Audio",
     "body": "Response Body",
+    "collapse_response_pane": "Collapse response pane",
     "duplicated": "Response duplicated",
     "duplicate_name_error": "Same name response already exists",
+    "expand_response_pane": "Expand response pane",
     "filter_response_body": "Filter JSON response body (uses jq syntax)",
     "headers": "Headers",
+    "response_pane": "Response",
     "request_headers": "Request Headers",
     "html": "HTML",
     "image": "Image",

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -213,7 +213,6 @@ function syncHorizontalPaneSizesFromEvent(event: PaneEvent[]) {
 
 async function onHorizontalPaneResize(event: PaneEvent[]) {
   syncHorizontalPaneSizesFromEvent(event)
-  await setPaneEvent(event, "horizontal")
 }
 
 function getExpandedBottomSize(size: number) {

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -35,14 +35,16 @@
           :min-size="RESPONSE_COLLAPSED_SIZE"
         >
           <div
-            class="group z-[1] flex cursor-pointer items-center border-0 border-dividerLight bg-primary"
+            class="group z-[1] flex cursor-pointer items-center bg-primary"
             :class="
               isStackedLayout
-                ? 'sticky top-0 flex-row border-0 border-dividerLight px-1 py-2'
-                : 'sticky left-0 top-0 min-h-0 w-10 shrink-0 flex-col justify-center gap-1 self-stretch border-0 border-dividerLight px-1 py-2'
+                ? 'sticky top-0 flex-row border-b border-dividerLight px-1 py-2'
+                : 'sticky left-0 top-0 min-h-0 w-10 shrink-0 flex-col justify-center gap-1 self-stretch border-r border-dividerLight px-1 py-2'
             "
             role="button"
             tabindex="0"
+            :aria-expanded="!isResponseCollapsed"
+            aria-controls="response-pane-content"
             :title="
               isResponseCollapsed
                 ? t('response.expand_response_pane')
@@ -79,7 +81,7 @@
                 <IconChevronsLeft v-else class="h-3.5 w-3.5" />
               </span>
               <div
-                class="font-semibold font-size-lg font-weight-600 text-color"
+                class="font-semibold text-secondaryDark"
                 :class="
                   isStackedLayout
                     ? 'truncate text-center'
@@ -91,7 +93,8 @@
             </div>
           </div>
           <div
-            v-if="!isResponseCollapsed"
+            id="response-pane-content"
+            v-show="!isResponseCollapsed"
             class="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"
           >
             <slot name="secondary" />

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -63,7 +63,7 @@
               "
             >
               <span
-                class="pointer-events-none inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-0 transition group-hover:opacity-100"
+                class="pointer-events-none inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100"
                 aria-hidden="true"
               >
                 <IconChevronsDown
@@ -93,8 +93,8 @@
             </div>
           </div>
           <div
-            :id="`${props.layoutId ?? 'default'}-response-pane-content`"
             v-show="!isResponseCollapsed"
+            :id="`${props.layoutId ?? 'default'}-response-pane-content`"
             class="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"
           >
             <slot name="secondary" />
@@ -203,12 +203,33 @@ async function setPaneEvent(
   await persistenceService.setLocalConfig(storageKey, JSON.stringify(event))
 }
 
-function syncHorizontalPaneSizesFromEvent(event: PaneEvent[]) {
+function syncHorizontalPaneSizesFromEvent(
+  event: PaneEvent[],
+  options?: { clampExpanded?: boolean }
+) {
+  const clampExpanded = options?.clampExpanded ?? false
   if (event.length < 2) return
   const [mainTopPane, mainBottomPane] = event
+  if (mainBottomPane?.size === undefined || mainBottomPane?.size === null) {
+    return
+  }
+
+  const bottom = mainBottomPane.size
+  if (bottom > RESPONSE_COLLAPSED_SIZE + 0.1) {
+    if (clampExpanded) {
+      const clampedBottom = getExpandedBottomSize(bottom)
+      PANE_MAIN_BOTTOM_SIZE.value = clampedBottom
+      PANE_MAIN_TOP_SIZE.value = Math.max(100 - clampedBottom, 0)
+    } else {
+      if (mainTopPane?.size !== null) {
+        PANE_MAIN_TOP_SIZE.value = mainTopPane.size
+      }
+      PANE_MAIN_BOTTOM_SIZE.value = bottom
+    }
+    return
+  }
   if (mainTopPane?.size !== null) PANE_MAIN_TOP_SIZE.value = mainTopPane.size
-  if (mainBottomPane?.size !== null)
-    PANE_MAIN_BOTTOM_SIZE.value = mainBottomPane.size
+  PANE_MAIN_BOTTOM_SIZE.value = bottom
 }
 
 function onHorizontalPaneResize(event: PaneEvent[]) {
@@ -220,12 +241,20 @@ function getExpandedBottomSize(size: number) {
 }
 
 async function onHorizontalPaneResized(event: PaneEvent[]) {
-  syncHorizontalPaneSizesFromEvent(event)
+  syncHorizontalPaneSizesFromEvent(event, {
+    clampExpanded: true,
+  })
   const mainBottomPane = event[1]
   if (mainBottomPane && mainBottomPane.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
     lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
   }
-  await setPaneEvent(event, "horizontal")
+  await setPaneEvent(
+    [
+      { max: 100, min: 0, size: PANE_MAIN_TOP_SIZE.value },
+      { max: 100, min: 0, size: PANE_MAIN_BOTTOM_SIZE.value },
+    ],
+    "horizontal"
+  )
 }
 
 async function populatePaneEvent() {
@@ -240,9 +269,10 @@ async function populatePaneEvent() {
 
   const horizontalPaneData = await getPaneData("horizontal")
   if (horizontalPaneData && Array.isArray(horizontalPaneData)) {
-    const [mainTopPane, mainBottomPane] = horizontalPaneData
-    PANE_MAIN_TOP_SIZE.value = mainTopPane?.size
-    PANE_MAIN_BOTTOM_SIZE.value = mainBottomPane?.size
+    syncHorizontalPaneSizesFromEvent(horizontalPaneData, {
+      clampExpanded: true,
+    })
+    const mainBottomPane = horizontalPaneData[1]
     if (mainBottomPane?.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
       lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
     }
@@ -269,9 +299,14 @@ async function persistHorizontalLayout() {
 
 async function toggleResponsePane() {
   if (isResponseCollapsed.value) {
-    const expandedBottom = getExpandedBottomSize(lastExpandedBottomSize.value)
+    const primaryMinSize = props.isEmbed ? 12 : 25
+    const maxBottomSize = 100 - primaryMinSize
+    const expandedBottom = Math.min(
+      getExpandedBottomSize(lastExpandedBottomSize.value),
+      maxBottomSize
+    )
     PANE_MAIN_BOTTOM_SIZE.value = expandedBottom
-    PANE_MAIN_TOP_SIZE.value = Math.max(100 - expandedBottom, 0)
+    PANE_MAIN_TOP_SIZE.value = 100 - expandedBottom
   } else {
     lastExpandedBottomSize.value = getExpandedBottomSize(
       PANE_MAIN_BOTTOM_SIZE.value

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -32,7 +32,11 @@
           :size="PANE_MAIN_BOTTOM_SIZE"
           class="flex min-h-0 flex-1 overflow-hidden"
           :class="isStackedLayout ? 'flex-col' : 'flex-row'"
-          :min-size="RESPONSE_COLLAPSED_SIZE"
+          :min-size="
+            isResponseCollapsed
+              ? RESPONSE_COLLAPSED_SIZE
+              : RESPONSE_EXPANDED_MIN_SIZE
+          "
         >
           <div
             class="group z-[1] flex cursor-pointer items-center bg-primary"
@@ -142,7 +146,6 @@ const breakpoints = useBreakpoints(breakpointsTailwind)
 const mdAndLarger = breakpoints.greater("md")
 
 const COLUMN_LAYOUT = useSetting("COLUMN_LAYOUT")
-
 const SIDEBAR = useSetting("SIDEBAR")
 
 const slots = useSlots()
@@ -172,26 +175,30 @@ const isStackedLayout = computed(
   () => COLUMN_LAYOUT.value || props.forceColumnLayout
 )
 
-const PANE_MAIN_SIZE = ref(70)
-const PANE_SIDEBAR_SIZE = ref(30)
-const PANE_MAIN_TOP_SIZE = ref(35)
-const PANE_MAIN_BOTTOM_SIZE = ref(65)
 const RESPONSE_COLLAPSED_SIZE = 5
 const RESPONSE_EXPANDED_MIN_SIZE = 25
+const PANE_MAIN_SIZE = ref(70)
+const PANE_SIDEBAR_SIZE = ref(30)
+
+// Default top/bottom split depends on layout direction
+const PANE_MAIN_TOP_SIZE = ref(COLUMN_LAYOUT.value ? 35 : 50)
+const PANE_MAIN_BOTTOM_SIZE = ref(COLUMN_LAYOUT.value ? 65 : 50)
+
+/** Last known expanded size – used to restore after a collapse toggle */
 const lastExpandedBottomSize = ref(PANE_MAIN_BOTTOM_SIZE.value)
 
-if (!COLUMN_LAYOUT.value) {
-  PANE_MAIN_TOP_SIZE.value = 50
-  PANE_MAIN_BOTTOM_SIZE.value = 50
-}
+const isResponseCollapsed = computed(
+  () => PANE_MAIN_BOTTOM_SIZE.value <= RESPONSE_COLLAPSED_SIZE + 0.1
+)
 
 async function getPaneData(
   type: "vertical" | "horizontal"
 ): Promise<PaneEvent[] | null> {
+  if (!props.layoutId) return null
   const storageKey = `${props.layoutId}-pane-config-${type}`
-  const paneEvent = await persistenceService.getLocalConfig(storageKey)
-  if (!paneEvent) return null
-  return JSON.parse(paneEvent)
+  const raw = await persistenceService.getLocalConfig(storageKey)
+  if (!raw) return null
+  return JSON.parse(raw)
 }
 
 async function setPaneEvent(
@@ -203,51 +210,57 @@ async function setPaneEvent(
   await persistenceService.setLocalConfig(storageKey, JSON.stringify(event))
 }
 
-function syncHorizontalPaneSizesFromEvent(
-  event: PaneEvent[],
-  options?: { clampExpanded?: boolean }
-) {
-  const clampExpanded = options?.clampExpanded ?? false
-  if (event.length < 2) return
-  const [mainTopPane, mainBottomPane] = event
-  if (mainBottomPane?.size === undefined || mainBottomPane?.size === null) {
-    return
-  }
-
-  const bottom = mainBottomPane.size
-  if (bottom > RESPONSE_COLLAPSED_SIZE + 0.1) {
-    if (clampExpanded) {
-      const clampedBottom = getExpandedBottomSize(bottom)
-      PANE_MAIN_BOTTOM_SIZE.value = clampedBottom
-      PANE_MAIN_TOP_SIZE.value = Math.max(100 - clampedBottom, 0)
-    } else {
-      if (mainTopPane?.size !== null) {
-        PANE_MAIN_TOP_SIZE.value = mainTopPane.size
-      }
-      PANE_MAIN_BOTTOM_SIZE.value = bottom
-    }
-    return
-  }
-  if (mainTopPane?.size !== null) PANE_MAIN_TOP_SIZE.value = mainTopPane.size
-  PANE_MAIN_BOTTOM_SIZE.value = bottom
-}
-
-function onHorizontalPaneResize(event: PaneEvent[]) {
-  syncHorizontalPaneSizesFromEvent(event)
-}
-
-function getExpandedBottomSize(size: number) {
+function clampBottomSize(size: number): number {
+  if (size <= RESPONSE_COLLAPSED_SIZE + 0.1) return RESPONSE_COLLAPSED_SIZE
   return Math.max(size, RESPONSE_EXPANDED_MIN_SIZE)
 }
 
-async function onHorizontalPaneResized(event: PaneEvent[]) {
-  syncHorizontalPaneSizesFromEvent(event, {
-    clampExpanded: true,
-  })
-  const mainBottomPane = event[1]
-  if (mainBottomPane && mainBottomPane.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
-    lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
+/**
+ * Apply a horizontal pane event array to the reactive size refs.
+ *
+ * @param event  - Two-element array from Splitpanes [top, bottom].
+ * @param clamp  - When true the bottom size is clamped to either the collapsed
+ *                 sentinel or RESPONSE_EXPANDED_MIN_SIZE, and the top size is
+ *                 recalculated to fill the remainder.  Pass `true` on drag-end
+ *                 and on hydration from storage; pass `false` during live drag
+ *                 so the user sees smooth feedback.
+ */
+function syncHorizontalPaneSizes(
+  event: PaneEvent[],
+  clamp: boolean = false
+): void {
+  if (event.length < 2) return
+
+  const [topPane, bottomPane] = event
+
+  if (bottomPane?.size === null || bottomPane?.size === undefined) return
+
+  const bottom = clamp ? clampBottomSize(bottomPane.size) : bottomPane.size
+
+  PANE_MAIN_BOTTOM_SIZE.value = bottom
+
+  PANE_MAIN_TOP_SIZE.value =
+    clamp || topPane?.size === null || topPane?.size === undefined
+      ? Math.max(100 - bottom, 0)
+      : topPane.size
+}
+
+function onHorizontalPaneResize(event: PaneEvent[]): void {
+  syncHorizontalPaneSizes(event, false)
+}
+
+async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
+  syncHorizontalPaneSizes(event, true)
+
+  if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
+    lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
   }
+
+  await persistCurrentHorizontalLayout()
+}
+
+async function persistCurrentHorizontalLayout(): Promise<void> {
+  if (!props.layoutId || !hasSecondary.value) return
   await setPaneEvent(
     [
       { max: 100, min: 0, size: PANE_MAIN_TOP_SIZE.value },
@@ -257,24 +270,24 @@ async function onHorizontalPaneResized(event: PaneEvent[]) {
   )
 }
 
-async function populatePaneEvent() {
+async function populatePaneEvent(): Promise<void> {
   if (!props.layoutId) return
 
   const verticalPaneData = await getPaneData("vertical")
-  if (verticalPaneData && Array.isArray(verticalPaneData)) {
+  if (Array.isArray(verticalPaneData) && verticalPaneData.length >= 2) {
     const [mainPane, sidebarPane] = verticalPaneData
-    PANE_MAIN_SIZE.value = mainPane?.size
-    PANE_SIDEBAR_SIZE.value = sidebarPane?.size
+    if (mainPane?.size !== null && mainPane?.size !== undefined)
+      PANE_MAIN_SIZE.value = mainPane.size
+    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined)
+      PANE_SIDEBAR_SIZE.value = sidebarPane.size
   }
 
   const horizontalPaneData = await getPaneData("horizontal")
-  if (horizontalPaneData && Array.isArray(horizontalPaneData)) {
-    syncHorizontalPaneSizesFromEvent(horizontalPaneData, {
-      clampExpanded: true,
-    })
-    const mainBottomPane = horizontalPaneData[1]
-    if (mainBottomPane?.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
-      lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
+  if (Array.isArray(horizontalPaneData) && horizontalPaneData.length >= 2) {
+    syncHorizontalPaneSizes(horizontalPaneData, true)
+
+    if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
+      lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
     }
   }
 }
@@ -283,38 +296,23 @@ onMounted(async () => {
   await populatePaneEvent()
 })
 
-const isResponseCollapsed = computed(
-  () => PANE_MAIN_BOTTOM_SIZE.value <= RESPONSE_COLLAPSED_SIZE + 0.1
-)
+async function toggleResponsePane(): Promise<void> {
+  const primaryMinSize = props.isEmbed ? 12 : 25
+  const maxBottomSize = 100 - primaryMinSize
 
-async function persistHorizontalLayout() {
-  if (!props.layoutId || !hasSecondary.value) return
-  const storageKey = `${props.layoutId}-pane-config-horizontal`
-  const paneEvent = [
-    { max: 100, min: 0, size: PANE_MAIN_TOP_SIZE.value },
-    { max: 100, min: 0, size: PANE_MAIN_BOTTOM_SIZE.value },
-  ]
-  await persistenceService.setLocalConfig(storageKey, JSON.stringify(paneEvent))
-}
-
-async function toggleResponsePane() {
   if (isResponseCollapsed.value) {
-    const primaryMinSize = props.isEmbed ? 12 : 25
-    const maxBottomSize = 100 - primaryMinSize
     const expandedBottom = Math.min(
-      getExpandedBottomSize(lastExpandedBottomSize.value),
+      Math.max(lastExpandedBottomSize.value, RESPONSE_EXPANDED_MIN_SIZE),
       maxBottomSize
     )
     PANE_MAIN_BOTTOM_SIZE.value = expandedBottom
     PANE_MAIN_TOP_SIZE.value = 100 - expandedBottom
   } else {
-    lastExpandedBottomSize.value = getExpandedBottomSize(
-      PANE_MAIN_BOTTOM_SIZE.value
-    )
+    lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
     PANE_MAIN_BOTTOM_SIZE.value = RESPONSE_COLLAPSED_SIZE
     PANE_MAIN_TOP_SIZE.value = Math.max(100 - RESPONSE_COLLAPSED_SIZE, 0)
   }
 
-  await persistHorizontalLayout()
+  await persistCurrentHorizontalLayout()
 }
 </script>

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -17,7 +17,8 @@
       <Splitpanes
         class="smart-splitter"
         :horizontal="COLUMN_LAYOUT || forceColumnLayout"
-        @resize="setPaneEvent($event, 'horizontal')"
+        @resize="onHorizontalPaneResize"
+        @resized="onHorizontalPaneResized"
       >
         <Pane
           :size="PANE_MAIN_TOP_SIZE"
@@ -29,10 +30,72 @@
         <Pane
           v-if="hasSecondary"
           :size="PANE_MAIN_BOTTOM_SIZE"
-          class="flex flex-col overflow-auto"
-          min-size="25"
+          class="flex min-h-0 flex-1 overflow-hidden"
+          :class="isStackedLayout ? 'flex-col' : 'flex-row'"
+          :min-size="RESPONSE_COLLAPSED_SIZE"
         >
-          <slot name="secondary" />
+          <div
+            class="group z-[1] flex cursor-pointer items-center border-0 border-dividerLight bg-primary"
+            :class="
+              isStackedLayout
+                ? 'sticky top-0 flex-row border-0 border-dividerLight px-1 py-2'
+                : 'sticky left-0 top-0 min-h-0 w-10 shrink-0 flex-col justify-center gap-1 self-stretch border-0 border-dividerLight px-1 py-2'
+            "
+            role="button"
+            tabindex="0"
+            :title="
+              isResponseCollapsed
+                ? t('response.expand_response_pane')
+                : t('response.collapse_response_pane')
+            "
+            @click="toggleResponsePane"
+            @keydown.enter.prevent="toggleResponsePane"
+            @keydown.space.prevent="toggleResponsePane"
+          >
+            <div
+              class="flex cursor-pointer"
+              :class="
+                isStackedLayout
+                  ? 'flex-1 flex-row items-center self-stretch'
+                  : 'flex-col items-center justify-center gap-1 self-stretch'
+              "
+            >
+              <span
+                class="pointer-events-none inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-0 transition group-hover:opacity-100"
+                aria-hidden="true"
+              >
+                <IconChevronsDown
+                  v-if="isStackedLayout && !isResponseCollapsed"
+                  class="h-3.5 w-3.5"
+                />
+                <IconChevronsUp
+                  v-else-if="isStackedLayout && isResponseCollapsed"
+                  class="h-3.5 w-3.5"
+                />
+                <IconChevronsRight
+                  v-else-if="!isStackedLayout && !isResponseCollapsed"
+                  class="h-3.5 w-3.5"
+                />
+                <IconChevronsLeft v-else class="h-3.5 w-3.5" />
+              </span>
+              <div
+                class="font-semibold font-size-lg font-weight-600 text-color"
+                :class="
+                  isStackedLayout
+                    ? 'truncate text-center'
+                    : 'rotate-180 text-center [text-orientation:mixed] [writing-mode:vertical-rl]'
+                "
+              >
+                {{ t("response.response_pane") }}
+              </div>
+            </div>
+          </div>
+          <div
+            v-if="!isResponseCollapsed"
+            class="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"
+          >
+            <slot name="secondary" />
+          </div>
         </Pane>
       </Splitpanes>
     </Pane>
@@ -55,7 +118,20 @@ import { useSetting } from "@composables/settings"
 import { breakpointsTailwind, useBreakpoints } from "@vueuse/core"
 import { useService } from "dioc/vue"
 import { computed, onMounted, ref, useSlots } from "vue"
+import IconChevronsDown from "~icons/lucide/chevrons-down"
+import IconChevronsLeft from "~icons/lucide/chevrons-left"
+import IconChevronsRight from "~icons/lucide/chevrons-right"
+import IconChevronsUp from "~icons/lucide/chevrons-up"
+import { useI18n } from "~/composables/i18n"
 import { PersistenceService } from "~/services/persistence"
+
+const t = useI18n()
+
+type PaneEvent = {
+  max: number
+  min: number
+  size: number
+}
 
 const SIDEBAR_ON_LEFT = useSetting("SIDEBAR_ON_LEFT")
 
@@ -88,20 +164,31 @@ const props = defineProps({
   },
 })
 
-type PaneEvent = {
-  max: number
-  min: number
-  size: number
-}
+/** Stacked top/bottom panes (Splitpanes horizontal); false = side-by-side */
+const isStackedLayout = computed(
+  () => COLUMN_LAYOUT.value || props.forceColumnLayout
+)
 
 const PANE_MAIN_SIZE = ref(70)
 const PANE_SIDEBAR_SIZE = ref(30)
 const PANE_MAIN_TOP_SIZE = ref(35)
 const PANE_MAIN_BOTTOM_SIZE = ref(65)
+const RESPONSE_COLLAPSED_SIZE = 5
+const RESPONSE_EXPANDED_MIN_SIZE = 25
+const lastExpandedBottomSize = ref(PANE_MAIN_BOTTOM_SIZE.value)
 
 if (!COLUMN_LAYOUT.value) {
   PANE_MAIN_TOP_SIZE.value = 50
   PANE_MAIN_BOTTOM_SIZE.value = 50
+}
+
+async function getPaneData(
+  type: "vertical" | "horizontal"
+): Promise<PaneEvent[] | null> {
+  const storageKey = `${props.layoutId}-pane-config-${type}`
+  const paneEvent = await persistenceService.getLocalConfig(storageKey)
+  if (!paneEvent) return null
+  return JSON.parse(paneEvent)
 }
 
 async function setPaneEvent(
@@ -111,6 +198,32 @@ async function setPaneEvent(
   if (!props.layoutId) return
   const storageKey = `${props.layoutId}-pane-config-${type}`
   await persistenceService.setLocalConfig(storageKey, JSON.stringify(event))
+}
+
+function syncHorizontalPaneSizesFromEvent(event: PaneEvent[]) {
+  if (event.length < 2) return
+  const [mainTopPane, mainBottomPane] = event
+  if (mainTopPane?.size !== null) PANE_MAIN_TOP_SIZE.value = mainTopPane.size
+  if (mainBottomPane?.size !== null)
+    PANE_MAIN_BOTTOM_SIZE.value = mainBottomPane.size
+}
+
+async function onHorizontalPaneResize(event: PaneEvent[]) {
+  syncHorizontalPaneSizesFromEvent(event)
+  await setPaneEvent(event, "horizontal")
+}
+
+function getExpandedBottomSize(size: number) {
+  return Math.max(size, RESPONSE_EXPANDED_MIN_SIZE)
+}
+
+async function onHorizontalPaneResized(event: PaneEvent[]) {
+  syncHorizontalPaneSizesFromEvent(event)
+  const mainBottomPane = event[1]
+  if (mainBottomPane && mainBottomPane.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
+    lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
+  }
+  await setPaneEvent(event, "horizontal")
 }
 
 async function populatePaneEvent() {
@@ -131,16 +244,37 @@ async function populatePaneEvent() {
   }
 }
 
-async function getPaneData(
-  type: "vertical" | "horizontal"
-): Promise<PaneEvent[] | null> {
-  const storageKey = `${props.layoutId}-pane-config-${type}`
-  const paneEvent = await persistenceService.getLocalConfig(storageKey)
-  if (!paneEvent) return null
-  return JSON.parse(paneEvent)
-}
-
 onMounted(async () => {
   await populatePaneEvent()
 })
+
+const isResponseCollapsed = computed(
+  () => PANE_MAIN_BOTTOM_SIZE.value <= RESPONSE_COLLAPSED_SIZE + 0.1
+)
+
+async function persistHorizontalLayout() {
+  if (!props.layoutId || !hasSecondary.value) return
+  const storageKey = `${props.layoutId}-pane-config-horizontal`
+  const paneEvent = [
+    { max: 100, min: 0, size: PANE_MAIN_TOP_SIZE.value },
+    { max: 100, min: 0, size: PANE_MAIN_BOTTOM_SIZE.value },
+  ]
+  await persistenceService.setLocalConfig(storageKey, JSON.stringify(paneEvent))
+}
+
+async function toggleResponsePane() {
+  if (isResponseCollapsed.value) {
+    const expandedBottom = getExpandedBottomSize(lastExpandedBottomSize.value)
+    PANE_MAIN_BOTTOM_SIZE.value = expandedBottom
+    PANE_MAIN_TOP_SIZE.value = Math.max(100 - expandedBottom, 0)
+  } else {
+    lastExpandedBottomSize.value = getExpandedBottomSize(
+      PANE_MAIN_BOTTOM_SIZE.value
+    )
+    PANE_MAIN_BOTTOM_SIZE.value = RESPONSE_COLLAPSED_SIZE
+    PANE_MAIN_TOP_SIZE.value = Math.max(100 - RESPONSE_COLLAPSED_SIZE, 0)
+  }
+
+  await persistHorizontalLayout()
+}
 </script>

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -39,12 +39,12 @@
             :class="
               isStackedLayout
                 ? 'sticky top-0 flex-row border-b border-dividerLight px-1 py-2'
-                : 'sticky left-0 top-0 min-h-0 w-10 shrink-0 flex-col justify-center gap-1 self-stretch border-r border-dividerLight px-1 py-2'
+                : 'sticky left-0 top-0 min-h-0 w-10 shrink-0 flex-col justify-center gap-1 self-stretch border-dividerLight px-1 py-2'
             "
             role="button"
             tabindex="0"
             :aria-expanded="!isResponseCollapsed"
-            aria-controls="response-pane-content"
+            :aria-controls="`${props.layoutId ?? 'default'}-response-pane-content`"
             :title="
               isResponseCollapsed
                 ? t('response.expand_response_pane')
@@ -92,7 +92,6 @@
               </div>
             </div>
           </div>
-          <div
           <div
             :id="`${props.layoutId ?? 'default'}-response-pane-content`"
             v-show="!isResponseCollapsed"
@@ -212,7 +211,7 @@ function syncHorizontalPaneSizesFromEvent(event: PaneEvent[]) {
     PANE_MAIN_BOTTOM_SIZE.value = mainBottomPane.size
 }
 
-async function onHorizontalPaneResize(event: PaneEvent[]) {
+function onHorizontalPaneResize(event: PaneEvent[]) {
   syncHorizontalPaneSizesFromEvent(event)
 }
 
@@ -244,6 +243,9 @@ async function populatePaneEvent() {
     const [mainTopPane, mainBottomPane] = horizontalPaneData
     PANE_MAIN_TOP_SIZE.value = mainTopPane?.size
     PANE_MAIN_BOTTOM_SIZE.value = mainBottomPane?.size
+    if (mainBottomPane?.size > RESPONSE_COLLAPSED_SIZE + 0.1) {
+      lastExpandedBottomSize.value = getExpandedBottomSize(mainBottomPane.size)
+    }
   }
 }
 

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -32,11 +32,7 @@
           :size="PANE_MAIN_BOTTOM_SIZE"
           class="flex min-h-0 flex-1 overflow-hidden"
           :class="isStackedLayout ? 'flex-col' : 'flex-row'"
-          :min-size="
-            isResponseCollapsed
-              ? RESPONSE_COLLAPSED_SIZE
-              : RESPONSE_EXPANDED_MIN_SIZE
-          "
+          :min-size="RESPONSE_COLLAPSED_SIZE"
         >
           <div
             class="group z-[1] flex cursor-pointer items-center bg-primary"
@@ -223,17 +219,16 @@ async function setPaneEvent(
  * RESPONSE_EXPANDED_MIN_SIZE.
  */
 function clampBottomSize(size: number): number {
-  if (size <= RESPONSE_COLLAPSED_SIZE + 0.1) return RESPONSE_COLLAPSED_SIZE
-  return Math.max(size, RESPONSE_EXPANDED_MIN_SIZE)
+  return size <= RESPONSE_COLLAPSED_SIZE + 0.1 ? RESPONSE_COLLAPSED_SIZE : size
 }
 
 /**
  * Apply a horizontal pane event array to the reactive size refs.
  *
  * @param event  - Two-element array from Splitpanes [top, bottom].
- * @param clamp  - When true the bottom size is clamped to either the collapsed
- *                 sentinel or RESPONSE_EXPANDED_MIN_SIZE, and the top size is
- *                 recalculated to fill the remainder.  Pass `true` on drag-end
+ * @param clamp  - When true the bottom size is snapped to the collapsed sentinel
+ *                 if at or below RESPONSE_COLLAPSED_SIZE, and the top size is
+ *                 recalculated to fill the remainder. Pass `true` on drag-end
  *                 and on hydration from storage; pass `false` during live drag
  *                 so the user sees smooth feedback.
  */
@@ -251,25 +246,22 @@ function syncHorizontalPaneSizes(
 
   PANE_MAIN_BOTTOM_SIZE.value = bottom
 
-  const topSize = topPane?.size
-  if (clamp || topSize === null || topSize === undefined) {
-    PANE_MAIN_TOP_SIZE.value = Math.max(100 - bottom, 0)
-  } else {
-    PANE_MAIN_TOP_SIZE.value = topSize
-  }
+  PANE_MAIN_TOP_SIZE.value =
+    clamp || topPane?.size === null || topPane?.size === undefined
+      ? Math.max(100 - bottom, 0)
+      : topPane.size
 }
 
 function onHorizontalPaneResize(event: PaneEvent[]): void {
   syncHorizontalPaneSizes(event, false)
-}
-
-async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
-  syncHorizontalPaneSizes(event, true)
-
   if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
     lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
   }
+}
 
+async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
+  // Snap to collapsed sentinel on release if the user dragged to the threshold.
+  syncHorizontalPaneSizes(event, true)
   await persistCurrentHorizontalLayout()
 }
 
@@ -290,12 +282,10 @@ async function populatePaneEvent(): Promise<void> {
   const verticalPaneData = await getPaneData("vertical")
   if (Array.isArray(verticalPaneData) && verticalPaneData.length >= 2) {
     const [mainPane, sidebarPane] = verticalPaneData
-    if (mainPane?.size !== null && mainPane?.size !== undefined) {
+    if (mainPane?.size !== null && mainPane?.size !== undefined)
       PANE_MAIN_SIZE.value = mainPane.size
-    }
-    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined) {
+    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined)
       PANE_SIDEBAR_SIZE.value = sidebarPane.size
-    }
   }
 
   const horizontalPaneData = await getPaneData("horizontal")

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -259,6 +259,15 @@ async function persistResponseCollapseMode(
 
 // ─── Pane-size persistence ───
 
+/**
+ * Returns the legacy per-type key used before the consolidated store was
+ * introduced (e.g. "rest-primary-pane-config-horizontal"). Used only as a
+ * one-time migration fallback in populatePaneEvent.
+ */
+function legacyPaneConfigKey(type: "vertical" | "horizontal"): string | null {
+  return props.layoutId ? `${props.layoutId}-pane-config-${type}` : null
+}
+
 async function getPaneData(
   type: "vertical" | "horizontal"
 ): Promise<PaneEvent[] | null> {
@@ -266,6 +275,25 @@ async function getPaneData(
   if (!key) return null
   const store = await readJsonConfig<Partial<PaneConfigStore>>(key)
   return store?.[type]?.[contextId()] ?? null
+}
+
+/**
+ * Reads pane data from the legacy per-type key format. Returns the parsed
+ * PaneEvent array if found, or null if the key never existed.
+ */
+async function getLegacyPaneData(
+  type: "vertical" | "horizontal"
+): Promise<PaneEvent[] | null> {
+  const key = legacyPaneConfigKey(type)
+  if (!key) return null
+  const raw = await persistenceService.getLocalConfig(key)
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as PaneEvent[]) : null
+  } catch {
+    return null
+  }
 }
 
 async function setPaneEvent(
@@ -353,14 +381,28 @@ async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
 async function populatePaneEvent(): Promise<void> {
   if (!props.layoutId) return
 
-  const verticalData = await getPaneData("vertical")
+  // For each axis, try the new consolidated key first. If absent, fall back to
+  // the legacy per-type key and immediately write the value into the new store
+  // so the migration only runs once.
+  async function resolveData(
+    type: "vertical" | "horizontal"
+  ): Promise<PaneEvent[] | null> {
+    const fresh = await getPaneData(type)
+    if (fresh) return fresh
+
+    const legacy = await getLegacyPaneData(type)
+    if (legacy) await setPaneEvent(legacy, type)
+    return legacy
+  }
+
+  const verticalData = await resolveData("vertical")
   if (Array.isArray(verticalData) && verticalData.length >= 2) {
     const [main, sidebar] = verticalData
     if (main?.size != null) PANE_MAIN_SIZE.value = main.size
     if (sidebar?.size != null) PANE_SIDEBAR_SIZE.value = sidebar.size
   }
 
-  const horizontalData = await getPaneData("horizontal")
+  const horizontalData = await resolveData("horizontal")
   if (!Array.isArray(horizontalData) || horizontalData.length < 2) return
 
   syncHorizontalPaneSizes(horizontalData, true)
@@ -383,6 +425,7 @@ async function populatePaneEvent(): Promise<void> {
 onMounted(populatePaneEvent)
 
 // ─── Toggle ───
+
 async function toggleResponsePane(): Promise<void> {
   if (isResponseCollapsed.value) {
     const expanded =

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -181,8 +181,8 @@ const PANE_MAIN_SIZE = ref(70)
 const PANE_SIDEBAR_SIZE = ref(30)
 
 // Default top/bottom split depends on layout direction
-const PANE_MAIN_TOP_SIZE = ref(COLUMN_LAYOUT.value ? 35 : 50)
-const PANE_MAIN_BOTTOM_SIZE = ref(COLUMN_LAYOUT.value ? 65 : 50)
+const PANE_MAIN_TOP_SIZE = ref(isStackedLayout.value ? 35 : 50)
+const PANE_MAIN_BOTTOM_SIZE = ref(isStackedLayout.value ? 65 : 50)
 
 /** Last known expanded size – used to restore after a collapse toggle */
 const lastExpandedBottomSize = ref(PANE_MAIN_BOTTOM_SIZE.value)
@@ -198,7 +198,11 @@ async function getPaneData(
   const storageKey = `${props.layoutId}-pane-config-${type}`
   const raw = await persistenceService.getLocalConfig(storageKey)
   if (!raw) return null
-  return JSON.parse(raw)
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
 }
 
 async function setPaneEvent(
@@ -210,6 +214,14 @@ async function setPaneEvent(
   await persistenceService.setLocalConfig(storageKey, JSON.stringify(event))
 }
 
+/**
+ * Clamp a bottom-pane size so it is never in the ambiguous zone between
+ * collapsed and the enforced expanded minimum.
+ *
+ * If the stored/dragged value is clearly collapsed (≤ RESPONSE_COLLAPSED_SIZE)
+ * we leave it alone.  Otherwise we push it up to at least
+ * RESPONSE_EXPANDED_MIN_SIZE.
+ */
 function clampBottomSize(size: number): number {
   if (size <= RESPONSE_COLLAPSED_SIZE + 0.1) return RESPONSE_COLLAPSED_SIZE
   return Math.max(size, RESPONSE_EXPANDED_MIN_SIZE)
@@ -239,10 +251,12 @@ function syncHorizontalPaneSizes(
 
   PANE_MAIN_BOTTOM_SIZE.value = bottom
 
-  PANE_MAIN_TOP_SIZE.value =
-    clamp || topPane?.size === null || topPane?.size === undefined
-      ? Math.max(100 - bottom, 0)
-      : topPane.size
+  const topSize = topPane?.size
+  if (clamp || topSize === null || topSize === undefined) {
+    PANE_MAIN_TOP_SIZE.value = Math.max(100 - bottom, 0)
+  } else {
+    PANE_MAIN_TOP_SIZE.value = topSize
+  }
 }
 
 function onHorizontalPaneResize(event: PaneEvent[]): void {
@@ -276,10 +290,12 @@ async function populatePaneEvent(): Promise<void> {
   const verticalPaneData = await getPaneData("vertical")
   if (Array.isArray(verticalPaneData) && verticalPaneData.length >= 2) {
     const [mainPane, sidebarPane] = verticalPaneData
-    if (mainPane?.size !== null && mainPane?.size !== undefined)
+    if (mainPane?.size !== null && mainPane?.size !== undefined) {
       PANE_MAIN_SIZE.value = mainPane.size
-    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined)
+    }
+    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined) {
       PANE_SIDEBAR_SIZE.value = sidebarPane.size
+    }
   }
 
   const horizontalPaneData = await getPaneData("horizontal")

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -44,7 +44,7 @@
             role="button"
             tabindex="0"
             :aria-expanded="!isResponseCollapsed"
-            :aria-controls="`${props.layoutId ?? 'default'}-response-pane-content`"
+            :aria-controls="`${props.layoutId ?? 'default'}-${props.tabId ?? 'default'}-response-pane-content`"
             :title="
               isResponseCollapsed
                 ? t('response.expand_response_pane')
@@ -94,7 +94,7 @@
           </div>
           <div
             v-show="!isResponseCollapsed"
-            :id="`${props.layoutId ?? 'default'}-response-pane-content`"
+            :id="`${props.layoutId ?? 'default'}-${props.tabId ?? 'default'}-response-pane-content`"
             class="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"
           >
             <slot name="secondary" />
@@ -114,9 +114,7 @@
 
 <script setup lang="ts">
 import { Pane, Splitpanes } from "splitpanes"
-
 import "splitpanes/dist/splitpanes.css"
-
 import { useSetting } from "@composables/settings"
 import { breakpointsTailwind, useBreakpoints } from "@vueuse/core"
 import { useService } from "dioc/vue"
@@ -130,139 +128,187 @@ import { PersistenceService } from "~/services/persistence"
 
 const t = useI18n()
 
-type PaneEvent = {
-  max: number
-  min: number
-  size: number
+type PaneEvent = { max: number; min: number; size: number }
+type ResponseCollapseMode = "auto" | "manual"
+type PaneConfigStore = {
+  vertical: Record<string, PaneEvent[]>
+  horizontal: Record<string, PaneEvent[]>
 }
 
 const SIDEBAR_ON_LEFT = useSetting("SIDEBAR_ON_LEFT")
+const COLUMN_LAYOUT = useSetting("COLUMN_LAYOUT")
+const SIDEBAR = useSetting("SIDEBAR")
 
 const breakpoints = useBreakpoints(breakpointsTailwind)
 const mdAndLarger = breakpoints.greater("md")
 
-const COLUMN_LAYOUT = useSetting("COLUMN_LAYOUT")
-const SIDEBAR = useSetting("SIDEBAR")
-
 const slots = useSlots()
-
 const persistenceService = useService(PersistenceService)
 
 const hasSidebar = computed(() => !!slots.sidebar)
 const hasSecondary = computed(() => !!slots.secondary)
 
 const props = defineProps({
-  layoutId: {
-    type: String,
-    default: null,
-  },
-  isEmbed: {
-    type: Boolean,
-    default: false,
-  },
-  forceColumnLayout: {
-    type: Boolean,
-    default: false,
-  },
+  layoutId: { type: String, default: null },
+  tabId: { type: String, default: null },
+  isEmbed: { type: Boolean, default: false },
+  forceColumnLayout: { type: Boolean, default: false },
 })
 
-/** Stacked top/bottom panes (Splitpanes horizontal); false = side-by-side */
 const isStackedLayout = computed(
   () => COLUMN_LAYOUT.value || props.forceColumnLayout
 )
 
 const RESPONSE_COLLAPSED_SIZE = 5
 const RESPONSE_EXPANDED_MIN_SIZE = 25
+
 const PANE_MAIN_SIZE = ref(70)
 const PANE_SIDEBAR_SIZE = ref(30)
-
-// Default top/bottom split depends on layout direction
 const PANE_MAIN_TOP_SIZE = ref(isStackedLayout.value ? 35 : 50)
 const PANE_MAIN_BOTTOM_SIZE = ref(isStackedLayout.value ? 65 : 50)
-
-/** Last known expanded size – used to restore after a collapse toggle */
 const lastExpandedBottomSize = ref(PANE_MAIN_BOTTOM_SIZE.value)
+const responseCollapseMode = ref<ResponseCollapseMode>("manual")
 
 const isResponseCollapsed = computed(
   () => PANE_MAIN_BOTTOM_SIZE.value <= RESPONSE_COLLAPSED_SIZE + 0.1
 )
 
-async function getPaneData(
-  type: "vertical" | "horizontal"
-): Promise<PaneEvent[] | null> {
-  if (!props.layoutId) return null
-  const storageKey = `${props.layoutId}-pane-config-${type}`
-  const raw = await persistenceService.getLocalConfig(storageKey)
+// The top pane min-size constrains how large the bottom pane can grow.
+const maxBottomSize = computed(() => 100 - (props.isEmbed ? 12 : 25))
+
+const defaultExpandedBottomSize = computed(() =>
+  Math.min(RESPONSE_EXPANDED_MIN_SIZE, maxBottomSize.value)
+)
+
+// ─── Persistence helpers ───
+
+function contextId(): string {
+  return props.tabId ?? "default"
+}
+
+function collapseModeKey(): string | null {
+  return props.layoutId ? `${props.layoutId}-response-collapse-mode` : null
+}
+
+function paneConfigKey(): string | null {
+  return props.layoutId ? `${props.layoutId}-pane-config` : null
+}
+
+async function readJsonConfig<T>(key: string): Promise<T | null> {
+  const raw = await persistenceService.getLocalConfig(key)
   if (!raw) return null
   try {
-    return JSON.parse(raw)
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? (parsed as T) : null
   } catch {
     return null
   }
 }
 
-async function setPaneEvent(
-  event: PaneEvent[],
-  type: "vertical" | "horizontal"
-) {
-  if (!props.layoutId) return
-  const storageKey = `${props.layoutId}-pane-config-${type}`
-  await persistenceService.setLocalConfig(storageKey, JSON.stringify(event))
+async function writeJsonConfig(key: string, value: unknown): Promise<void> {
+  await persistenceService.setLocalConfig(key, JSON.stringify(value))
 }
 
-/**
- * Clamp a bottom-pane size so it is never in the ambiguous zone between
- * collapsed and the enforced expanded minimum.
- *
- * If the stored/dragged value is clearly collapsed (≤ RESPONSE_COLLAPSED_SIZE)
- * we leave it alone.  Otherwise we push it up to at least
- * RESPONSE_EXPANDED_MIN_SIZE.
- */
-function clampBottomSize(size: number): number {
-  return size <= RESPONSE_COLLAPSED_SIZE + 0.1 ? RESPONSE_COLLAPSED_SIZE : size
+// ─── Collapse-mode persistence ───
+
+async function loadResponseCollapseMode(): Promise<ResponseCollapseMode> {
+  const key = collapseModeKey()
+  if (!key) return "manual"
+
+  const raw = await persistenceService.getLocalConfig(key)
+  if (!raw) return "manual"
+
+  // Backward-compat: older versions stored a bare string.
+  if (raw === "auto" || raw === "manual") return raw
+
+  const record = await readJsonConfig<Record<string, unknown>>(key)
+  const mode = record?.[contextId()] ?? record?.["default"]
+  return mode === "auto" || mode === "manual" ? mode : "manual"
 }
 
-/**
- * Apply a horizontal pane event array to the reactive size refs.
- *
- * @param event  - Two-element array from Splitpanes [top, bottom].
- * @param clamp  - When true the bottom size is snapped to the collapsed sentinel
- *                 if at or below RESPONSE_COLLAPSED_SIZE, and the top size is
- *                 recalculated to fill the remainder. Pass `true` on drag-end
- *                 and on hydration from storage; pass `false` during live drag
- *                 so the user sees smooth feedback.
- */
-function syncHorizontalPaneSizes(
-  event: PaneEvent[],
-  clamp: boolean = false
-): void {
-  if (event.length < 2) return
+async function persistResponseCollapseMode(
+  mode: ResponseCollapseMode | null
+): Promise<void> {
+  const key = collapseModeKey()
+  if (!key) return
 
-  const [topPane, bottomPane] = event
+  const id = contextId()
+  const raw = await persistenceService.getLocalConfig(key)
 
-  if (bottomPane?.size === null || bottomPane?.size === undefined) return
+  // Backward-compat: promote bare string to record form.
+  let record: Record<string, ResponseCollapseMode> = {}
+  if (raw === "auto" || raw === "manual") {
+    record.default = raw
+  } else if (raw) {
+    record =
+      (await readJsonConfig<Record<string, ResponseCollapseMode>>(key)) ?? {}
+  }
 
-  const bottom = clamp ? clampBottomSize(bottomPane.size) : bottomPane.size
+  if (mode === null) {
+    delete record[id]
+  } else {
+    record[id] = mode
+  }
 
-  PANE_MAIN_BOTTOM_SIZE.value = bottom
-
-  PANE_MAIN_TOP_SIZE.value =
-    clamp || topPane?.size === null || topPane?.size === undefined
-      ? Math.max(100 - bottom, 0)
-      : topPane.size
-}
-
-function onHorizontalPaneResize(event: PaneEvent[]): void {
-  syncHorizontalPaneSizes(event, false)
-  if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
-    lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
+  if (Object.keys(record).length === 0) {
+    await persistenceService.removeLocalConfig(key)
+  } else {
+    await writeJsonConfig(key, record)
   }
 }
 
-async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
-  // Snap to collapsed sentinel on release if the user dragged to the threshold.
-  syncHorizontalPaneSizes(event, true)
-  await persistCurrentHorizontalLayout()
+// ─── Pane-size persistence ───
+
+async function getPaneData(
+  type: "vertical" | "horizontal"
+): Promise<PaneEvent[] | null> {
+  const key = paneConfigKey()
+  if (!key) return null
+  const store = await readJsonConfig<Partial<PaneConfigStore>>(key)
+  return store?.[type]?.[contextId()] ?? null
+}
+
+async function setPaneEvent(
+  event: PaneEvent[],
+  type: "vertical" | "horizontal"
+): Promise<void> {
+  const key = paneConfigKey()
+  if (!key) return
+
+  const existing = await readJsonConfig<Partial<PaneConfigStore>>(key)
+  const store: PaneConfigStore = {
+    vertical: existing?.vertical ?? {},
+    horizontal: existing?.horizontal ?? {},
+  }
+  store[type][contextId()] = event
+  await writeJsonConfig(key, store)
+}
+
+// ─── Pane-size sync ───
+
+/**
+ * Snaps the bottom pane: values at or below the collapsed threshold become the
+ * sentinel; anything above is pushed up to the expanded minimum.
+ */
+function clampBottomSize(size: number): number {
+  return size <= RESPONSE_COLLAPSED_SIZE + 0.1
+    ? RESPONSE_COLLAPSED_SIZE
+    : Math.max(size, RESPONSE_EXPANDED_MIN_SIZE)
+}
+
+/**
+ * Applies a two-element Splitpanes event to the reactive size refs.
+ * Pass `clamp = true` on drag-end and hydration; `false` during live drag.
+ */
+function syncHorizontalPaneSizes(event: PaneEvent[], clamp = false): void {
+  if (event.length < 2) return
+  const [topPane, bottomPane] = event
+  if (bottomPane?.size == null) return
+
+  const bottom = clamp ? clampBottomSize(bottomPane.size) : bottomPane.size
+  PANE_MAIN_BOTTOM_SIZE.value = bottom
+  PANE_MAIN_TOP_SIZE.value =
+    clamp || topPane?.size == null ? Math.max(100 - bottom, 0) : topPane.size
 }
 
 async function persistCurrentHorizontalLayout(): Promise<void> {
@@ -276,47 +322,85 @@ async function persistCurrentHorizontalLayout(): Promise<void> {
   )
 }
 
-async function populatePaneEvent(): Promise<void> {
-  if (!props.layoutId) return
+// ─── Event handlers ───
 
-  const verticalPaneData = await getPaneData("vertical")
-  if (Array.isArray(verticalPaneData) && verticalPaneData.length >= 2) {
-    const [mainPane, sidebarPane] = verticalPaneData
-    if (mainPane?.size !== null && mainPane?.size !== undefined)
-      PANE_MAIN_SIZE.value = mainPane.size
-    if (sidebarPane?.size !== null && sidebarPane?.size !== undefined)
-      PANE_SIDEBAR_SIZE.value = sidebarPane.size
-  }
-
-  const horizontalPaneData = await getPaneData("horizontal")
-  if (Array.isArray(horizontalPaneData) && horizontalPaneData.length >= 2) {
-    syncHorizontalPaneSizes(horizontalPaneData, true)
-
-    if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
-      lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
-    }
+function onHorizontalPaneResize(event: PaneEvent[]): void {
+  syncHorizontalPaneSizes(event, false)
+  if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
+    lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
   }
 }
 
-onMounted(async () => {
-  await populatePaneEvent()
-})
-
-async function toggleResponsePane(): Promise<void> {
-  const primaryMinSize = props.isEmbed ? 12 : 25
-  const maxBottomSize = 100 - primaryMinSize
+async function onHorizontalPaneResized(event: PaneEvent[]): Promise<void> {
+  syncHorizontalPaneSizes(event, true)
 
   if (isResponseCollapsed.value) {
-    const expandedBottom = Math.min(
-      Math.max(lastExpandedBottomSize.value, RESPONSE_EXPANDED_MIN_SIZE),
-      maxBottomSize
-    )
-    PANE_MAIN_BOTTOM_SIZE.value = expandedBottom
-    PANE_MAIN_TOP_SIZE.value = 100 - expandedBottom
+    // Drag-to-collapse: expanding should reset to the default minimum, not the
+    // pre-collapse size (which is near-zero and meaningless as a restore target).
+    responseCollapseMode.value = "auto"
+    lastExpandedBottomSize.value = defaultExpandedBottomSize.value
+    await persistResponseCollapseMode("auto")
+  } else {
+    responseCollapseMode.value = "manual"
+    await persistResponseCollapseMode(null)
+  }
+
+  await persistCurrentHorizontalLayout()
+}
+
+// ─── Lifecycle ───
+
+async function populatePaneEvent(): Promise<void> {
+  if (!props.layoutId) return
+
+  const verticalData = await getPaneData("vertical")
+  if (Array.isArray(verticalData) && verticalData.length >= 2) {
+    const [main, sidebar] = verticalData
+    if (main?.size != null) PANE_MAIN_SIZE.value = main.size
+    if (sidebar?.size != null) PANE_SIDEBAR_SIZE.value = sidebar.size
+  }
+
+  const horizontalData = await getPaneData("horizontal")
+  if (!Array.isArray(horizontalData) || horizontalData.length < 2) return
+
+  syncHorizontalPaneSizes(horizontalData, true)
+
+  responseCollapseMode.value = await loadResponseCollapseMode()
+
+  // When switching tabs: if the last collapse was triggered by dragging to the
+  // threshold, start expanded rather than staying collapsed.
+  if (responseCollapseMode.value === "auto" && isResponseCollapsed.value) {
+    const expanded = defaultExpandedBottomSize.value
+    PANE_MAIN_BOTTOM_SIZE.value = expanded
+    PANE_MAIN_TOP_SIZE.value = 100 - expanded
+    lastExpandedBottomSize.value = expanded
+    responseCollapseMode.value = "manual"
+  } else if (PANE_MAIN_BOTTOM_SIZE.value > RESPONSE_COLLAPSED_SIZE + 0.1) {
+    lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
+  }
+}
+
+onMounted(populatePaneEvent)
+
+// ─── Toggle ───
+async function toggleResponsePane(): Promise<void> {
+  if (isResponseCollapsed.value) {
+    const expanded =
+      responseCollapseMode.value === "auto"
+        ? defaultExpandedBottomSize.value
+        : Math.min(lastExpandedBottomSize.value, maxBottomSize.value)
+
+    PANE_MAIN_BOTTOM_SIZE.value = expanded
+    PANE_MAIN_TOP_SIZE.value = 100 - expanded
+    lastExpandedBottomSize.value = expanded
+    responseCollapseMode.value = "manual"
+    await persistResponseCollapseMode(null)
   } else {
     lastExpandedBottomSize.value = PANE_MAIN_BOTTOM_SIZE.value
     PANE_MAIN_BOTTOM_SIZE.value = RESPONSE_COLLAPSED_SIZE
     PANE_MAIN_TOP_SIZE.value = Math.max(100 - RESPONSE_COLLAPSED_SIZE, 0)
+    responseCollapseMode.value = "manual"
+    await persistResponseCollapseMode("manual")
   }
 
   await persistCurrentHorizontalLayout()

--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -93,7 +93,8 @@
             </div>
           </div>
           <div
-            id="response-pane-content"
+          <div
+            :id="`${props.layoutId ?? 'default'}-response-pane-content`"
             v-show="!isResponseCollapsed"
             class="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"
           >

--- a/packages/hoppscotch-common/src/components/graphql/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppPaneLayout layout-id="gql-primary">
+  <AppPaneLayout layout-id="gql-primary" :tab-id="tab.id">
     <template #primary>
       <GraphqlRequestOptions
         v-model="tab.document.request"

--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppPaneLayout layout-id="rest-primary">
+  <AppPaneLayout layout-id="rest-primary" :tab-id="tab.id">
     <template #primary>
       <HttpRequest v-model="tab" />
       <HttpRequestOptions


### PR DESCRIPTION
Resolves #6032


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsible response pane with a sticky, keyboard-accessible toggle, smoother live resizing, clamped sizes, and layout-aware defaults for reliable behavior. Works in stacked and side-by-side layouts with refined styling, better responsiveness, accessibility, and persisted sizes.

- New Features
  - Accessible toggle: click/Enter/Space, `aria-expanded` + `aria-controls`, sticky header/rail, orientation-aware chevrons; content stays mounted when collapsed.
  - Resizing + persistence: live drag updates with clamping on release; layout-aware defaults and calculations via `isStackedLayout`; saves per `layoutId` on drag and toggle; restores last expanded size on reopen.
  - Size limits: collapsed 5%, expanded min 25%; respects embed primary min size (12%) when reopening.
  - i18n: `response_pane`, `collapse_response_pane`, `expand_response_pane`.
  - Responses are now **independent per request tab**. The response pane’s collapse mode and split sizes are persisted separately, so switching between tabs restores the last expanded/collapsed state and the last resized response height for that tab.

<sup>Written for commit b4c8d2cc0f8ebcf7891e247dee195926835fd33e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



