### PR TITLE
fix the* import postman size limit 10mb

### DIFF
--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -123,7 +123,7 @@ const experimentalScriptingEnabled = useSetting(
   "EXPERIMENTAL_SCRIPTING_SANDBOX"
 )
 
-const ALLOWED_FILE_SIZE_LIMIT = platform.limits?.collectionImportSizeLimit ?? 10 // Default to 10 MB
+const ALLOWED_FILE_SIZE_LIMIT = platform.limits?.collectionImportSizeLimit ?? 50 // Default to 50
 
 const importFilesCount = ref(0)
 


### PR DESCRIPTION
Closes #6037

the fallback value for 'CollectionImportSizeLimit' in 'FileImport.vue' is hardcoded to 10 mb, which is the cause of the bug

change:

changed the fallback to 50 to match the size in the self-hosted platform 'main.ts'

note:

please test with a dummy json > 10mb to make sure it works 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the default Postman collection import size limit from 10 MB to 50 MB to match the platform default. Fixes #6037 by allowing imports >10 MB when no platform limit is provided.

<sup>Written for commit 7c053916ba79bc55bc8ef56349f17d7fce2610e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

