### PR TITLE
feat(collections): auto reveal saved request location in sidebar

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -12,7 +12,11 @@
       @dragleave="ordering = false"
       @dragend="resetDragState"
     ></div>
-    <div class="relative flex flex-col">
+    <div
+      class="relative flex flex-col"
+      :data-collections-node-id="dataNodeId"
+      data-collections-node-type="collection"
+    >
       <div
         class="z-[1] pointer-events-none absolute inset-0 bg-accent opacity-0 transition"
         :class="{
@@ -485,6 +489,11 @@ const collectionRefID = computed(() => {
   return props.collectionsType === "my-collections"
     ? (props.data as HoppCollection)._ref_id
     : props.id
+})
+
+const dataNodeId = computed(() => {
+  const prefix = props.collectionsType === "team-collections" ? "team:" : "my:"
+  return `${prefix}${props.id}`
 })
 
 const currentSortOrder = ref<"asc" | "desc">(

--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -42,15 +42,26 @@
     <div class="flex flex-1 flex-col">
       <HoppSmartTree :adapter="myAdapter">
         <template
-          #content="{ node, toggleChildren, isOpen, highlightChildren }"
+          #content="{
+            node,
+            toggleChildren: nodeToggleChildren,
+            isOpen: nodeIsOpen,
+            highlightChildren,
+          }"
         >
+          <TreeNodeRegistrar
+            v-if="node && node.id"
+            :id="node.id"
+            :toggle-children="nodeToggleChildren"
+            :is-open="nodeIsOpen"
+          />
           <CollectionsCollection
             v-if="node.data.type === 'collections'"
             :id="node.id"
             :parent-i-d="node.data.data.parentIndex"
             :data="node.data.data.data"
             :collections-type="collectionsType.type"
-            :is-open="isOpen"
+            :is-open="nodeIsOpen"
             :is-last-item="node.data.isLastItem"
             :is-selected="
               isSelected({
@@ -140,7 +151,7 @@
             "
             @toggle-children="
               () => {
-                ;(toggleChildren(),
+                ;(nodeToggleChildren(),
                   saveRequest &&
                     emit('select', {
                       pickedType: 'my-collection',
@@ -155,7 +166,7 @@
             :parent-i-d="node.data.data.parentIndex"
             :data="node.data.data.data"
             :collections-type="collectionsType.type"
-            :is-open="isOpen"
+            :is-open="nodeIsOpen"
             :is-last-item="node.data.isLastItem"
             :is-selected="
               isSelected({
@@ -242,7 +253,7 @@
             "
             @toggle-children="
               () => {
-                ;(toggleChildren(),
+                ;(nodeToggleChildren(),
                   saveRequest &&
                     emit('select', {
                       pickedType: 'my-folder',
@@ -262,7 +273,12 @@
             :is-active="
               isActiveRequest(
                 node.data.data.parentIndex,
-                node.data.data.data._ref_id ?? node.data.data.data.id
+                getStableRequestRefID({
+                  request: node.data.data.data,
+                  folderPath: node.data.data.parentIndex,
+                  requestIndex: pathToIndex(node.id),
+                }),
+                parseInt(pathToIndex(node.id))
               )
             "
             :is-selected="
@@ -460,7 +476,16 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconImport from "~icons/lucide/folder-down"
 import IconArrowUpDown from "~icons/lucide/arrow-up-down"
 import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data"
-import { computed, PropType, ref, Ref, toRef } from "vue"
+import {
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+  Ref,
+  toRef,
+  nextTick,
+  watch,
+} from "vue"
 import { GetMyTeamsQuery } from "~/helpers/backend/graphql"
 import { ChildrenResult, SmartTreeAdapter } from "@hoppscotch/ui/helpers"
 import { useI18n } from "@composables/i18n"
@@ -771,7 +796,11 @@ const active = computed(
     tabs.currentActiveTab.value.document.saveContext
 )
 
-const isActiveRequest = (folderPath: string, requestRefID: string) => {
+const isActiveRequest = (
+  folderPath: string,
+  requestRefID: string,
+  requestIndex: number
+) => {
   if (active.value === null || !active.value) return false
 
   return pipe(
@@ -781,10 +810,25 @@ const isActiveRequest = (folderPath: string, requestRefID: string) => {
       (active) =>
         active.originLocation === "user-collection" &&
         active.folderPath === folderPath &&
-        active.requestRefID === requestRefID &&
+        (active.requestRefID && requestRefID
+          ? active.requestRefID === requestRefID
+          : active.requestIndex === requestIndex) &&
         active.exampleID === undefined
     ),
     O.isSome
+  )
+}
+
+const getStableRequestRefID = (args: {
+  folderPath: string
+  requestIndex: string
+  request: HoppRESTRequest
+}) => {
+  return (
+    args.request._ref_id ??
+    args.request.id ??
+    // Always non-empty and unique within personal collections tree
+    `${args.folderPath}/${args.requestIndex}`
   )
 }
 
@@ -802,13 +846,19 @@ const selectRequest = (data: {
       requestIndex: parseInt(requestIndex),
     })
   } else {
+    const stableRequestRefID = getStableRequestRefID({
+      request,
+      folderPath,
+      requestIndex,
+    })
     emit("select-request", {
       request,
       folderPath,
       requestIndex,
       isActive: isActiveRequest(
         folderPath,
-        request._ref_id ?? request.id ?? ""
+        stableRequestRefID,
+        parseInt(requestIndex)
       ),
     })
   }
@@ -993,4 +1043,104 @@ class MyCollectionsAdapter implements SmartTreeAdapter<MyCollectionNode> {
 const myAdapter: SmartTreeAdapter<MyCollectionNode> = new MyCollectionsAdapter(
   refFilterCollection
 )
+
+type NodeToggleState = {
+  toggleChildren: () => void
+  isOpen: boolean
+}
+
+const nodeTogglers = new Map<string, NodeToggleState>()
+
+const registerNodeToggler = (id: string, state: NodeToggleState) => {
+  nodeTogglers.set(id, state)
+}
+
+const TreeNodeRegistrar = defineComponent({
+  name: "TreeNodeRegistrar",
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    toggleChildren: {
+      type: Function as PropType<() => void>,
+      required: true,
+    },
+    isOpen: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  setup(props) {
+    // Keep map updated as isOpen changes across renders.
+    watch(
+      () => props.isOpen,
+      (isOpen) => {
+        registerNodeToggler(props.id, {
+          toggleChildren: props.toggleChildren,
+          isOpen,
+        })
+      },
+      { immediate: true }
+    )
+
+    return () => null
+  },
+})
+
+const openNode = async (id: string) => {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const entry = nodeTogglers.get(id)
+    if (entry) {
+      if (!entry.isOpen) entry.toggleChildren()
+      await nextTick()
+
+      const updatedEntry = nodeTogglers.get(id)
+      if (updatedEntry?.isOpen) return
+    } else {
+      await nextTick()
+    }
+  }
+}
+
+const scrollToNode = async (id: string) => {
+  // Retry because nodes can mount after async expansion/render.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const el = document.querySelector(
+      `[data-collections-node-id="my:${CSS.escape(id)}"]`
+    )
+    if (el && "scrollIntoView" in el) {
+      ;(el as HTMLElement).scrollIntoView({
+        block: "center",
+        behavior: "smooth",
+      })
+      return
+    }
+    await nextTick()
+  }
+}
+
+const reveal = async (target: {
+  originLocation: "user-collection"
+  folderPath: string
+  requestIndex: number
+}) => {
+  const folderPath = target.folderPath
+  const ancestors: string[] = []
+  const parts = folderPath.split("/").filter((p) => p.length > 0)
+  for (let i = 0; i < parts.length; i++) {
+    ancestors.push(parts.slice(0, i + 1).join("/"))
+  }
+
+  for (const id of ancestors) {
+    await openNode(id)
+  }
+
+  await nextTick()
+  await scrollToNode(`${folderPath}/${target.requestIndex}`)
+}
+
+defineExpose({
+  reveal,
+})
 </script>

--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="flex flex-col">
+  <div
+    class="flex flex-col"
+    :data-collections-node-id="dataNodeId"
+    data-collections-node-type="request"
+  >
     <div
       class="h-1 w-full transition"
       :class="[
@@ -38,13 +42,7 @@
           class="pointer-events-none flex w-8 items-center justify-start truncate px-0.5"
           :style="{ color: getMethodLabelColorClassOf(request.method) }"
         >
-          <component
-            :is="IconCheckCircle"
-            v-if="isSelected"
-            class="svg-icons"
-            :class="{ 'text-accent': isSelected }"
-          />
-          <HoppSmartSpinner v-else-if="isRequestLoading" />
+          <HoppSmartSpinner v-if="isRequestLoading" />
           <span v-else class="truncate text-tiny font-semibold">
             {{ request.method }}
           </span>
@@ -234,7 +232,6 @@
 </template>
 
 <script setup lang="ts">
-import IconCheckCircle from "~icons/lucide/check-circle"
 import IconMoreVertical from "~icons/lucide/more-vertical"
 import IconEdit from "~icons/lucide/edit"
 import IconCopy from "~icons/lucide/copy"
@@ -319,6 +316,11 @@ const props = defineProps({
     default: false,
     required: false,
   },
+})
+
+const dataNodeId = computed(() => {
+  const prefix = props.collectionsType === "team-collections" ? "team:" : "my:"
+  return `${prefix}${props.requestID}`
 })
 
 type ResponsePayload = {

--- a/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
@@ -63,15 +63,26 @@
     <div class="flex flex-col overflow-hidden">
       <HoppSmartTree :adapter="teamAdapter">
         <template
-          #content="{ node, toggleChildren, isOpen, highlightChildren }"
+          #content="{
+            node,
+            toggleChildren: nodeToggleChildren,
+            isOpen: nodeIsOpen,
+            highlightChildren,
+          }"
         >
+          <TreeNodeRegistrar
+            v-if="node && node.id"
+            :id="node.id"
+            :toggle-children="nodeToggleChildren"
+            :is-open="nodeIsOpen"
+          />
           <CollectionsCollection
             v-if="node.data.type === 'collections'"
             :id="node.data.data.data.id"
             :parent-i-d="node.data.data.parentIndex"
             :data="node.data.data.data"
             :collections-type="collectionsType.type"
-            :is-open="isOpen"
+            :is-open="nodeIsOpen"
             :team-loading-collections="teamLoadingCollections"
             :export-loading="exportLoading"
             :has-no-team-access="hasNoTeamAccess || isShowingSearchResults"
@@ -164,7 +175,7 @@
                     pickedType: 'teams-collection',
                     collectionID: node.id,
                   }),
-                  toggleChildren())
+                  nodeToggleChildren())
               }
             "
             @run-collection="
@@ -177,7 +188,7 @@
               () => {
                 handleCollectionClick({
                   collectionID: node.id,
-                  isOpen,
+                  isOpen: nodeIsOpen,
                 })
               }
             "
@@ -188,7 +199,7 @@
             :parent-i-d="node.data.data.parentIndex"
             :data="node.data.data.data"
             :collections-type="collectionsType.type"
-            :is-open="isOpen"
+            :is-open="nodeIsOpen"
             :export-loading="exportLoading"
             :team-loading-collections="teamLoadingCollections"
             :has-no-team-access="hasNoTeamAccess || isShowingSearchResults"
@@ -277,7 +288,7 @@
             "
             @toggle-children="
               () => {
-                ;(toggleChildren(),
+                ;(nodeToggleChildren(),
                   saveRequest &&
                     emit('select', {
                       pickedType: 'teams-folder',
@@ -297,7 +308,7 @@
                   handleCollectionClick({
                     // for the folders, we get a path, so we need to get the last part of the path which is the folder id
                     collectionID: node.id.split('/').pop() as string,
-                    isOpen,
+                    isOpen: nodeIsOpen,
                   })
               }
             "
@@ -515,7 +526,16 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconImport from "~icons/lucide/folder-down"
 import IconArrowUpDown from "~icons/lucide/arrow-up-down"
 
-import { computed, PropType, ref, Ref, toRef } from "vue"
+import {
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+  Ref,
+  toRef,
+  nextTick,
+  watch,
+} from "vue"
 import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
 import { TeamCollection } from "~/helpers/teams/TeamCollection"
@@ -1130,4 +1150,107 @@ class TeamCollectionsAdapter implements SmartTreeAdapter<TeamCollectionNode> {
 
 const teamAdapter: SmartTreeAdapter<TeamCollectionNode> =
   new TeamCollectionsAdapter(teamCollectionsList)
+
+type NodeToggleState = {
+  toggleChildren: () => void
+  isOpen: boolean
+}
+
+const nodeTogglers = new Map<string, NodeToggleState>()
+
+const registerNodeToggler = (id: string, state: NodeToggleState) => {
+  nodeTogglers.set(id, state)
+}
+
+const TreeNodeRegistrar = defineComponent({
+  name: "TreeNodeRegistrar",
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    toggleChildren: {
+      type: Function as PropType<() => void>,
+      required: true,
+    },
+    isOpen: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  setup(props) {
+    watch(
+      () => props.isOpen,
+      (isOpen) => {
+        registerNodeToggler(props.id, {
+          toggleChildren: props.toggleChildren,
+          isOpen,
+        })
+      },
+      { immediate: true }
+    )
+
+    return () => null
+  },
+})
+
+const openNode = async (id: string) => {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const entry = nodeTogglers.get(id)
+    if (entry) {
+      if (!entry.isOpen) entry.toggleChildren()
+      await nextTick()
+
+      const updatedEntry = nodeTogglers.get(id)
+      if (updatedEntry?.isOpen) return
+    }
+
+    // Let the adapter emit/resolve async loads and re-render.
+    await nextTick()
+  }
+}
+
+const scrollToNode = async (folderPath: string, requestID: string) => {
+  // Request nodes in team tree use `requestID`, while reveal has `folderPath/requestID`.
+  const selectors = [
+    `[data-collections-node-id="team:${CSS.escape(`${folderPath}/${requestID}`)}"]`,
+    `[data-collections-node-id="team:${CSS.escape(requestID)}"]`,
+  ]
+
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const el = selectors
+      .map((selector) => document.querySelector(selector))
+      .find((node) => node != null)
+
+    if (el && "scrollIntoView" in el) {
+      ;(el as HTMLElement).scrollIntoView({
+        block: "center",
+        behavior: "smooth",
+      })
+      return
+    }
+    await nextTick()
+  }
+}
+
+const reveal = async (target: {
+  originLocation: "team-collection"
+  folderPath: string
+  requestID: string
+}) => {
+  const folderPath = target.folderPath
+  const parts = folderPath.split("/").filter((p) => p.length > 0)
+
+  // Expand each ancestor path, e.g. a/b/c
+  for (let i = 0; i < parts.length; i++) {
+    await openNode(parts.slice(0, i + 1).join("/"))
+  }
+
+  await nextTick()
+  await scrollToNode(folderPath, target.requestID)
+}
+
+defineExpose({
+  reveal,
+})
 </script>

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -28,11 +28,12 @@
     </div>
     <CollectionsMyCollections
       v-if="collectionsType.type === 'my-collections'"
+      ref="myCollectionsRef"
       :collections-type="collectionsType"
       :filtered-collections="filteredCollections"
       :filter-text="filterTexts"
       :save-request="saveRequest"
-      :picked="picked"
+      :picked="resolvedPicked"
       @run-collection="
         runCollectionHandler({
           type: 'my-collections',
@@ -76,6 +77,7 @@
 
     <CollectionsTeamCollections
       v-else
+      ref="teamCollectionsRef"
       :collections-type="collectionsType"
       :team-collection-list="
         filterTexts.length > 0 ? teamsSearchResults : teamCollections
@@ -90,7 +92,7 @@
       :duplicate-request-loading="duplicateRequestLoading"
       :duplicate-collection-loading="duplicateCollectionLoading"
       :save-request="saveRequest"
-      :picked="picked"
+      :picked="resolvedPicked"
       :collection-move-loading="collectionMoveLoading"
       :request-move-loading="requestMoveLoading"
       @add-request="addRequest"
@@ -435,6 +437,32 @@ const collectionsType = ref<CollectionType>({
   selectedTeam: undefined,
 })
 
+type RevealTarget =
+  | {
+      originLocation: "user-collection"
+      folderPath: string
+      requestIndex: number
+    }
+  | {
+      originLocation: "team-collection"
+      folderPath: string
+      requestID: string
+    }
+
+const sidebarPicked = ref<Picked | null>(null)
+
+const resolvedPicked = computed(() => {
+  return props.saveRequest ? props.picked : sidebarPicked.value
+})
+
+const myCollectionsRef = ref<{
+  reveal: (target: RevealTarget) => Promise<void>
+} | null>(null)
+
+const teamCollectionsRef = ref<{
+  reveal: (target: RevealTarget) => Promise<void>
+} | null>(null)
+
 // Collection Data
 const editingCollection = ref<HoppCollection | TeamCollection | null>(null)
 const editingCollectionIsTeam = ref<boolean>(false)
@@ -594,6 +622,56 @@ onMounted(async () => {
 const switchToMyCollections = () => {
   collectionsType.value.type = "my-collections"
   collectionsType.value.selectedTeam = undefined
+}
+
+const revealInCollectionsSidebar = async (): Promise<void> => {
+  const doc = tabs.currentActiveTab.value.document
+  if (doc.type !== "request") return
+
+  const ctx = doc.saveContext
+  if (!ctx) return
+
+  // Ensure reveal works from a stable, unfiltered tree state.
+  filterTexts.value = ""
+
+  if (ctx.originLocation === "user-collection") {
+    if (!("folderPath" in ctx) || ctx.folderPath === null) return
+    if (ctx.requestIndex === null) return
+
+    switchToMyCollections()
+
+    sidebarPicked.value = {
+      pickedType: "my-request",
+      folderPath: ctx.folderPath,
+      requestIndex: ctx.requestIndex,
+    }
+
+    await nextTick()
+    await myCollectionsRef.value?.reveal({
+      originLocation: "user-collection",
+      folderPath: ctx.folderPath,
+      requestIndex: ctx.requestIndex,
+    })
+    return
+  }
+
+  if (ctx.originLocation === "team-collection") {
+    if (!ctx.collectionID) return
+
+    collectionsType.value.type = "team-collections"
+
+    sidebarPicked.value = {
+      pickedType: "teams-request",
+      requestID: ctx.requestID,
+    }
+
+    await nextTick()
+    await teamCollectionsRef.value?.reveal({
+      originLocation: "team-collection",
+      folderPath: ctx.collectionID,
+      requestID: ctx.requestID,
+    })
+  }
 }
 
 /**
@@ -2442,11 +2520,14 @@ const selectRequest = (selectedRequest: {
       })
     }
   } else {
+    const stableRequestRefID =
+      request._ref_id ?? request.id ?? `${folderPath}/${requestIndex}`
+
     possibleTab = tabs.getTabRefWithSaveContext({
       originLocation: "user-collection",
       requestIndex: parseInt(requestIndex),
       folderPath: folderPath!,
-      requestRefID: request._ref_id ?? request.id,
+      requestRefID: stableRequestRefID,
     })
 
     if (possibleTab) {
@@ -2461,7 +2542,7 @@ const selectRequest = (selectedRequest: {
           originLocation: "user-collection",
           folderPath: folderPath!,
           requestIndex: parseInt(requestIndex),
-          requestRefID: request._ref_id ?? request.id,
+          requestRefID: stableRequestRefID,
         },
         inheritedProperties: cascadeParentCollectionForProperties(
           folderPath,
@@ -3655,5 +3736,9 @@ defineActionHandler("collection.new", () => {
 })
 defineActionHandler("modals.collection.import", () => {
   displayModalImportExport(true)
+})
+
+defineActionHandler("collections.reveal_in_collection", () => {
+  void revealInCollectionsSidebar()
 })
 </script>

--- a/packages/hoppscotch-common/src/components/http/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/http/Sidebar.vue
@@ -79,6 +79,7 @@ import { useI18n } from "@composables/i18n"
 import MockServerDashboard from "~/components/mockServer/MockServerDashboard.vue"
 import { useMockServerWorkspaceSync } from "~/composables/mockServerWorkspace"
 import { useMockServerVisibility } from "~/composables/mockServerVisibility"
+import { defineActionHandler } from "~/helpers/actions"
 
 const t = useI18n()
 
@@ -96,4 +97,8 @@ const selectedNavigationTab = ref<RequestOptionTabs>("collections")
 
 // Ensure mock servers are kept in sync with workspace changes globally
 useMockServerWorkspaceSync()
+
+defineActionHandler("rest.sidebar.show_collections", () => {
+  selectedNavigationTab.value = "collections"
+})
 </script>

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, computed } from "vue"
+import { ref, onMounted, computed, watch } from "vue"
 import { generateUniqueRefId, safelyExtractRESTRequest } from "@hoppscotch/data"
 import { translateExtURLParams } from "~/helpers/RESTExtURLParams"
 import { useRoute } from "vue-router"
@@ -195,6 +195,19 @@ const contextMenu = ref<PopupDetails>({
 })
 
 const activeTabs = tabs.getActiveTabs()
+
+watch(
+  () => currentTabID.value,
+  () => {
+    const doc = tabs.currentActiveTab.value.document
+    if (doc.type !== "request") return
+    if (!doc.saveContext) return
+
+    // Auto-reveal only for saved-in-collection requests
+    invokeAction("rest.sidebar.show_collections", {})
+    invokeAction("collections.reveal_in_collection", {})
+  }
+)
 
 function bindRequestToURLParams() {
   const route = useRoute()


### PR DESCRIPTION
- add auto reveal when a saved request tab becomes active
- expand parent folders and scroll to the request row
- use stable request ids to keep active green dot accurate
- remove manual reveal action from tab context menu

### What's changed

- Added automatic request reveal in Collections when a saved REST request tab becomes active.
- Added reveal flow that expands parent folders and scrolls the target request into view.
- Improved active-request matching with stable request reference fallback logic so green-dot state is accurate.
- Removed the manual “Reveal in collection” action from the tab context menu.
- Updated collection tree node registration/reveal behavior in personal and team collection trees to make reveal deterministic.

### Notes to reviewers

- This change is scoped to REST collections/navigation UX and does not alter request execution logic.
- Reveal is no-op for tabs without `saveContext` (unsaved/scratch requests).
- If a request no longer exists in the collection tree, reveal gracefully does not select/scroll that missing node.
- There are existing unrelated lint warnings in the repo; this PR addressed commit-blocking errors introduced in this change path.