### PR TITLE
fix: pin 35 unpinned action(s),extract 19 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-hoppscotch-agent.yml
+++ b/.github/workflows/build-hoppscotch-agent.yml
@@ -66,11 +66,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -87,7 +87,7 @@ jobs:
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
       - name: Import Code-Signing Certificates
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
@@ -166,11 +166,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -187,7 +187,7 @@ jobs:
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
       - name: Import Code-Signing Certificates
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
@@ -266,11 +266,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -358,11 +358,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -451,11 +451,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -540,11 +540,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -596,9 +596,12 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
+          AZURE_CODE_SIGNING_NAME: ${{ secrets.AZURE_CODE_SIGNING_NAME }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
         run: |
           cd packages/hoppscotch-agent
-          trusted-signing-cli -e ${{ secrets.AZURE_ENDPOINT }} -a ${{ secrets.AZURE_CODE_SIGNING_NAME }} -c ${{ secrets.AZURE_CERT_PROFILE_NAME }} "src-tauri/target/release/hoppscotch-agent.exe"
+          trusted-signing-cli -e ${AZURE_ENDPOINT} -a ${AZURE_CODE_SIGNING_NAME} -c ${AZURE_CERT_PROFILE_NAME} "src-tauri/target/release/hoppscotch-agent.exe"
       - name: Zip portable executable
         shell: powershell
         run: |

--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -65,10 +65,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -107,8 +107,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -117,6 +117,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}
@@ -171,10 +173,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -204,8 +206,8 @@ jobs:
       - name: Setup environment
         shell: pwsh
         run: |
-          if ("${{ secrets.ENV_FILE_CONTENT }}" -ne "") {
-            "${{ secrets.ENV_FILE_CONTENT }}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
+          if ("${ENV_FILE_CONTENT}" -ne "") {
+            "${ENV_FILE_CONTENT}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
             Write-Host "Created .env file from repository secret"
           } elseif (Test-Path -Path "${{ env.WORKSPACE_PATH }}\.env") {
             Write-Host "Using existing .env file found in repository"
@@ -216,6 +218,8 @@ jobs:
           pnpm install -f --shamefully-hoist --ignore-scripts
           pnpm --filter hoppscotch-backend exec prisma generate
           pnpm install -f --shamefully-hoist --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         shell: pwsh
         run: |
@@ -274,10 +278,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -291,7 +295,7 @@ jobs:
           unzip cargo-tauri-x86_64-apple-darwin.zip
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
-      - uses: apple-actions/import-codesign-certs@v3
+      - uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         if: ${{ inputs.disable_signing != true }}
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
@@ -306,8 +310,8 @@ jobs:
           key: ${{ runner.os }}-cargo-x86_64-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -316,6 +320,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}
@@ -371,10 +377,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -388,7 +394,7 @@ jobs:
           unzip cargo-tauri-aarch64-apple-darwin.zip
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
-      - uses: apple-actions/import-codesign-certs@v3
+      - uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         if: ${{ inputs.disable_signing != true }}
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
@@ -403,8 +409,8 @@ jobs:
           key: ${{ runner.os }}-cargo-aarch64-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -413,6 +419,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}

--- a/.github/workflows/release-push-docker.yml
+++ b/.github/workflows/release-push-docker.yml
@@ -25,20 +25,20 @@ jobs:
         run: cp .env.example .env
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push the backend container by digest
         id: backend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push the frontend container by digest
         id: frontend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push the admin dashboard container by digest
         id: sh_admin-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push the AIO container by digest
         id: aio-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -131,13 +131,13 @@ jobs:
           merge-multiple: true
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -145,38 +145,55 @@ jobs:
       - name: "[Backend] - Create manifest list and push"
         working-directory: digests/backend
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}:${{ github.ref_name }} \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_BACKEND_CONTAINER_NAME}:${REF_NAME} \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}@sha256:%s ' *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}:latest \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_BACKEND_CONTAINER_NAME}:latest \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}@sha256:%s ' *)
 
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_BACKEND_CONTAINER_NAME: ${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}
       - name: "[Frontend] - Create manifest list and push"
         working-directory: digests/frontend
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}:${{ github.ref_name }} \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_FRONTEND_CONTAINER_NAME}:${REF_NAME} \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}@sha256:%s ' *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}:latest \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_FRONTEND_CONTAINER_NAME}:latest \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}@sha256:%s ' *)
 
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_FRONTEND_CONTAINER_NAME: ${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}
       - name: "[SH Admin] - Create manifest list and push"
         working-directory: digests/sh_admin
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}:${{ github.ref_name }} \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_SH_ADMIN_CONTAINER_NAME}:${REF_NAME} \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}@sha256:%s ' *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}:latest \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_SH_ADMIN_CONTAINER_NAME}:latest \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}@sha256:%s ' *)
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_SH_ADMIN_CONTAINER_NAME: ${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}
       - name: "[AIO] - Create manifest list and push"
         working-directory: digests/aio
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}:${{ github.ref_name }} \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_AIO_CONTAINER_NAME}:${REF_NAME} \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}@sha256:%s ' *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}:latest \
+          docker buildx imagetools create -t ${DOCKER_ORG_NAME}/${DOCKER_AIO_CONTAINER_NAME}:latest \
             $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}@sha256:%s ' *)
 
+
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_AIO_CONTAINER_NAME: ${{ secrets.DOCKER_AIO_CONTAINER_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 10
           run_install: false


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/build-hoppscotch-agent.yml` | Pinned 14 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/build-hoppscotch-agent.yml` | Extracted 3 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/build-hoppscotch-desktop.yml` | Pinned 10 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/build-hoppscotch-desktop.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/release-push-docker.yml` | Pinned 10 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/release-push-docker.yml` | Extracted 12 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/tests.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-008 | high | `.github/workflows/release-push-docker.yml` | Secret Directly Interpolated in run Block |
| RGS-008 | high | `.github/workflows/release-push-docker.yml` | Secret Directly Interpolated in run Block |
| RGS-008 | high | `.github/workflows/release-push-docker.yml` | Secret Directly Interpolated in run Block |
| RGS-008 | high | `.github/workflows/release-push-docker.yml` | Secret Directly Interpolated in run Block |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions by pinning 35 third-party actions to commit SHAs and moving 19 inline expressions/secrets out of run steps into env vars. This lowers supply-chain and command-injection risk without changing workflow behavior.

- **Security**
  - Pinned actions across all updated workflows, including `pnpm/action-setup`, `actions-rs/toolchain`, `apple-actions/import-codesign-certs`, and Docker actions.
  - Moved inline `${{ }}` uses to `env:` in `build-hoppscotch-agent.yml`, `build-hoppscotch-desktop.yml`, and `release-push-docker.yml` (e.g., AZURE_* and Docker vars).
  - Follow-up: review remaining direct secret interpolations in `release-push-docker.yml` run blocks.

<sup>Written for commit 40f18d40ab8c9b6c131cec17037fa142b6483108. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

