### PR TITLE
fix(common): newly created folder not shown in save-as dialog

### DIFF
--- a/packages/hoppscotch-common/src/services/team-collection.service.ts
+++ b/packages/hoppscotch-common/src/services/team-collection.service.ts
@@ -294,7 +294,7 @@ export class TeamCollectionsService extends Service<void> {
     // Add to entity ids set
     this.entityIDs.add(`collection-${collection.id}`)
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -386,7 +386,7 @@ export class TeamCollectionsService extends Service<void> {
 
     updateCollInTree(tree, collectionUpdate)
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -401,7 +401,7 @@ export class TeamCollectionsService extends Service<void> {
 
     this.entityIDs.delete(`collection-${collectionID}`)
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -428,7 +428,7 @@ export class TeamCollectionsService extends Service<void> {
     // Update the Entity IDs list
     this.entityIDs.add(`request-${request.id}`)
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -447,7 +447,7 @@ export class TeamCollectionsService extends Service<void> {
 
     Object.assign(req, requestUpdate)
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -469,7 +469,7 @@ export class TeamCollectionsService extends Service<void> {
     this.entityIDs.delete(`request-${requestID}`)
 
     // Publish new tree
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   /**
@@ -588,7 +588,7 @@ export class TeamCollectionsService extends Service<void> {
       this.reorderItems(collection.requests, requestIndex, destinationIndex)
     }
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   public updateCollectionOrder = (
@@ -653,7 +653,7 @@ export class TeamCollectionsService extends Service<void> {
       }
     }
 
-    this.collections.value = tree
+    this.collections.value = [...tree]
   }
 
   private registerSubscriptions() {


### PR DESCRIPTION
Closes #6031

### What's changed

The save-as dialog doesn't show newly created folders because Vue's `ref` setter skips updates when the value has the same reference identity. All mutation methods in `TeamCollectionsService` (`addCollection`, `updateCollection`, `removeCollection`, `addRequest`, `updateRequest`, `removeRequest`, `updateRequestOrder`, `updateCollectionOrder`) were reassigning the same `tree` array back to `this.collections.value`. Since it's the same object, Vue's identity check (`oldVal === newVal`) short-circuits and watchers don't fire.

Changed `this.collections.value = tree` to `this.collections.value = [...tree]` in all 8 spots. This is the same pattern already used by `expandCollection()` at line 1059, which works correctly.

### Notes to reviewers

The `expandCollection()` method was already doing `[...tree]` and didn't have this bug. The other methods just weren't following the same pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the save-as dialog not showing newly created folders by ensuring Vue reactivity triggers when the collections tree changes. All mutation methods now assign a new array (`[...tree]`) instead of reusing the same reference.

- **Bug Fixes**
  - Replaced `this.collections.value = tree` with `this.collections.value = [...tree]` in `TeamCollectionsService` methods: `addCollection`, `updateCollection`, `removeCollection`, `addRequest`, `updateRequest`, `removeRequest`, `updateRequestOrder`, `updateCollectionOrder`.

<sup>Written for commit 35dea7dfc81a79c6eac637492f0068bc9e5d9fdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

