### PR TITLE
fix: pin 35 actions to commit SHA, extract 19 expressions to env vars

### DIFF
--- a/.github/workflows/build-hoppscotch-agent.yml
+++ b/.github/workflows/build-hoppscotch-agent.yml
@@ -66,11 +66,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -87,7 +87,7 @@ jobs:
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
       - name: Import Code-Signing Certificates
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
@@ -166,11 +166,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -187,7 +187,7 @@ jobs:
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
       - name: Import Code-Signing Certificates
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE_PASSWORD }}
@@ -266,11 +266,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -358,11 +358,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -451,11 +451,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -540,11 +540,11 @@ jobs:
         with:
           node-version: 20
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.15.0
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           override: true
@@ -596,9 +596,12 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
+          AZURE_CODE_SIGNING_NAME: ${{ secrets.AZURE_CODE_SIGNING_NAME }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
         run: |
           cd packages/hoppscotch-agent
-          trusted-signing-cli -e ${{ secrets.AZURE_ENDPOINT }} -a ${{ secrets.AZURE_CODE_SIGNING_NAME }} -c ${{ secrets.AZURE_CERT_PROFILE_NAME }} "src-tauri/target/release/hoppscotch-agent.exe"
+          trusted-signing-cli -e $env:AZURE_ENDPOINT -a $env:AZURE_CODE_SIGNING_NAME -c $env:AZURE_CERT_PROFILE_NAME "src-tauri/target/release/hoppscotch-agent.exe"
       - name: Zip portable executable
         shell: powershell
         run: |

--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -65,10 +65,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -107,8 +107,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -117,6 +117,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}
@@ -171,10 +173,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -204,8 +206,8 @@ jobs:
       - name: Setup environment
         shell: pwsh
         run: |
-          if ("${{ secrets.ENV_FILE_CONTENT }}" -ne "") {
-            "${{ secrets.ENV_FILE_CONTENT }}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
+          if ("$env:ENV_FILE_CONTENT" -ne "") {
+            "$env:ENV_FILE_CONTENT" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
             Write-Host "Created .env file from repository secret"
           } elseif (Test-Path -Path "${{ env.WORKSPACE_PATH }}\.env") {
             Write-Host "Using existing .env file found in repository"
@@ -216,6 +218,8 @@ jobs:
           pnpm install -f --shamefully-hoist --ignore-scripts
           pnpm --filter hoppscotch-backend exec prisma generate
           pnpm install -f --shamefully-hoist --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         shell: pwsh
         run: |
@@ -274,10 +278,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -291,7 +295,7 @@ jobs:
           unzip cargo-tauri-x86_64-apple-darwin.zip
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
-      - uses: apple-actions/import-codesign-certs@v3
+      - uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         if: ${{ inputs.disable_signing != true }}
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
@@ -306,8 +310,8 @@ jobs:
           key: ${{ runner.os }}-cargo-x86_64-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -316,6 +320,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}
@@ -371,10 +377,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.18.3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: nightly
           override: true
@@ -388,7 +394,7 @@ jobs:
           unzip cargo-tauri-aarch64-apple-darwin.zip
           chmod +x cargo-tauri
           sudo mv cargo-tauri /usr/local/bin/tauri
-      - uses: apple-actions/import-codesign-certs@v3
+      - uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         if: ${{ inputs.disable_signing != true }}
         with:
           p12-file-base64: ${{ secrets.HOPPSCOTCH_APPLE_CERTIFICATE }}
@@ -403,8 +409,8 @@ jobs:
           key: ${{ runner.os }}-cargo-aarch64-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup environment
         run: |
-          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
-            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+          if [ ! -z "${ENV_FILE_CONTENT}" ]; then
+            echo "${ENV_FILE_CONTENT}" > ${{ env.WORKSPACE_PATH }}/.env
             echo "Created .env file from repository secret"
           elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
             echo "Using existing .env file found in repository"
@@ -413,6 +419,8 @@ jobs:
             echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
+        env:
+          ENV_FILE_CONTENT: ${{ secrets.ENV_FILE_CONTENT }}
       - name: Build web app
         run: |
           pnpm install --dir ${{ env.WEB_PATH }}

--- a/.github/workflows/release-push-docker.yml
+++ b/.github/workflows/release-push-docker.yml
@@ -25,20 +25,20 @@ jobs:
         run: cp .env.example .env
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push the backend container by digest
         id: backend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push the frontend container by digest
         id: frontend-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push the admin dashboard container by digest
         id: sh_admin-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push the AIO container by digest
         id: aio-build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
         with:
           context: .
           file: ./prod.Dockerfile
@@ -98,10 +98,10 @@ jobs:
 
       - name: Make digest files
         run: |
-          backend_digest="${{ steps.backend-build.outputs.digest }}"
-          frontend_digest="${{ steps.frontend-build.outputs.digest }}"
-          sh_admin_digest="${{ steps.sh_admin-build.outputs.digest }}"
-          aio_digest="${{ steps.aio-build.outputs.digest }}"
+          backend_digest="${BACKEND_DIGEST}"
+          frontend_digest="${FRONTEND_DIGEST}"
+          sh_admin_digest="${SH_ADMIN_DIGEST}"
+          aio_digest="${AIO_DIGEST}"
 
           mkdir -p digests/backend digests/frontend digests/sh_admin digests/aio
 
@@ -109,6 +109,11 @@ jobs:
           touch "digests/frontend/${frontend_digest#sha256:}"
           touch "digests/sh_admin/${sh_admin_digest#sha256:}"
           touch "digests/aio/${aio_digest#sha256:}"
+        env:
+          BACKEND_DIGEST: ${{ steps.backend-build.outputs.digest }}
+          FRONTEND_DIGEST: ${{ steps.frontend-build.outputs.digest }}
+          SH_ADMIN_DIGEST: ${{ steps.sh_admin-build.outputs.digest }}
+          AIO_DIGEST: ${{ steps.aio-build.outputs.digest }}
 
       - name: Upload digests files as artifacts
         uses: actions/upload-artifact@v4
@@ -131,13 +136,13 @@ jobs:
           merge-multiple: true
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -145,38 +150,55 @@ jobs:
       - name: "[Backend] - Create manifest list and push"
         working-directory: digests/backend
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}:${{ github.ref_name }} \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_BACKEND_CONTAINER_NAME}":"${REF_NAME}" \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_BACKEND_CONTAINER_NAME}@sha256:%s " *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}:latest \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_BACKEND_CONTAINER_NAME}":latest \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_BACKEND_CONTAINER_NAME}@sha256:%s " *)
 
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_BACKEND_CONTAINER_NAME: ${{ secrets.DOCKER_BACKEND_CONTAINER_NAME }}
       - name: "[Frontend] - Create manifest list and push"
         working-directory: digests/frontend
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}:${{ github.ref_name }} \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_FRONTEND_CONTAINER_NAME}":"${REF_NAME}" \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_FRONTEND_CONTAINER_NAME}@sha256:%s " *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}:latest \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_FRONTEND_CONTAINER_NAME}":latest \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_FRONTEND_CONTAINER_NAME}@sha256:%s " *)
 
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_FRONTEND_CONTAINER_NAME: ${{ secrets.DOCKER_FRONTEND_CONTAINER_NAME }}
       - name: "[SH Admin] - Create manifest list and push"
         working-directory: digests/sh_admin
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}:${{ github.ref_name }} \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_SH_ADMIN_CONTAINER_NAME}":"${REF_NAME}" \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_SH_ADMIN_CONTAINER_NAME}@sha256:%s " *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}:latest \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_SH_ADMIN_CONTAINER_NAME}":latest \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_SH_ADMIN_CONTAINER_NAME}@sha256:%s " *)
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_SH_ADMIN_CONTAINER_NAME: ${{ secrets.DOCKER_SH_ADMIN_CONTAINER_NAME }}
       - name: "[AIO] - Create manifest list and push"
         working-directory: digests/aio
         run: |
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}:${{ github.ref_name }} \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_AIO_CONTAINER_NAME}":"${REF_NAME}" \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_AIO_CONTAINER_NAME}@sha256:%s " *)
 
-          docker buildx imagetools create -t ${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}:latest \
-            $(printf '${{ secrets.DOCKER_ORG_NAME }}/${{ secrets.DOCKER_AIO_CONTAINER_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create -t "${DOCKER_ORG_NAME}"/"${DOCKER_AIO_CONTAINER_NAME}":latest \
+            $(printf "${DOCKER_ORG_NAME}/${DOCKER_AIO_CONTAINER_NAME}@sha256:%s " *)
 
+
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
+          DOCKER_AIO_CONTAINER_NAME: ${{ secrets.DOCKER_AIO_CONTAINER_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 10
           run_install: false


### PR DESCRIPTION
Re-submission of #6050. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 35 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 19 expressions from run blocks to env vars

## Changes by file

| File | Changes |
|------|---------|
| build-hoppscotch-agent.yml | Pinned actions to SHA |
| build-hoppscotch-desktop.yml | Pinned actions to SHA |
| release-push-docker.yml | Pinned actions to SHA |
| tests.yml | Pinned actions to SHA |

## A note on internal action pinning

This PR pins all actions including org-owned ones. Best practice is to pin everything — the tj-actions/changed-files attack was an internally maintained action that was compromised, and every repo referencing it by tag silently executed attacker code. That said, it's your codebase. If you'd prefer to leave org-owned actions unpinned, let us know and we'll adjust the PR.

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

I put up some research on this on [Twitter](https://x.com/vigilance_one/status/2036581210663616729) and a [research site](https://www.vigilantdefense.com/research/github-top-50k-repos-cicd-security-scan) if you want more context. I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard).

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins 35 GitHub Actions to immutable commit SHAs and extracts 19 inline expressions into environment variables. Fixes PowerShell and bash env var syntax and tightens quoting; workflows behave the same.

- **Dependencies**
  - Pinned actions to SHAs across 4 workflows (e.g., `pnpm/action-setup`, `actions-rs/toolchain`, `apple-actions/import-codesign-certs`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`).
  - Added version comments next to each pin.

- **Refactors**
  - Moved `${{ }}` expressions from `run:` to `env:` and referenced as `$VAR` (bash) and `$env:VAR` (PowerShell); corrected `.env` setup on all OS targets.
  - Added safe quoting in Azure signing, `.env` creation, and Docker `imagetools`/digest steps; used env vars for `github.ref_name`, image names, and digests.
  - No changes to triggers, permissions, or logic.

<sup>Written for commit a6311d83d37968df69075baa56699ffea51afd58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

