### PR TITLE
fix(teams): refetch environment list after CRUD mutations

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -398,10 +398,12 @@ const importToTeams = async (content: Environment[]) => {
     toast.error(t("import.failed"))
   } else {
     toast.success(t("import.success"))
+    emit("refetch-environments")
   }
 }
 
 const emit = defineEmits<{
   (e: "hide-modal"): () => void
+  (e: "refetch-environments"): void
 }>()
 </script>

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -27,6 +27,7 @@
       :loading="loading"
       :adapter-error="adapterError"
       @select-environment="handleEnvironmentChange"
+      @refetch-environments="refetchTeamEnvironments"
     />
     <EnvironmentsMyDetails
       :show="showModalDetails"
@@ -136,6 +137,12 @@ const selectedEnvironmentIndex = useStream(
 const loading = computed(
   () => adapterLoading.value && teamEnvironmentList.value.length === 0
 )
+
+const refetchTeamEnvironments = () => {
+  if (environmentType.value.selectedTeam?.teamID) {
+    adapter.fetchList().catch((e) => console.error(e))
+  }
+}
 
 const switchToMyEnvironments = () => {
   environmentType.value.selectedTeam = undefined
@@ -277,6 +284,7 @@ const duplicateGlobalEnvironment = async () => {
         },
         () => {
           toast.success(t("environment.duplicated"))
+          refetchTeamEnvironments()
         }
       )
     )()
@@ -312,6 +320,7 @@ const removeSelectedEnvironment = () => {
         },
         () => {
           toast.success(`${t("team_environment.deleted")}`)
+          refetchTeamEnvironments()
         }
       )
     )()

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -307,6 +307,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: "hide-modal"): void
+  (e: "refetch-environments"): void
 }>()
 
 const idTicker = ref(0)
@@ -601,6 +602,7 @@ const saveEnvironment = async () => {
             }
             hideModal()
             toast.success(`${t("environment.created")}`)
+            emit("refetch-environments")
             isLoading.value = false
           }
         )
@@ -647,7 +649,7 @@ const saveEnvironment = async () => {
           () => {
             hideModal()
             toast.success(`${t("environment.updated")}`)
-
+            emit("refetch-environments")
             isLoading.value = false
           }
         )

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -181,6 +181,7 @@ const emit = defineEmits<{
   (e: "edit-environment"): void
   (e: "show-environment-properties"): void
   (e: "select-environment"): void
+  (e: "refetch-environments"): void
 }>()
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
@@ -217,6 +218,7 @@ const removeEnvironment = () => {
         toast.success(`${t("team_environment.deleted")}`)
         secretEnvironmentService.deleteSecretEnvironment(props.environment.id)
         currentEnvironmentValueService.deleteEnvironment(props.environment.id)
+        emit("refetch-environments")
       }
     )
   )()
@@ -234,6 +236,7 @@ const duplicateEnvironment = async () => {
       },
       () => {
         toast.success(`${t("environment.duplicated")}`)
+        emit("refetch-environments")
       }
     )
   )()

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -127,6 +127,7 @@
         @show-environment-properties="
           showEnvironmentProperties(env.environment.id)
         "
+        @refetch-environments="emit('refetch-environments')"
       />
     </div>
 
@@ -139,6 +140,7 @@
       :is-secret-option-selected="secretOptionSelected"
       :is-viewer="team?.role === 'VIEWER'"
       @hide-modal="displayModalEdit(false)"
+      @refetch-environments="emit('refetch-environments')"
     />
     <EnvironmentsImportExport
       v-if="showModalImportExport"
@@ -146,6 +148,7 @@
       :team-id="team?.teamID"
       environment-type="TEAM_ENV"
       @hide-modal="displayModalImportExport(false)"
+      @refetch-environments="emit('refetch-environments')"
     />
     <EnvironmentsProperties
       v-if="showEnvironmentsPropertiesModal"
@@ -187,6 +190,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "select-environment", data: HandleEnvChangeProp): void
+  (e: "refetch-environments"): void
 }>()
 
 const filterText = ref("")


### PR DESCRIPTION
## Summary

Fixes #6015

After performing CRUD operations on team environments, the UI shows a success toast but the environment list remains stale until page reload.

## Root Cause

The environment list relies on GraphQL subscriptions via in-memory PubSub for real-time updates. In multi-instance deployments, mutations routed to a different instance than the subscription listener are silently lost.

## Fix

Added explicit refetch/invalidation of the environment list after create, delete, and duplicate mutations. This ensures the UI updates regardless of the PubSub backend.

- **`teams/Environment.vue`**: Emit `refetch-environments` after successful delete and duplicate
- **`teams/Details.vue`**: Emit `refetch-environments` after successful create and update
- **`ImportExport.vue`**: Emit `refetch-environments` after successful team environment import
- **`teams/index.vue`**: Bubble the event up from child components
- **`index.vue`**: Listen for the event and call `adapter.fetchList()` to re-query the server; also refetch after mutations that happen directly in this component (duplicate global env, delete selected env)

## Test Plan

- Create a new team environment → list should update immediately
- Delete a team environment → list should update immediately
- Duplicate a team environment → list should update immediately
- Import team environments → list should update immediately
- No page reload needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the team environment list updates immediately after create, update, delete, duplicate, and import. We now refetch from the server instead of relying on in-memory PubSub subscriptions, fixing stale lists in multi-instance setups.

- **Bug Fixes**
  - Emit `refetch-environments` on success in `teams/Environment.vue`, `teams/Details.vue`, and `ImportExport.vue`.
  - Bubble the event through `teams/index.vue`.
  - Listen in `environments/index.vue` and call `adapter.fetchList()` when a team is selected.
  - Also refetch after mutations performed directly in `environments/index.vue` (duplicate global env, delete selected env).

<sup>Written for commit 8cd917148ab0b29f5a717476c1c57cc640de9126. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

