### PR TITLE
fix(common): ignore output-only curl flags during import (#5910)

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1066,6 +1066,53 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl https://example.com -H 'X-Debug: keep -s and --verbose' --silent`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [
+        {
+          active: true,
+          key: "X-Debug",
+          value: "keep -s and --verbose",
+          description: "",
+        },
+      ],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
+  {
+    command: `curl https://example.com -d '{"mode":"-s --verbose"}' -sS`,
+    response: makeRESTRequest({
+      method: "POST",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: "application/json",
+        body: `{
+  "mode": "-s --verbose"
+}`,
+      },
+      headers: [],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,44 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl -sS https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
+  {
+    command: `curl -s -S -v https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -56,6 +56,16 @@ const prescreenXArgs = flow(
   S.trim
 )
 
+// Drop cURL flags that only change terminal output and should not affect request import.
+const stripOutputOnlyFlags = flow(
+  S.replace(
+    /(^|\s)(?:-(?:[sSvV]+)|--silent|--show-error|--verbose|--no-progress-meter)(?=\s|$)/g,
+    "$1"
+  ),
+  S.replace(/\s{2,}/g, " "),
+  S.trim
+)
+
 /**
  * Sanitizes and makes curl string processable
  * @param curlCommand Raw curl command string
@@ -65,6 +75,8 @@ export const preProcessCurlCommand = (curlCommand: string) =>
   pipe(
     curlCommand,
     O.fromPredicate((curlCmd) => curlCmd.length > 0),
-    O.map(flow(paperCuts, replaceLongOptions, prescreenXArgs)),
+    O.map(
+      flow(paperCuts, replaceLongOptions, stripOutputOnlyFlags, prescreenXArgs)
+    ),
     O.getOrElse(() => "")
   )

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -56,15 +56,84 @@ const prescreenXArgs = flow(
   S.trim
 )
 
+const outputOnlyLongFlags = new Set([
+  "--silent",
+  "--show-error",
+  "--verbose",
+  "--no-progress-meter",
+])
+
+const outputOnlyShortFlagPattern = /^-[sSvV]+$/
+
+const tokenizeCurlCommand = (curlCmd: string) => {
+  const tokens: string[] = []
+  let token = ""
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (const char of curlCmd) {
+    if (escaped) {
+      token += char
+      escaped = false
+      continue
+    }
+
+    if (char === "\\") {
+      token += char
+      escaped = true
+      continue
+    }
+
+    if (quote) {
+      token += char
+
+      if (char === quote) {
+        quote = null
+      }
+
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      token += char
+      quote = char
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      if (token.length > 0) {
+        tokens.push(token)
+        token = ""
+      }
+
+      continue
+    }
+
+    token += char
+  }
+
+  if (token.length > 0) {
+    tokens.push(token)
+  }
+
+  return tokens
+}
+
 // Drop cURL flags that only change terminal output and should not affect request import.
-const stripOutputOnlyFlags = flow(
-  S.replace(
-    /(^|\s)(?:-(?:[sSvV]+)|--silent|--show-error|--verbose|--no-progress-meter)(?=\s|$)/g,
-    "$1"
-  ),
-  S.replace(/\s{2,}/g, " "),
-  S.trim
-)
+// Only strips standalone tokens composed entirely of output-only flags.
+// Mixed short options such as `-sH` remain untouched because they may affect the request.
+const stripOutputOnlyFlags = (curlCmd: string) =>
+  pipe(
+    curlCmd,
+    tokenizeCurlCommand,
+    A.filter(
+      (token) =>
+        !outputOnlyLongFlags.has(token) &&
+        !outputOnlyShortFlagPattern.test(token)
+    ),
+    (tokens) => tokens.join(" "),
+    S.trim
+  )
 
 /**
  * Sanitizes and makes curl string processable


### PR DESCRIPTION
 ## Summary

    Fix cURL import failures when the command includes output-only flags such as
  `-s`, `-S`, `-v`, or combined variants like `-sS`.

    These flags only affect terminal output behavior and should not affect
  request parsing, but they currently cause Hoppscotch to reject otherwise valid
  cURL commands during import.

    Closes #5910

    ## Changes

    - strip output-only cURL flags before parsing the command
    - keep the existing request parsing flow unchanged for actual request-
  related options
    - add regression tests for:
      - `curl -sS https://example.com`
      - `curl -s -S -v https://example.com`

    ## Why

    `-s`, `-S`, and `-v` are common flags in real-world cURL commands copied
  from docs, scripts, and terminals. Since they do not modify the HTTP request
  itself, the importer should safely ignore them instead of treating the command
  as invalid.

    ## Testing

    Ran:

    ```bash
    pnpm --dir packages/hoppscotch-common test --
  src/helpers/curl/__tests__/curlparser.spec.js

  Result:

  •  52  test files passed
  •  713  tests passed
  •  2  skipped
  ## Files Changed

  •  packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
  •  packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import failures by ignoring output-only flags (`-s`, `-S`, `-v`, `-sS`) during preprocessing. We now remove these standalone tokens while preserving quoted values and valid combined options so requests import correctly.

- **Bug Fixes**
  - Strip output-only flags and long forms (`--silent`, `--show-error`, `--verbose`, `--no-progress-meter`) in the `packages/hoppscotch-common` preprocessor; only remove standalone tokens and keep mixed short options (e.g., `-sH`).
  - Preserve quoted and escaped values when tokenizing so flags inside headers or JSON bodies are not removed.
  - Add tests for `curl -sS https://example.com`, `curl -s -S -v https://example.com`, headers like `X-Debug: keep -s and --verbose`, and JSON bodies containing `-s --verbose`.

<sup>Written for commit 6d97ce5c5d2e8df3133dfc6441324509c4c01603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

