### PR TITLE
fix: upgrade quinn-proto to 0.11.14 (CVE-2026-31812)

### DIFF
--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -3950,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
Upgrade quinn-proto from 0.11.13 to 0.11.14 to fix CVE-2026-31812.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-31812 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-31812` |
| **File** | `packages/hoppscotch-agent/src-tauri/Cargo.lock` |

**Description**: quinn-proto: quinn-proto: Denial of Service via crafted QUIC Initial packet

## Changes
- `packages/hoppscotch-agent/src-tauri/Cargo.lock`
- `packages/hoppscotch-agent/src-tauri/Cargo.toml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `quinn-proto` to 0.11.14 in the Hoppscotch agent to patch CVE-2026-31812 (DoS via crafted QUIC Initial packet). Removes the high-severity scanner finding in `src-tauri`.

- **Dependencies**
  - Bumped `quinn-proto` 0.11.13 → 0.11.14 in `packages/hoppscotch-agent/src-tauri`.

<sup>Written for commit 197486e408609e6f24bbca17e58ac630dcccd646. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

