### PR TITLE
fix(workspace): sort workspaces alphabetically in dropdown

### DIFF
--- a/packages/hoppscotch-common/src/components/workspace/Selector.vue
+++ b/packages/hoppscotch-common/src/components/workspace/Selector.vue
@@ -108,7 +108,10 @@ const currentUser = useReadonlyStream(
 
 const workspaceService = useService(WorkspaceService)
 const teamListadapter = workspaceService.acquireTeamListAdapter(null)
-const myTeams = useReadonlyStream(teamListadapter.teamList$, [])
+const unsortedTeams = useReadonlyStream(teamListadapter.teamList$, [])
+const myTeams = computed(() =>
+  [...unsortedTeams.value].sort((a, b) => a.name.localeCompare(b.name))
+)
 const isTeamListLoading = useReadonlyStream(teamListadapter.loading$, false)
 const teamListAdapterError = useReadonlyStream(teamListadapter.error$, null)
 const REMEMBERED_TEAM_ID = useLocalState("REMEMBERED_TEAM_ID")

--- a/packages/hoppscotch-common/src/components/workspace/Selector.vue
+++ b/packages/hoppscotch-common/src/components/workspace/Selector.vue
@@ -49,8 +49,8 @@
           />
         </div>
         <HoppSmartItem
-          v-for="(team, index) in myTeams"
-          :key="`team-${String(index)}`"
+          v-for="team in myTeams"
+          :key="`team-${team.id}`"
           :icon="IconUsers"
           :label="team.name"
           :info-icon="isActiveWorkspace(team.id) ? IconDone : undefined"


### PR DESCRIPTION
Closes #6096

## Introduction

The workspace dropdown renders teams in database insertion order, making it difficult to find the right workspace when there are many teams (55+ in the reporter's case).

## What's changed

- Added a `computed` property in `Selector.vue` that sorts the teams list alphabetically by name using `localeCompare`
- The original stream (`teamListadapter.teamList$`) is preserved as `unsortedTeams` — the sorted list is derived reactively via `computed`

**Why client-side sort instead of backend `orderBy`?**

The backend `getTeamsOfUser()` uses cursor-based pagination with `cursor: { id }`. Prisma's cursor pagination [requires sorting by a sequential, unique column](https://www.prisma.io/docs/orm/prisma-client/queries/pagination) matching the cursor field. Adding `orderBy: { name: 'asc' }` would break cursor pagination because `name` is not sequential or unique. Sorting client-side after all pages are fetched avoids this issue entirely.

## Notes to reviewers

- This is the second part of #6096. The first part (spotlight search pagination) is addressed in #6097.
- `computed` is already imported from `vue` in this file.
- `[...array].sort()` creates a copy — the original stream is not mutated.
- `localeCompare` handles unicode and international workspace names correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort workspaces alphabetically in the workspace dropdown and fix list keying to keep item state stable. Closes #6096.

- **Bug Fixes**
  - Dropdown: derive `myTeams` from `unsortedTeams` via `computed` and `localeCompare`, copying with `[...arr].sort(...)` to avoid mutating the original stream.
  - Use `team.id` as the `v-for` key instead of the index to prevent mis-bound component state after sorting.

<sup>Written for commit 0b8f57b0b6b2e777ffbd5c4033090dd94816ed26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

