### PR TITLE
feat: add RS256 and RSA algorithm support to JWT authentication

### DIFF
--- a/packages/hoppscotch-common/src/components/http/authorization/JWT.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/JWT.vue
@@ -290,7 +290,20 @@ Your private key here
   })
 )
 
-const algorithms: HoppRESTAuthJWT["algorithm"][] = ["HS256", "HS384", "HS512"]
+const algorithms: HoppRESTAuthJWT["algorithm"][] = [
+  "HS256",
+  "HS384",
+  "HS512",
+  "RS256",
+  "RS384",
+  "RS512",
+  "PS256",
+  "PS384",
+  "PS512",
+  "ES256",
+  "ES384",
+  "ES512",
+]
 
 const addToTargets = [
   {

--- a/packages/hoppscotch-data/src/utils/jwt.ts
+++ b/packages/hoppscotch-data/src/utils/jwt.ts
@@ -59,7 +59,7 @@ export async function generateJWTToken(
   }
 
   try {
-    let cryptoKey: Uint8Array
+    let key: Uint8Array | CryptoKey
 
     // Use private key for RSA/ECDSA algorithms, secret for HMAC algorithms
     if (
@@ -67,19 +67,35 @@ export async function generateJWTToken(
       algorithm.startsWith("ES") ||
       algorithm.startsWith("PS")
     ) {
-      // RSA or ECDSA algorithms - use private key
+      // RSA, ECDSA, or PSS algorithms - import private key
       if (!privateKey) {
-        console.error("Private key is required for RSA/ECDSA algorithms")
+        console.error("Private key is required for RSA/ECDSA/PSS algorithms")
         return null
       }
-      cryptoKey = new TextEncoder().encode(privateKey)
+
+      try {
+        // Import the private key for asymmetric algorithms
+        if (algorithm.startsWith("RS") || algorithm.startsWith("PS")) {
+          // RSA algorithms
+          key = await jose.importPKCS8(privateKey, algorithm)
+        } else if (algorithm.startsWith("ES")) {
+          // ECDSA algorithms
+          key = await jose.importPKCS8(privateKey, algorithm)
+        } else {
+          console.error("Unsupported algorithm:", algorithm)
+          return null
+        }
+      } catch (keyError) {
+        console.error("Failed to import private key:", keyError)
+        return null
+      }
     } else {
-      // HMAC algorithms - use secret
+      // HMAC algorithms - use secret as Uint8Array
       if (!secret) {
         console.error("Secret is required for HMAC algorithms")
         return null
       }
-      cryptoKey = isSecretBase64Encoded
+      key = isSecretBase64Encoded
         ? Uint8Array.from(Buffer.from(secret, "base64"))
         : new TextEncoder().encode(secret)
     }
@@ -89,7 +105,7 @@ export async function generateJWTToken(
         alg: algorithm,
         ...parsedHeaders,
       })
-      .sign(cryptoKey)
+      .sign(key)
 
     return token
   } catch (e) {


### PR DESCRIPTION
Closes #6074

## 🚀 What does this PR do?

This PR adds support for **asymmetric JWT algorithms (RS*, PS*, ES*)**, including **RS256**, enabling proper private key-based token signing.

---

## ✨ Changes

### 1. JWT Token Generation Fix
- Updated `generateJWTToken` to correctly handle asymmetric algorithms
- Used `jose.importPKCS8()` to import private keys as `CryptoKey`
- Fixed incorrect handling where private keys were treated as plain strings

### 2. Expanded Algorithm Support (UI)
- Added support for additional JWT algorithms:
  - **HMAC**: HS256, HS384, HS512  
  - **RSA**: RS256, RS384, RS512  
  - **PSS**: PS256, PS384, PS512  
  - **ECDSA**: ES256, ES384, ES512  
- UI dynamically supports private key input for asymmetric algorithms

---

## 💡 Why is this needed?

Many modern authentication systems (e.g., Salesforce, OAuth providers) rely on **RS256 and other asymmetric algorithms** for secure JWT signing.

Previously, private keys were not handled correctly, which caused issues when generating tokens using these algorithms.

---

## 🧪 How to Test

1. Open JWT Auth settings  
2. Select an asymmetric algorithm (e.g., RS256)  
3. Provide a valid private key (PKCS8 format)  
4. Generate token and verify it works with supported services  

---

## 📝 Notes

- No breaking changes introduced  
- Existing HMAC-based JWT functionality remains unchanged  
- Improves compatibility with real-world authentication providers  

---

Please let me know if any additional edge cases should be handled 🙌

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RS256 and other asymmetric JWT algorithms, and fixes private key handling so tokens sign correctly. The JWT UI now supports selecting these algorithms and entering a PKCS8 private key.

- **New Features**
  - Support for `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`.
  - UI shows private key input when an asymmetric algorithm is selected.

- **Bug Fixes**
  - `generateJWTToken` imports PKCS8 private keys via `jose` and signs with a `CryptoKey`.
  - HMAC secrets are encoded correctly, including base64.

<sup>Written for commit a8e623df6d9500846cb4ecdbc4c61411cadb7045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

