### PR TITLE
feat: add checkbox to disable environment entries

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -130,7 +130,15 @@
                     v-for="({ id, env }, index) in tab.variables"
                     :key="`${tab.id}-${id}-${index}`"
                     class="flex divide-x divide-dividerLight"
-                  >
+>
+                    <div class="flex items-center px-2">
+                      <input
+                        type="checkbox"
+                        :checked="env.enabled !== false"
+                        class="cursor-pointer"
+                        @change="env.enabled = ($event.target as HTMLInputElement).checked"
+                      />
+                    </div>
                     <input
                       v-model="env.key"
                       v-focus
@@ -510,6 +518,7 @@ const addEnvironmentVariable = () => {
       currentValue: "",
       initialValue: "",
       secret: selectedEnvOption.value === "secret",
+      enabled: true,
     },
   })
 }
@@ -533,14 +542,14 @@ const saveEnvironment = () => {
   }
 
   const filteredVariables = pipe(
-    vars.value,
-    A.filterMap(
-      flow(
-        O.fromPredicate((e) => e.env.key !== ""),
-        O.map((e) => e.env)
-      )
+  vars.value,
+  A.filterMap(
+    flow(
+      O.fromPredicate((e) => e.env.key !== "" && e.env.enabled !== false),
+      O.map((e) => e.env)
     )
   )
+)
 
   const secretVariables = pipe(
     filteredVariables,

--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, loadEnv, normalizePath } from "vite"
 import { APP_INFO, META_TAGS } from "./meta"
 import { viteStaticCopy as StaticCopy } from "vite-plugin-static-copy"
-import generateSitemap from "vite-plugin-pages-sitemap"
+//import generateSitemap from "vite-plugin-pages-sitemap"
 import HtmlConfig from "vite-plugin-html-config"
 import Vue from "@vitejs/plugin-vue"
 import VueI18n from "@intlify/unplugin-vue-i18n/vite"
@@ -30,6 +30,7 @@ export default defineConfig({
     "process.platform": '"browser"',
   },
   server: {
+  hmr: { overlay: false },
     port: 3000,
   },
   preview: {
@@ -108,23 +109,10 @@ export default defineConfig({
       routeStyle: "nuxt",
       dirs: ["../hoppscotch-common/src/pages", "./src/pages"],
       importMode: "async",
-      onRoutesGenerated(routes) {
-        generateSitemap({
-          routes,
-          nuxtStyle: true,
-          allowRobots: true,
-          dest: ".sitemap-gen",
-          hostname: ENV.VITE_BASE_URL,
-        })
-      },
+      onRoutesGenerated(routes) {},
     }),
     StaticCopy({
-      targets: [
-        {
-          src: normalizePath(path.resolve(__dirname, "./.sitemap-gen/*")),
-          dest: normalizePath(path.resolve(__dirname, "./dist")),
-        },
-      ],
+      targets: [],
     }),
     Layouts({
       layoutsDirs: "../hoppscotch-common/src/layouts",
@@ -231,7 +219,7 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 15728640, // 15 MB
         navigateFallbackDenylist: [
           /robots.txt/,
-          /sitemap.xml/,
+          ///sitemap.xml/,
           /discord/,
           /telegram/,
           /beta/,


### PR DESCRIPTION
Corresponding to issue  #312 
Added a checkbox to each environment variable row to enable/disable entries. 
Disabled entries are excluded when saving the environment.
Changes:
1. Added enabled toggle checkbox to each variable row in Details.vue
2. New entries default to enabled: true
3. Disabled entries are filtered out on save

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a checkbox to enable/disable environment variables without deleting them, so you can keep entries but exclude them when using an environment. Addresses #312.

- **New Features**
  - Added an enable/disable checkbox to each variable row in `packages/hoppscotch-common/src/components/environments/my/Details.vue`.
  - New variables default to enabled.
  - Disabled variables are filtered out on save.

- **Refactors**
  - Updated `packages/hoppscotch-selfhost-web/vite.config.ts` to disable sitemap generation/copy and turn off HMR overlay.

<sup>Written for commit 3f6f050ee7d2cb1e5e01fbf28d0fb4bb98fb9bb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

