### PR TITLE
refactor(cli): match test-result helper name to documented contract

### DIFF
--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -369,7 +369,7 @@ export const processRequest =
 
       // Updating report with current tests, result and duration.
       report.tests = testsReport;
-      report.result = report.result && _hasFailedTestCases;
+      report.result = report.result && !_hasFailedTestCases;
       report.duration.test = duration;
 
       // Updating resulting envs from test-runner.

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -30,7 +30,7 @@ import {
 } from "./display";
 import { getDurationInSeconds, getMetaDataPairs } from "./getters";
 import { preRequestScriptRunner } from "./pre-request";
-import { getTestScriptParams, hasFailedTestCases, testRunner } from "./test";
+import { getTestScriptParams, hasAllTestsPassed, testRunner } from "./test";
 
 /**
  * Processes given variable, which includes checking for secret variables
@@ -337,7 +337,7 @@ export const processRequest =
       report.result = false;
     } else {
       const { envs, testsReport, duration } = testRunnerRes.right;
-      const _hasFailedTestCases = hasFailedTestCases(testsReport);
+      const _allTestsPassed = hasAllTestsPassed(testsReport);
 
       // Check if any tests have uncaught runtime errors (e.g., ReferenceError, TypeError)
       // Don't include validation errors (they're reported as individual testcases)
@@ -369,7 +369,7 @@ export const processRequest =
 
       // Updating report with current tests, result and duration.
       report.tests = testsReport;
-      report.result = report.result && !_hasFailedTestCases;
+      report.result = report.result && _allTestsPassed;
       report.duration.test = duration;
 
       // Updating resulting envs from test-runner.

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -369,7 +369,7 @@ export const processRequest =
 
       // Updating report with current tests, result and duration.
       report.tests = testsReport;
-      report.result = report.result && !_hasFailedTestCases;
+      report.result = report.result && _hasFailedTestCases;
       report.duration.test = duration;
 
       // Updating resulting envs from test-runner.

--- a/packages/hoppscotch-cli/src/utils/test.ts
+++ b/packages/hoppscotch-cli/src/utils/test.ts
@@ -237,13 +237,12 @@ export const getFailedExpectedResults = (expectResults: ExpectResult[]) =>
   );
 
 /**
- * Checks if any of the tests-report have failed test-cases.
+ * Checks whether every test report has zero failed test cases.
  * @param testsReport Provides "failed" test-cases data.
- * @returns True, if one or more failed test-cases found.
- * False, if all test-cases passed.
+ * @returns True, if all test-cases passed. False, otherwise.
  */
-export const hasFailedTestCases = (testsReport: TestReport[]) =>
+export const hasAllTestsPassed = (testsReport: TestReport[]) =>
   pipe(
     testsReport,
-    A.some(({ failed }) => failed > 0)
+    A.every(({ failed }) => failed === 0)
   );

--- a/packages/hoppscotch-cli/src/utils/test.ts
+++ b/packages/hoppscotch-cli/src/utils/test.ts
@@ -245,5 +245,5 @@ export const getFailedExpectedResults = (expectResults: ExpectResult[]) =>
 export const hasFailedTestCases = (testsReport: TestReport[]) =>
   pipe(
     testsReport,
-    A.every(({ failed }) => failed === 0)
+    A.some(({ failed }) => failed > 0)
   );


### PR DESCRIPTION
Closes #6118

The helper `hasFailedTestCases` in the CLI had a name and JSDoc that described the inverse of what it returned. Renames the helper to `hasAllTestsPassed` so the name matches the existing `A.every(({ failed }) => failed === 0)` predicate.

### What's changed

- Renamed `hasFailedTestCases` → `hasAllTestsPassed` in `packages/hoppscotch-cli/src/utils/test.ts`, with the JSDoc updated to match the new name
- Renamed the local variable at the single call site in `packages/hoppscotch-cli/src/utils/request.ts` — the call site's shape is unchanged (`report.result = report.result && _allTestsPassed`)

### Notes to reviewers

No CLI behaviour change. The predicate (`A.every(failed === 0)`) is unchanged; only the helper's name and JSDoc change, along with the local variable rename at the call site. The call site was already treating the helper's return value as a pass signal, so the rename aligns the name with how it was always consumed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed inverted test result logic by renaming `hasFailedTestCases` to `hasAllTestsPassed` and using it directly in `packages/hoppscotch-cli/src/utils/request.ts`. `report.result` is now true only when all tests pass; updated JSDoc in `packages/hoppscotch-cli/src/utils/test.ts` and dropped call-site negation, resolving #6118.

<sup>Written for commit 761068b618ef82252640c66b4326a6d566b58c49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->