### PR TITLE
fix(data): make `$randomUUID` predefined variable RFC 4122 compliant

### DIFF
--- a/packages/hoppscotch-data/src/predefinedVariables.ts
+++ b/packages/hoppscotch-data/src/predefinedVariables.ts
@@ -4,29 +4,29 @@ export type PredefinedVariable = {
   getValue: () => string
 }
 
+const generateV4Uuid = () => {
+  const characters = "0123456789abcdef"
+  let uuid = ""
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid += "-"
+    } else if (i === 14) {
+      uuid += "4"
+    } else if (i === 19) {
+      uuid += characters.charAt(8 + Math.floor(Math.random() * 4))
+    } else {
+      uuid += characters.charAt(Math.floor(Math.random() * characters.length))
+    }
+  }
+  return uuid
+}
+
 export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
   // Common
   {
     key: "$guid",
     description: "A v4 style GUID.",
-    getValue: () => {
-      const characters = "0123456789abcdef"
-      let guid = ""
-      for (let i = 0; i < 36; i++) {
-        if (i === 8 || i === 13 || i === 18 || i === 23) {
-          guid += "-"
-        } else if (i === 14) {
-          guid += "4"
-        } else if (i === 19) {
-          guid += characters.charAt(8 + Math.floor(Math.random() * 4))
-        } else {
-          guid += characters.charAt(
-            Math.floor(Math.random() * characters.length)
-          )
-        }
-      }
-      return guid
-    },
+    getValue: generateV4Uuid,
   },
   {
     key: "$timestamp",
@@ -42,24 +42,7 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
   {
     key: "$randomUUID",
     description: "A random 36-character UUID.",
-    getValue: () => {
-      const characters = "0123456789abcdef"
-      let uuid = ""
-      for (let i = 0; i < 36; i++) {
-        if (i === 8 || i === 13 || i === 18 || i === 23) {
-          uuid += "-"
-        } else if (i === 14) {
-          uuid += "4"
-        } else if (i === 19) {
-          uuid += characters.charAt(8 + Math.floor(Math.random() * 4))
-        } else {
-          uuid += characters.charAt(
-            Math.floor(Math.random() * characters.length)
-          )
-        }
-      }
-      return uuid
-    },
+    getValue: generateV4Uuid,
   },
 
   // Text, numbers, and colors

--- a/packages/hoppscotch-data/src/predefinedVariables.ts
+++ b/packages/hoppscotch-data/src/predefinedVariables.ts
@@ -48,6 +48,10 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
       for (let i = 0; i < 36; i++) {
         if (i === 8 || i === 13 || i === 18 || i === 23) {
           uuid += "-"
+        } else if (i === 14) {
+          uuid += "4"
+        } else if (i === 19) {
+          uuid += characters.charAt(8 + Math.floor(Math.random() * 4))
         } else {
           uuid += characters.charAt(
             Math.floor(Math.random() * characters.length)
@@ -140,7 +144,7 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
     description: "A random IPv6 address.",
     getValue: () => {
       const ip = Array.from({ length: 8 }, () =>
-        Math.floor(Math.random() * 65536).toString(16)
+        Math.floor(Math.random() * 65536).toString(16).padStart(4, "0")
       )
       return ip.join(":")
     },
@@ -151,7 +155,7 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
     description: "A random MAC address.",
     getValue: () => {
       const mac = Array.from({ length: 6 }, () =>
-        Math.floor(Math.random() * 256).toString(16)
+        Math.floor(Math.random() * 256).toString(16).padStart(2, "0")
       )
       return mac.join(":")
     },


### PR DESCRIPTION
Closes #6124

`$randomUUID` was generating random hex at all positions instead of setting RFC 4122 v4 version and variant bits, so the output failed strict UUID validators even though the shape looked correct. Adjacent `$randomIPV6` and `$randomMACAddress` were emitting unpadded hex, producing formats some tooling rejects.

### What's changed

- `$randomUUID` now sets position 14 to `4` (version nibble) and position 19 to one of `8`, `9`, `a`, `b` (variant nibble), mirroring existing `$guid` behaviour.
- Zero-pads `$randomIPV6` hextets to 4 chars and `$randomMACAddress` octets to 2 chars so both emit fixed-width hex.
- Extracts a shared `generateV4Uuid` helper so `$guid` and `$randomUUID` use the same generator.

### Notes to reviewers

- `$guid` behaviour is unchanged by the shared-helper extraction.
- TypeScript typecheck clean (`pnpm exec tsc --noEmit` in `packages/hoppscotch-data`).

---
## Summary by cubic
Make `$randomUUID` RFC 4122 v4 compliant and unify v4 UUID generation via a shared helper used by `$guid` and `$randomUUID`. Also zero-pad IPv6 and MAC outputs for valid formatting.

- **Bug Fixes**
  - `$randomUUID` now sets nibble 14 to `4` and nibble 19 to one of `8`, `9`, `a`, `b`.
  - Zero-pad IPv6 hextets to 4 chars and MAC octets to 2 chars.

<sup>Written for commit 19b088b124fe618722b0e09e19f7098fdb71b41d. Summary will update on new commits.</sup>

<\!-- End of auto-generated description by cubic. -->