### PR TITLE
fix: handle array-valued Postman headers on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import * as E from "fp-ts/Either"
+import { hoppPostmanImporter } from "../import-export/import/postman"
+
+const postmanCollectionWithArrayHeader = JSON.stringify({
+  info: {
+    name: "Array Header Import",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Import Array Header",
+      request: {
+        method: "GET",
+        header: [
+          {
+            key: "Authorization",
+            value: ["Basic xxxxx", "Basic xxxxxxxxxxxx="],
+          },
+          {
+            key: "Content-Type",
+            value: "application/x-www-form-urlencoded",
+          },
+        ],
+        url: "https://echo.hoppscotch.io/get",
+      },
+    },
+  ],
+})
+
+describe("Postman importer", () => {
+  it("joins array header values instead of crashing during import", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithArrayHeader,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0]?.requests[0]?.headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Basic xxxxx, Basic xxxxxxxxxxxx=",
+          active: true,
+        }),
+        expect.objectContaining({
+          key: "Content-Type",
+          value: "application/x-www-form-urlencoded",
+          active: true,
+        }),
+      ])
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -105,6 +105,15 @@ const parseDescription = (descField?: string | DescriptionDefinition) => {
   return descField.content
 }
 
+const normalizePMHeaderValue = (value: unknown): string =>
+  Array.isArray(value)
+    ? pipe(
+        value,
+        A.map((entry) => String(entry ?? "")),
+        stringArrayJoin(", ")
+      )
+    : String(value ?? "")
+
 const getHoppCollVariables = (
   ig: ItemGroup<Item>
 ): HoppCollectionVariable[] => {
@@ -142,7 +151,7 @@ const getHoppReqHeaders = (
 
       return <HoppRESTHeader>{
         key: replacePMVarTemplating(header.key),
-        value: replacePMVarTemplating(header.value),
+        value: replacePMVarTemplating(normalizePMHeaderValue(header.value)),
         active: !header.disabled,
         description,
       }


### PR DESCRIPTION
## Summary
- normalize Postman header values that arrive as arrays before templating them
- keep imported header entries usable by joining array values into a single string
- add a regression test covering array-valued header imports

## Root cause
The Postman importer assumed every header value was a string and passed it directly into `replacePMVarTemplating()`. Some Postman exports contain `header.value` as an array, which caused the import flow to throw before the request could be created.

## Testing
- `corepack pnpm --filter @hoppscotch/common test -- --run src/helpers/__tests__/postman-import.spec.ts`
- `corepack pnpm --filter @hoppscotch/common do-typecheck`
- `corepack pnpm --filter @hoppscotch/common exec eslint src/helpers/import-export/import/postman.ts src/helpers/__tests__/postman-import.spec.ts`
- `git commit` pre-commit hook (`pnpm -r do-lint && pnpm -r do-typecheck`)

Closes #6132


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Postman importer by normalizing array-valued headers into strings before templating, so requests import correctly. Array values are joined with ", " to keep headers usable.

- **Bug Fixes**
  - Normalize Postman header values; join arrays with ", " before `replacePMVarTemplating()`.
  - Add regression test for array-valued header imports in `@hoppscotch/common`.

<sup>Written for commit 1642a228313b60ab9b50c310b5d67dab6f54eab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

