### PR TITLE
fix: handle array header values in Postman import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -140,9 +140,16 @@ const getHoppReqHeaders = (
     A.map((header) => {
       const description = parseDescription(header.description)
 
+      // Postman allows header values to be arrays (multiple values for
+      // the same header). Normalize to a comma-separated string per
+      // RFC 7230 §3.2.6 before processing. See #6132.
+      const rawValue = Array.isArray(header.value)
+        ? header.value.join(", ")
+        : (header.value ?? "")
+
       return <HoppRESTHeader>{
         key: replacePMVarTemplating(header.key),
-        value: replacePMVarTemplating(header.value),
+        value: replacePMVarTemplating(rawValue),
         active: !header.disabled,
         description,
       }


### PR DESCRIPTION
Fixes #6132.

Postman allows header values to be arrays (multiple values for the same key), like:

```json
{
  "key": "Authorization",
  "value": ["Basic xxxxx", "Basic xxxxxxxxxxxx="]
}
```

The importer passed `header.value` directly to `replacePMVarTemplating` which expects a string. When the value was an array, it crashed.

Normalize array values to a comma-separated string per RFC 7230 §3.2.6 before processing. String values and null/undefined pass through unchanged. One file, 8 lines added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6132 by preventing crashes in the Postman importer when headers use array values. Arrays are normalized to a comma-separated string per RFC 7230 §3.2.6 before templating; strings and null/undefined continue to work.

<sup>Written for commit 36ef7f1fb485e898c745d3186fabc4faf7b881bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

