### PR TITLE
fix(common): handle non-string values in Postman collection import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -1,0 +1,60 @@
+import * as E from "fp-ts/Either"
+import { describe, expect, it } from "vitest"
+
+import { hoppPostmanImporter } from "../import-export/import/postman"
+
+const postmanCollectionWithArrayHeader = JSON.stringify({
+  info: {
+    name: "Array Header Import",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Import Array Header",
+      request: {
+        method: "GET",
+        header: [
+          {
+            key: "Authorization",
+            value: ["Basic xxxxx", "Basic xxxxxxxxxxxx="],
+          },
+          {
+            key: "Content-Type",
+            value: "application/x-www-form-urlencoded",
+          },
+        ],
+        url: "https://echo.hoppscotch.io/get",
+      },
+    },
+  ],
+})
+
+describe("Postman importer", () => {
+  it("coerces array header values instead of crashing during import", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithArrayHeader,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0].requests[0].headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Basic xxxxx,Basic xxxxxxxxxxxx=",
+          active: true,
+        }),
+        expect.objectContaining({
+          key: "Content-Type",
+          value: "application/x-www-form-urlencoded",
+          active: true,
+        }),
+      ])
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -63,10 +63,10 @@ const getCollectionSchema = (jsonStr: string): string | null => {
   }
 }
 
-export const replacePMVarTemplating = flow(
-  S.replace(/{{\s*/g, "<<"),
-  S.replace(/\s*}}/g, ">>")
-)
+export const replacePMVarTemplating = (value: unknown): string => {
+  const str = typeof value === "string" ? value : String(value ?? "")
+  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+}
 
 const PMRawLanguageOptionsToContentTypeMap: Record<
   PMRawLanguage,


### PR DESCRIPTION
Closes #5755

### What's changed

Postman collections allow header, query param, and variable values to be non-string types (arrays, numbers, objects). When importing such collections, `replacePMVarTemplating` passes these values into fp-ts `S.replace`, which calls `.replace()` on the input — causing `TypeError: e.replaceAll is not a function` (or `t.replace is not a function` depending on the build).

The fix adds type checking at the entry point of `replacePMVarTemplating`. If the value is already a string, it's used as-is. Otherwise it's coerced via `String()`, with `null`/`undefined` falling back to an empty string. This covers all call sites (headers, params, variables, auth fields, body content) without needing to patch each one individually.

### Notes to reviewers

The third-party `postman-collection` SDK types declare `header.value` as `string`, but Postman's actual export format allows arrays and other types in these positions — confirmed by the reporter's screenshot in the issue thread. The SDK's type definitions are simply incomplete here, so the runtime guard is necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash in Postman collection import when headers, query params, or variables contain non‑string values. `replacePMVarTemplating` now coerces any input to a string (null/undefined → empty string) before `fp-ts` `S.replace`, and adds a test verifying array header values import without errors.

<sup>Written for commit 48578df6cae3cd49dbd414076b7e42750f3a1b8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

