### PR TITLE
fix(common): apply platform default proxy URL on load and reset

### DIFF
--- a/packages/hoppscotch-common/src/components/settings/Proxy.vue
+++ b/packages/hoppscotch-common/src/components/settings/Proxy.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed, watch } from "vue"
+import { ref, computed, watch } from "vue"
 import { refAutoReset } from "@vueuse/core"
 
 import { useService } from "dioc/vue"
@@ -57,26 +57,35 @@ const store = useService(KernelInterceptorProxyStore)
 const interceptorService = useService(KernelInterceptorService)
 const proxyInterceptorService = useService(ProxyKernelInterceptorService)
 
-const proxyUrl = ref("")
+// Local editable copy, synced from the reactive store
+const proxyUrl = ref(store.settings$.value.proxyUrl)
+
+// When the store's settings change (e.g. async init resolves, or external
+// tab updates via the Store watcher), keep the local input in sync —
+// but only if the user hasn't actively edited it to something different.
+watch(
+  () => store.settings$.value.proxyUrl,
+  (storeUrl) => {
+    // Don't overwrite user edits, only sync when local still matches
+    // the previous store value (i.e. user hasn't typed anything new)
+    if (proxyUrl.value === "" || proxyUrl.value === storeUrl) {
+      proxyUrl.value = storeUrl
+    }
+  },
+  { immediate: true }
+)
 
 const currentUser = useReadonlyStream(
   platform.auth.getCurrentUserStream(),
   platform.auth.getCurrentUser()
 )
 
-async function updateProxyUrl() {
-  await store.updateSettings({ proxyUrl: proxyUrl.value })
-  toast.success(t("state.saved"))
-}
-
-watch(
-  () => currentUser.value,
-  async () => {
-    if (!currentUser.value) {
-      proxyUrl.value = await getDefaultProxyUrl()
-    }
+// Reset proxy URL to default when user logs out
+watch(currentUser, async (user) => {
+  if (!user) {
+    proxyUrl.value = await getDefaultProxyUrl()
   }
-)
+})
 
 const enabled = computed(
   () => interceptorService.getCurrentId() === proxyInterceptorService.id
@@ -87,16 +96,16 @@ const clearIcon = refAutoReset<typeof IconRotateCCW | typeof IconCheck>(
   1000
 )
 
+async function updateProxyUrl() {
+  await store.updateSettings({ proxyUrl: proxyUrl.value })
+  toast.success(t("state.saved"))
+}
+
 async function resetSettings() {
   await store.resetSettings()
-  const settings = store.getSettings()
-  proxyUrl.value = settings.proxyUrl
+  // Store is reactive, settings$ already updated, just sync local ref
+  proxyUrl.value = store.settings$.value.proxyUrl
   clearIcon.value = IconCheck
   toast.success(t("state.cleared"))
 }
-
-onMounted(async () => {
-  const settings = store.getSettings()
-  proxyUrl.value = settings.proxyUrl
-})
 </script>

--- a/packages/hoppscotch-common/src/components/settings/Proxy.vue
+++ b/packages/hoppscotch-common/src/components/settings/Proxy.vue
@@ -33,18 +33,15 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue"
 import { refAutoReset } from "@vueuse/core"
-
 import { useService } from "dioc/vue"
 
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { useReadonlyStream } from "~/composables/stream"
-import { getDefaultProxyUrl } from "~/helpers/proxyUrl"
 import { platform } from "~/platform"
 
 import { KernelInterceptorProxyStore } from "~/platform/std/kernel-interceptors/proxy/store"
 import { ProxyKernelInterceptorService } from "~/platform/std/kernel-interceptors/proxy/index"
-
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
 
 import IconRotateCCW from "~icons/lucide/rotate-ccw"
@@ -65,10 +62,10 @@ const proxyUrl = ref(store.settings$.value.proxyUrl)
 // but only if the user hasn't actively edited it to something different.
 watch(
   () => store.settings$.value.proxyUrl,
-  (storeUrl) => {
+  (storeUrl, prevStoreUrl) => {
     // Don't overwrite user edits, only sync when local still matches
     // the previous store value (i.e. user hasn't typed anything new)
-    if (proxyUrl.value === "" || proxyUrl.value === storeUrl) {
+    if (proxyUrl.value === "" || proxyUrl.value === prevStoreUrl) {
       proxyUrl.value = storeUrl
     }
   },
@@ -80,10 +77,14 @@ const currentUser = useReadonlyStream(
   platform.auth.getCurrentUser()
 )
 
-// Reset proxy URL to default when user logs out
+// Reset proxy settings to platform defaults when user logs out.
+// Force-sync the local ref after reset — the settings$ watch has a guard
+// that skips sync when the user has unsaved local edits, but logout should
+// unconditionally reset the input.
 watch(currentUser, async (user) => {
   if (!user) {
-    proxyUrl.value = await getDefaultProxyUrl()
+    await store.resetSettings()
+    proxyUrl.value = store.settings$.value.proxyUrl
   }
 })
 
@@ -103,7 +104,7 @@ async function updateProxyUrl() {
 
 async function resetSettings() {
   await store.resetSettings()
-  // Store is reactive, settings$ already updated, just sync local ref
+  // Store is reactive — settings$ already updated, just sync local ref
   proxyUrl.value = store.settings$.value.proxyUrl
   clearIcon.value = IconCheck
   toast.success(t("state.cleared"))

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -3,7 +3,7 @@ import { Observable } from "rxjs"
 import { distinctUntilChanged, pluck } from "rxjs/operators"
 import type { KeysMatching } from "~/types/ts-utils"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
-import { DEFAULT_HOPP_PROXY_URL, getDefaultProxyUrl } from "~/helpers/proxyUrl"
+import { DEFAULT_HOPP_PROXY_URL } from "~/helpers/proxyUrl"
 
 export const HoppBgColors = ["system", "light", "dark", "black"] as const
 
@@ -87,12 +87,6 @@ export type SettingsDef = {
   ENABLE_EXPERIMENTAL_DOCUMENTATION: boolean
 }
 
-let defaultProxyURL = DEFAULT_HOPP_PROXY_URL
-
-getDefaultProxyUrl().then((url) => {
-  defaultProxyURL = url
-})
-
 export const getDefaultSettings = (): SettingsDef => {
   return {
     syncCollections: true,
@@ -122,8 +116,10 @@ export const getDefaultSettings = (): SettingsDef => {
     // Set empty because interceptor module will set the default value
     CURRENT_KERNEL_INTERCEPTOR_ID: "",
 
-    // TODO: Interceptor related settings should move under the interceptor systems
-    PROXY_URL: defaultProxyURL,
+    // Static fallback, the actual platform-aware proxy URL is managed by
+    // `KernelInterceptorProxyStore` which resolves it at runtime via
+    // `getDefaultProxyUrl()` (after the platform is initialised).
+    PROXY_URL: DEFAULT_HOPP_PROXY_URL,
     URL_EXCLUDES: {
       auth: true,
       httpUser: true,

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
@@ -1,4 +1,4 @@
-import { ref, readonly, type Ref, type DeepReadonly } from "vue"
+import { ref, readonly, toRaw, type Ref, type DeepReadonly } from "vue"
 import { Service } from "dioc"
 import { Store } from "~/kernel/store"
 import { getDefaultProxyUrl, DEFAULT_HOPP_PROXY_URL } from "~/helpers/proxyUrl"
@@ -68,7 +68,14 @@ export class KernelInterceptorProxyStore extends Service {
     watcher.on("change", async ({ value }) => {
       if (value) {
         const storedData = value as StoredData
-        this._settings.value = storedData.settings
+        this._settings.value = {
+          ...this._settings.value,
+          // Only sync user-configurable fields from external changes.
+          // Fallback to current value if persisted data is missing the field
+          // (e.g. older schema). accessToken stays env-derived.
+          proxyUrl:
+            storedData.settings?.proxyUrl ?? this._settings.value.proxyUrl,
+        }
       }
     })
   }
@@ -85,7 +92,10 @@ export class KernelInterceptorProxyStore extends Service {
       const storedData = loadResult.right
       this._settings.value = {
         ...defaults,
-        ...storedData.settings,
+        // Only restore user-configurable fields from storage.
+        // accessToken is env-derived (VITE_PROXYSCOTCH_ACCESS_TOKEN) and
+        // must always reflect the current deployment, not a stale persisted value.
+        proxyUrl: storedData.settings?.proxyUrl ?? defaults.proxyUrl,
       }
     } else {
       this._settings.value = { ...defaults }
@@ -94,9 +104,11 @@ export class KernelInterceptorProxyStore extends Service {
   }
 
   private async persistSettings(): Promise<void> {
+    const rawSettings = toRaw(this._settings.value)
+
     const storedData: StoredData = {
       version: "v1",
-      settings: this._settings.value,
+      settings: { ...rawSettings },
       lastUpdated: new Date().toISOString(),
     }
 
@@ -111,10 +123,17 @@ export class KernelInterceptorProxyStore extends Service {
     }
   }
 
-  public async updateSettings(patch: Partial<ProxySettings>): Promise<void> {
+  /**
+   * Update user-configurable proxy settings.
+   * Only `proxyUrl` is user-configurable, `accessToken` and `version` are
+   * derived at runtime and cannot be overwritten by callers.
+   */
+  public async updateSettings(
+    patch: Pick<ProxySettings, "proxyUrl">
+  ): Promise<void> {
     this._settings.value = {
       ...this._settings.value,
-      ...patch,
+      proxyUrl: patch.proxyUrl,
     }
     await this.persistSettings()
   }

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
@@ -1,12 +1,13 @@
+import { ref, readonly, type Ref, type DeepReadonly } from "vue"
 import { Service } from "dioc"
 import { Store } from "~/kernel/store"
-import { settingsStore } from "~/newstore/settings"
+import { getDefaultProxyUrl, DEFAULT_HOPP_PROXY_URL } from "~/helpers/proxyUrl"
 import * as E from "fp-ts/Either"
 
 const STORE_NAMESPACE = "interceptors.proxy.v1"
 const SETTINGS_KEY = "settings"
 
-type ProxySettings = {
+export type ProxySettings = {
   version: "v1"
   proxyUrl: string
   accessToken: string
@@ -18,16 +19,41 @@ interface StoredData {
   lastUpdated: string
 }
 
-const DEFAULT_SETTINGS: ProxySettings = {
-  version: "v1",
-  proxyUrl: settingsStore.value.PROXY_URL ?? "https://proxy.hoppscotch.io",
-  accessToken: import.meta.env.VITE_PROXYSCOTCH_ACCESS_TOKEN ?? "",
+/**
+ * Build fresh default settings.
+ * Called as a function (not a static const) so that `getDefaultProxyUrl()`
+ * can resolve against the current platform, which isn't available at
+ * module-load time.
+ */
+async function buildDefaultSettings(): Promise<ProxySettings> {
+  return {
+    version: "v1",
+    proxyUrl: await getDefaultProxyUrl(),
+    accessToken: import.meta.env.VITE_PROXYSCOTCH_ACCESS_TOKEN ?? "",
+  }
 }
 
+/**
+ * Reactive proxy settings store.
+ *
+ * Exposes `settings$` as a readonly ref, any component or service that reads
+ * `settings$.value` will automatically re-render when settings change.
+ */
 export class KernelInterceptorProxyStore extends Service {
   public static readonly ID = "KERNEL_PROXY_INTERCEPTOR_STORE"
 
-  private settings: ProxySettings = { ...DEFAULT_SETTINGS }
+  private readonly _settings = ref<ProxySettings>({
+    version: "v1",
+    proxyUrl: DEFAULT_HOPP_PROXY_URL,
+    accessToken: import.meta.env.VITE_PROXYSCOTCH_ACCESS_TOKEN ?? "",
+  })
+
+  /**
+   * Reactive, read-only view of the current proxy settings.
+   */
+  public readonly settings$: DeepReadonly<Ref<ProxySettings>> = readonly(
+    this._settings
+  )
 
   async onServiceInit(): Promise<void> {
     const initResult = await Store.init()
@@ -42,7 +68,7 @@ export class KernelInterceptorProxyStore extends Service {
     watcher.on("change", async ({ value }) => {
       if (value) {
         const storedData = value as StoredData
-        this.settings = storedData.settings
+        this._settings.value = storedData.settings
       }
     })
   }
@@ -53,13 +79,16 @@ export class KernelInterceptorProxyStore extends Service {
       SETTINGS_KEY
     )
 
+    const defaults = await buildDefaultSettings()
+
     if (E.isRight(loadResult) && loadResult.right) {
       const storedData = loadResult.right
-      this.settings = {
-        ...DEFAULT_SETTINGS,
+      this._settings.value = {
+        ...defaults,
         ...storedData.settings,
       }
     } else {
+      this._settings.value = { ...defaults }
       await this.persistSettings()
     }
   }
@@ -67,7 +96,7 @@ export class KernelInterceptorProxyStore extends Service {
   private async persistSettings(): Promise<void> {
     const storedData: StoredData = {
       version: "v1",
-      settings: this.settings,
+      settings: this._settings.value,
       lastUpdated: new Date().toISOString(),
     }
 
@@ -82,21 +111,24 @@ export class KernelInterceptorProxyStore extends Service {
     }
   }
 
-  public async updateSettings(settings: Partial<ProxySettings>): Promise<void> {
-    this.settings = {
-      ...this.settings,
-      ...settings,
+  public async updateSettings(patch: Partial<ProxySettings>): Promise<void> {
+    this._settings.value = {
+      ...this._settings.value,
+      ...patch,
     }
-
     await this.persistSettings()
   }
 
+  /**
+   * @deprecated Use `settings$` for reactive access. This exists only for
+   * non-reactive contexts (e.g. inside `execute()` in the interceptor service).
+   */
   public getSettings(): ProxySettings {
-    return { ...this.settings }
+    return { ...this._settings.value }
   }
 
   public async resetSettings(): Promise<void> {
-    this.settings = { ...DEFAULT_SETTINGS }
+    this._settings.value = await buildDefaultSettings()
     await this.persistSettings()
   }
 }


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes FE-1204

## Summary

This PR fixes the bug related to proxyURL updation

- **Proxy reset button not working** — `resetSettings()` reset to `DEFAULT_SETTINGS`, a static const captured at module-load time with the same race condition — it never had the platform-aware proxy URL.

## Root cause

The proxy store used a **static `DEFAULT_SETTINGS` const** evaluated at import time, when the platform isn't initialized yet. The `getDefaultProxyUrl().then()` in `settings.ts` was a dead workaround that never actually worked because it also fired before `setPlatformDef()`.

## What changed

**`proxy/store.ts` — Made settings reactive, resolved at runtime**
- Replaced static `DEFAULT_SETTINGS` const with async `buildDefaultSettings()` that resolves `getDefaultProxyUrl()` at call time (after platform init)
- Changed `private settings` plain field → `private _settings = ref<ProxySettings>(...)` with a `readonly` public `settings$` ref, matching the reactive pattern used by `AgentStore`, `WorkspaceService`, and other dioc services in the codebase
- Constructor default uses `DEFAULT_HOPP_PROXY_URL` as a sensible sync fallback before async init completes
- Removed dependency on `settingsStore` — the proxy store now owns its own defaults

**`Proxy.vue` — Declarative reactivity instead of imperative polling**
- Removed `onMounted` + `getSettings()` sync read (the source of the empty URL bug)
- Added a `watch` on `store.settings$.value.proxyUrl` with `immediate: true` — the component stays in sync automatically as the store initializes, loads from persistence, or receives external updates
- No timing assumptions, no `waitForInit()` hacks

**`newstore/settings.ts` — Removed dead race-condition code**
- Removed the `getDefaultProxyUrl().then()` call and `defaultProxyURL` variable that never worked due to the platform init race
- `PROXY_URL` now uses static `DEFAULT_HOPP_PROXY_URL` directly (the actual runtime URL is managed by `KernelInterceptorProxyStore`)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the default proxy URL not initializing or resetting correctly. Addresses FE-1204 by making proxy settings reactive and resolving the platform-aware default at runtime.

- **Bug Fixes**
  - `KernelInterceptorProxyStore`: added reactive `settings$`; resolve defaults via `getDefaultProxyUrl()` at runtime with `DEFAULT_HOPP_PROXY_URL` as sync fallback; persist with `toRaw`; on load and cross‑tab updates, only apply `proxyUrl` (keep `accessToken` env‑derived); `updateSettings` now only accepts `{ proxyUrl }`; `resetSettings()` rebuilds runtime defaults.
  - `Proxy.vue`: local input syncs from `settings$` via a guarded, immediate watch that doesn’t overwrite user edits; on logout, call `resetSettings()` and force‑sync input; removed `onMounted` polling and default‑URL fetch.
  - `newstore/settings.ts`: removed race‑prone async default logic; `PROXY_URL` now uses `DEFAULT_HOPP_PROXY_URL` (runtime default is owned by the proxy store).

<sup>Written for commit a3abf4682f8f6913c704d365f1d1b2d13386a9c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

