### PR TITLE
fix(common): support `id_token` in Authorization Code OAuth flow

### DIFF
--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -189,7 +189,6 @@ const initAuthCodeOauthFlow = async ({
     return E.left("INVALID_AUTH_ENDPOINT")
   }
 
-  url.searchParams.set("grant_type", "authorization_code")
   url.searchParams.set("client_id", clientID)
   url.searchParams.set("state", state)
   url.searchParams.set("response_type", "code")
@@ -289,18 +288,31 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     return E.left("AUTH_TOKEN_REQUEST_FAILED" as const)
   }
 
-  const withAccessTokenSchema = z.object({
-    access_token: z.string(),
-    refresh_token: z.string().optional(),
-  })
+  const withAccessTokenSchema = z
+    .object({
+      access_token: z.string().optional(),
+      id_token: z.string().optional(),
+      refresh_token: z.string().optional(),
+    })
+    .refine((data) => data.access_token || data.id_token, {
+      message: "Either access_token or id_token must be present",
+    })
 
   const parsedTokenResponse = withAccessTokenSchema.safeParse(
     responsePayload.right
   )
 
-  return parsedTokenResponse.success
-    ? E.right(parsedTokenResponse.data)
-    : E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
+  if (!parsedTokenResponse.success) {
+    return E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
+  }
+
+  return E.right({
+    access_token:
+      parsedTokenResponse.data.access_token ||
+      parsedTokenResponse.data.id_token ||
+      "",
+    refresh_token: parsedTokenResponse.data.refresh_token,
+  })
 }
 
 const generateCodeVerifier = () => {


### PR DESCRIPTION
Closes FE-1205

This update addresses improves the handling of OAuth tokens to ensure that either an access_token or id_token is present.

### What's changed
- Refactored the OAuth token handling to require either access_token or id_token.
- Fixes Authorization Code flow fails with Google OAuth




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth 2.0 Authorization Code flow with Google by accepting an `id_token` when no `access_token` is returned and removing an invalid param from the auth request. Resolves FE-1205 and improves compatibility with Google and other OIDC providers.

- **Bug Fixes**
  - Removed `grant_type` from authorization endpoint params.
  - Token handling now requires either `access_token` or `id_token`.
  - Normalizes the result: uses `id_token` as `access_token` fallback and preserves `refresh_token`.

<sup>Written for commit be90f080b567b21ef76aa0fe1de9f2a93d75caf7. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



