### PR TITLE
fix(common,cli): harden digest auth challenge parsing

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
@@ -56,4 +56,24 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5-sess",
     });
   });
+
+  it("ignores preceding schemes with quoted Digest text and keyless tokens", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Bearer realm="Digest realm required", Digest stale, realm="Protected Area", nonce="nonce123==", qop=auth-conf,auth, algorithm=MD5',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    });
+  });
 });

--- a/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
@@ -76,4 +76,24 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5",
     });
   });
+
+  it("skips malformed =value directives without hanging or losing later params", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Digest realm="Protected Area", =badvalue, nonce="nonce123==", qop=auth-conf,auth',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    });
+  });
 });

--- a/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequest } = vi.hoisted(() => ({
+  mockRequest: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    request: mockRequest,
+  },
+}));
+
+import { fetchInitialDigestAuthInfo } from "../../utils/auth/digest";
+
+describe("fetchInitialDigestAuthInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses digest challenges with quoted equals values and qop lists", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "www-authenticate":
+          'Basic realm="fallback", Digest realm="Protected Area", nonce="abc==", qop="auth,auth-int", opaque="xyz==", algorithm=MD5',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "abc==",
+      qop: "auth",
+      opaque: "xyz==",
+      algorithm: "MD5",
+    });
+  });
+
+  it("normalizes auth-int and md5-sess challenges without opaque", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'realm="Protected Area", nonce="nonce123==", qop="auth-int", algorithm=md5-sess',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "POST", false)
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth-int",
+      opaque: undefined,
+      algorithm: "MD5-sess",
+    });
+  });
+});

--- a/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/digest-auth.spec.ts
@@ -96,4 +96,56 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5",
     });
   });
+
+  it("ignores trailing non-digest schemes after valid digest params", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Digest realm="Protected Area", nonce="nonce123==", qop="auth", algorithm=MD5, Basic realm="fallback"',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    });
+  });
+
+  it("rejects digest challenges with unsupported qop values", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Digest realm="Protected Area", nonce="nonce123==", qop="auth-conf", algorithm=MD5',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).rejects.toThrow(
+      "Failed to parse authentication parameters from WWW-Authenticate header"
+    );
+  });
+
+  it("rejects digest challenges with unsupported algorithms", async () => {
+    mockRequest.mockResolvedValue({
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Digest realm="Protected Area", nonce="nonce123==", qop="auth", algorithm=SHA-256',
+      },
+    });
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET", false)
+    ).rejects.toThrow(
+      "Failed to parse authentication parameters from WWW-Authenticate header"
+    );
+  });
 });

--- a/packages/hoppscotch-cli/src/__tests__/unit/pre-request-digest.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/pre-request-digest.spec.ts
@@ -1,0 +1,103 @@
+import { Environment, HoppRESTRequest } from "@hoppscotch/data";
+import * as E from "fp-ts/Either";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetchInitialDigestAuthInfo, mockGenerateDigestAuthHeader } =
+  vi.hoisted(() => ({
+    mockFetchInitialDigestAuthInfo: vi.fn(),
+    mockGenerateDigestAuthHeader: vi.fn(),
+  }));
+
+vi.mock("../../utils/auth/digest", () => ({
+  fetchInitialDigestAuthInfo: mockFetchInitialDigestAuthInfo,
+  generateDigestAuthHeader: mockGenerateDigestAuthHeader,
+}));
+
+import { getEffectiveRESTRequest } from "../../utils/pre-request";
+import {
+  fetchInitialDigestAuthInfo,
+  generateDigestAuthHeader,
+} from "../../utils/auth/digest";
+
+const DEFAULT_ENV = <Environment>{
+  name: "Env",
+  variables: [],
+};
+
+const DIGEST_HEADER =
+  'Digest username="user", realm="realm", nonce="nonce", uri="/", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"';
+
+const DEFAULT_REQUEST = <HoppRESTRequest>{
+  v: "1",
+  name: "name",
+  method: "GET",
+  endpoint: "https://example.com",
+  params: [],
+  headers: [],
+  preRequestScript: "",
+  testScript: "",
+  requestVariables: [],
+  responses: {},
+  auth: {
+    authActive: true,
+    authType: "digest",
+    username: "user",
+    password: "pass",
+    realm: "",
+    nonce: "user-nonce",
+    algorithm: "MD5",
+    qop: "",
+    nc: "00000001",
+    cnonce: "",
+    opaque: "",
+    disableRetry: false,
+  },
+  body: {
+    contentType: null,
+    body: null,
+  },
+};
+
+describe("CLI digest auth request generation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(fetchInitialDigestAuthInfo).mockResolvedValue({
+      realm: "realm",
+      nonce: "server-nonce",
+      qop: "auth",
+      algorithm: "MD5",
+      opaque: "",
+    });
+    vi.mocked(generateDigestAuthHeader).mockResolvedValue(DIGEST_HEADER);
+  });
+
+  it("uses the user-provided nonce override instead of the fetched nonce", async () => {
+    const result = await getEffectiveRESTRequest(DEFAULT_REQUEST, DEFAULT_ENV);
+
+    expect(fetchInitialDigestAuthInfo).toHaveBeenCalledWith(
+      "https://example.com",
+      "GET",
+      false
+    );
+    expect(generateDigestAuthHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonce: "user-nonce",
+        qop: "auth",
+      })
+    );
+
+    expect(E.isRight(result)).toBe(true);
+
+    if (E.isRight(result)) {
+      expect(
+        result.right.effectiveRequest.effectiveFinalHeaders
+      ).toContainEqual(
+        expect.objectContaining({
+          key: "Authorization",
+          value: DIGEST_HEADER,
+        })
+      );
+    }
+  });
+});

--- a/packages/hoppscotch-cli/src/utils/auth/digest.ts
+++ b/packages/hoppscotch-cli/src/utils/auth/digest.ts
@@ -97,7 +97,10 @@ const parseDigestAuthHeader = (
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase();
 
-    if (!key || digestHeader[index] !== "=") continue;
+    if (!key || digestHeader[index] !== "=") {
+      if (index === keyStart) index++;
+      continue;
+    }
 
     index++;
 

--- a/packages/hoppscotch-cli/src/utils/auth/digest.ts
+++ b/packages/hoppscotch-cli/src/utils/auth/digest.ts
@@ -28,11 +28,50 @@ export interface DigestAuthInfo {
 
 type DigestAuthHeaderParams = Record<string, string>;
 
+const extractDigestChallenge = (header: string) => {
+  let index = 0;
+
+  while (index < header.length) {
+    while (index < header.length && /[\s,]/.test(header[index])) {
+      index++;
+    }
+
+    if (
+      header.slice(index, index + 6).toLowerCase() === "digest" &&
+      /\s/.test(header[index + 6] ?? "")
+    ) {
+      return header.slice(index + 6).trim();
+    }
+
+    let inQuotes = false;
+
+    while (index < header.length) {
+      const char = header[index];
+
+      if (char === "\\" && inQuotes) {
+        index += 2;
+        continue;
+      }
+
+      if (char === '"') {
+        inQuotes = !inQuotes;
+      } else if (!inQuotes && char === ",") {
+        index++;
+        break;
+      }
+
+      index++;
+    }
+  }
+
+  return header.trim();
+};
+
 // Utility function to parse Digest auth header values
 const parseDigestAuthHeader = (
   header: string
 ): DigestAuthHeaderParams | null => {
-  const digestHeader = header.replace(/^.*?\bDigest\s+/i, "").trim();
+  const digestHeader = extractDigestChallenge(header);
 
   if (!digestHeader) return null;
 
@@ -58,7 +97,7 @@ const parseDigestAuthHeader = (
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase();
 
-    if (!key || digestHeader[index] !== "=") break;
+    if (!key || digestHeader[index] !== "=") continue;
 
     index++;
 
@@ -96,7 +135,18 @@ const parseDigestAuthHeader = (
     } else {
       const valueStart = index;
 
-      while (index < digestHeader.length && digestHeader[index] !== ",") {
+      while (index < digestHeader.length) {
+        if (digestHeader[index] !== ",") {
+          index++;
+          continue;
+        }
+
+        if (key !== "qop") break;
+
+        const rest = digestHeader.slice(index + 1);
+
+        if (/^\s*[a-z0-9_-]+\s*=/i.test(rest)) break;
+
         index++;
       }
 

--- a/packages/hoppscotch-cli/src/utils/auth/digest.ts
+++ b/packages/hoppscotch-cli/src/utils/auth/digest.ts
@@ -26,20 +26,130 @@ export interface DigestAuthInfo {
   algorithm: string;
 }
 
+type DigestAuthHeaderParams = Record<string, string>;
+
 // Utility function to parse Digest auth header values
 const parseDigestAuthHeader = (
   header: string
-): { [key: string]: string } | null => {
-  const matches = header.match(/([a-z0-9]+)="([^"]+)"/gi);
-  if (!matches) return null;
+): DigestAuthHeaderParams | null => {
+  const digestHeader = header.replace(/^.*?\bDigest\s+/i, "").trim();
 
-  const authParams: { [key: string]: string } = {};
-  matches.forEach((match) => {
-    const parts = match.split("=");
-    authParams[parts[0]] = parts[1].replace(/"/g, "");
-  });
+  if (!digestHeader) return null;
 
-  return authParams;
+  const authParams: DigestAuthHeaderParams = {};
+  let index = 0;
+
+  while (index < digestHeader.length) {
+    while (index < digestHeader.length && /[\s,]/.test(digestHeader[index])) {
+      index++;
+    }
+
+    if (index >= digestHeader.length) break;
+
+    const keyStart = index;
+
+    while (
+      index < digestHeader.length &&
+      digestHeader[index] !== "=" &&
+      digestHeader[index] !== ","
+    ) {
+      index++;
+    }
+
+    const key = digestHeader.slice(keyStart, index).trim().toLowerCase();
+
+    if (!key || digestHeader[index] !== "=") break;
+
+    index++;
+
+    while (index < digestHeader.length && /\s/.test(digestHeader[index])) {
+      index++;
+    }
+
+    let value = "";
+
+    if (digestHeader[index] === '"') {
+      index++;
+
+      while (index < digestHeader.length) {
+        const char = digestHeader[index];
+
+        if (char === "\\") {
+          index++;
+
+          if (index < digestHeader.length) {
+            value += digestHeader[index];
+            index++;
+          }
+
+          continue;
+        }
+
+        if (char === '"') {
+          index++;
+          break;
+        }
+
+        value += char;
+        index++;
+      }
+    } else {
+      const valueStart = index;
+
+      while (index < digestHeader.length && digestHeader[index] !== ",") {
+        index++;
+      }
+
+      value = digestHeader.slice(valueStart, index).trim();
+    }
+
+    authParams[key] = normalizeDigestAuthValue(key, value);
+  }
+
+  return Object.keys(authParams).length > 0 ? authParams : null;
+};
+
+const normalizeDigestAuthValue = (key: string, value: string) => {
+  if (key === "qop") {
+    return selectDigestQop(value);
+  }
+
+  if (key === "algorithm") {
+    return normalizeDigestAlgorithm(value);
+  }
+
+  return value;
+};
+
+const selectDigestQop = (value: string) => {
+  const qopOptions = value
+    .split(",")
+    .map((option) => option.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (qopOptions.includes("auth")) {
+    return "auth";
+  }
+
+  if (qopOptions.includes("auth-int")) {
+    return "auth-int";
+  }
+
+  return value;
+};
+
+const normalizeDigestAlgorithm = (value: string) => {
+  const normalizedAlgorithm = value.trim().toLowerCase();
+
+  if (normalizedAlgorithm === "md5-sess") {
+    return "MD5-sess";
+  }
+
+  if (normalizedAlgorithm === "md5") {
+    return "MD5";
+  }
+
+  return value;
 };
 
 // Function to generate Digest Auth Header
@@ -135,7 +245,7 @@ export const fetchInitialDigestAuthInfo = async (
             nonce: authParams.nonce,
             qop: authParams.qop,
             opaque: authParams.opaque,
-            algorithm: authParams.algorithm,
+            algorithm: authParams.algorithm ?? "MD5",
           };
         }
       }

--- a/packages/hoppscotch-cli/src/utils/auth/digest.ts
+++ b/packages/hoppscotch-cli/src/utils/auth/digest.ts
@@ -27,6 +27,7 @@ export interface DigestAuthInfo {
 }
 
 type DigestAuthHeaderParams = Record<string, string>;
+const DIGEST_DIRECTIVE_NAME_PATTERN = /^[a-z0-9_-]+$/i;
 
 const extractDigestChallenge = (header: string) => {
   let index = 0;
@@ -97,8 +98,14 @@ const parseDigestAuthHeader = (
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase();
 
-    if (!key || digestHeader[index] !== "=") {
+    const hasAssignment = digestHeader[index] === "=";
+    const isValidDirectiveName = DIGEST_DIRECTIVE_NAME_PATTERN.test(key);
+
+    if (!key || !hasAssignment || !isValidDirectiveName) {
       if (index === keyStart) index++;
+      else if (hasAssignment) {
+        index = skipDigestDirectiveValue(digestHeader, index + 1);
+      }
       continue;
     }
 
@@ -156,7 +163,13 @@ const parseDigestAuthHeader = (
       value = digestHeader.slice(valueStart, index).trim();
     }
 
-    authParams[key] = normalizeDigestAuthValue(key, value);
+    const normalizedValue = normalizeDigestAuthValue(key, value);
+
+    if (!normalizedValue && (key === "qop" || key === "algorithm")) {
+      return null;
+    }
+
+    authParams[key] = normalizedValue;
   }
 
   return Object.keys(authParams).length > 0 ? authParams : null;
@@ -188,7 +201,7 @@ const selectDigestQop = (value: string) => {
     return "auth-int";
   }
 
-  return value;
+  return "";
 };
 
 const normalizeDigestAlgorithm = (value: string) => {
@@ -202,7 +215,40 @@ const normalizeDigestAlgorithm = (value: string) => {
     return "MD5";
   }
 
-  return value;
+  return "";
+};
+
+const skipDigestDirectiveValue = (header: string, index: number) => {
+  while (index < header.length && /\s/.test(header[index])) {
+    index++;
+  }
+
+  if (header[index] === '"') {
+    index++;
+
+    while (index < header.length) {
+      const char = header[index];
+
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+
+      index++;
+
+      if (char === '"') {
+        break;
+      }
+    }
+
+    return index;
+  }
+
+  while (index < header.length && header[index] !== ",") {
+    index++;
+  }
+
+  return index;
 };
 
 // Function to generate Digest Auth Header

--- a/packages/hoppscotch-cli/src/utils/pre-request.ts
+++ b/packages/hoppscotch-cli/src/utils/pre-request.ts
@@ -312,7 +312,7 @@ export async function getEffectiveRESTRequest(
           ? parseTemplateString(request.auth.realm, resolvedVariables)
           : authInfo.realm,
         nonce: request.auth.nonce
-          ? parseTemplateString(authInfo.nonce, resolvedVariables)
+          ? parseTemplateString(request.auth.nonce, resolvedVariables)
           : authInfo.nonce,
         endpoint: parseTemplateString(endpoint, resolvedVariables),
         method,

--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
@@ -94,4 +94,22 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5",
     })
   })
+
+  it("skips malformed =value directives without hanging or losing later params", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Digest realm="Protected Area", =badvalue, nonce="nonce123==", qop=auth-conf,auth'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    })
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
@@ -112,4 +112,50 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5",
     })
   })
+
+  it("ignores trailing non-digest schemes after valid digest params", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Digest realm="Protected Area", nonce="nonce123==", qop="auth", algorithm=MD5, Basic realm="fallback"'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    })
+  })
+
+  it("rejects digest challenges with unsupported qop values", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Digest realm="Protected Area", nonce="nonce123==", qop="auth-conf", algorithm=MD5'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).rejects.toThrow(
+      "Failed to parse authentication parameters from WWW-Authenticate header"
+    )
+  })
+
+  it("rejects digest challenges with unsupported algorithms", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Digest realm="Protected Area", nonce="nonce123==", qop="auth", algorithm=SHA-256'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).rejects.toThrow(
+      "Failed to parse authentication parameters from WWW-Authenticate header"
+    )
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
@@ -1,0 +1,79 @@
+import * as E from "fp-ts/Either"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockExecute, mockGetI18n, mockGetService } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockGetI18n: vi.fn(),
+  mockGetService: vi.fn(),
+}))
+
+vi.mock("~/modules/dioc", () => ({
+  getService: mockGetService,
+}))
+
+vi.mock("~/modules/i18n", () => ({
+  getI18n: mockGetI18n,
+}))
+
+vi.mock("~/services/kernel-interceptor.service", () => ({
+  KernelInterceptorService: vi.fn(),
+}))
+
+import { fetchInitialDigestAuthInfo } from "../digest"
+
+const createDigestChallenge = (authHeader: string) => ({
+  response: Promise.resolve(
+    E.right({
+      status: 401,
+      headers: {
+        "WWW-Authenticate": authHeader,
+      },
+    })
+  ),
+})
+
+describe("fetchInitialDigestAuthInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetI18n.mockReturnValue(vi.fn())
+    mockGetService.mockReturnValue({
+      execute: mockExecute,
+    })
+  })
+
+  it("parses digest challenges with quoted equals values and qop lists", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Basic realm="fallback", Digest realm="Protected Area", nonce="abc==", qop="auth,auth-int", opaque="xyz==", algorithm=MD5'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "abc==",
+      qop: "auth",
+      opaque: "xyz==",
+      algorithm: "MD5",
+    })
+  })
+
+  it("normalizes auth-int and md5-sess challenges without opaque", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'realm="Protected Area", nonce="nonce123==", qop="auth-int", algorithm=md5-sess'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "POST")
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth-int",
+      opaque: undefined,
+      algorithm: "MD5-sess",
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/digest.spec.ts
@@ -76,4 +76,22 @@ describe("fetchInitialDigestAuthInfo", () => {
       algorithm: "MD5-sess",
     })
   })
+
+  it("ignores preceding schemes with quoted Digest text and keyless tokens", async () => {
+    mockExecute.mockResolvedValue(
+      createDigestChallenge(
+        'Bearer realm="Digest realm required", Digest stale, realm="Protected Area", nonce="nonce123==", qop=auth-conf,auth, algorithm=MD5'
+      )
+    )
+
+    await expect(
+      fetchInitialDigestAuthInfo("https://api.example.com/data", "GET")
+    ).resolves.toEqual({
+      realm: "Protected Area",
+      nonce: "nonce123==",
+      qop: "auth",
+      opaque: undefined,
+      algorithm: "MD5",
+    })
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -78,6 +78,8 @@ export interface DigestAuthInfo {
   algorithm: string
 }
 
+type DigestAuthHeaderParams = Record<string, string>
+
 export async function fetchInitialDigestAuthInfo(
   url: string,
   method: string
@@ -127,7 +129,7 @@ export async function fetchInitialDigestAuthInfo(
             nonce: authParams.nonce,
             qop: authParams.qop,
             opaque: authParams.opaque,
-            algorithm: authParams.algorithm,
+            algorithm: authParams.algorithm ?? "MD5",
           }
         }
       }
@@ -148,17 +150,123 @@ export async function fetchInitialDigestAuthInfo(
 }
 
 // Utility function to parse Digest auth header values
-function parseDigestAuthHeader(
-  header: string
-): { [key: string]: string } | null {
-  const matches = header.match(/([a-z0-9]+)="([^"]+)"/gi)
-  if (!matches) return null
+function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
+  const digestHeader = header.replace(/^.*?\bDigest\s+/i, "").trim()
 
-  const authParams: { [key: string]: string } = {}
-  matches.forEach((match) => {
-    const parts = match.split("=")
-    authParams[parts[0]] = parts[1].replace(/"/g, "")
-  })
+  if (!digestHeader) return null
 
-  return authParams
+  const authParams: DigestAuthHeaderParams = {}
+  let index = 0
+
+  while (index < digestHeader.length) {
+    while (index < digestHeader.length && /[\s,]/.test(digestHeader[index])) {
+      index++
+    }
+
+    if (index >= digestHeader.length) break
+
+    const keyStart = index
+
+    while (
+      index < digestHeader.length &&
+      digestHeader[index] !== "=" &&
+      digestHeader[index] !== ","
+    ) {
+      index++
+    }
+
+    const key = digestHeader.slice(keyStart, index).trim().toLowerCase()
+
+    if (!key || digestHeader[index] !== "=") break
+
+    index++
+
+    while (index < digestHeader.length && /\s/.test(digestHeader[index])) {
+      index++
+    }
+
+    let value = ""
+
+    if (digestHeader[index] === '"') {
+      index++
+
+      while (index < digestHeader.length) {
+        const char = digestHeader[index]
+
+        if (char === "\\") {
+          index++
+
+          if (index < digestHeader.length) {
+            value += digestHeader[index]
+            index++
+          }
+
+          continue
+        }
+
+        if (char === '"') {
+          index++
+          break
+        }
+
+        value += char
+        index++
+      }
+    } else {
+      const valueStart = index
+
+      while (index < digestHeader.length && digestHeader[index] !== ",") {
+        index++
+      }
+
+      value = digestHeader.slice(valueStart, index).trim()
+    }
+
+    authParams[key] = normalizeDigestAuthValue(key, value)
+  }
+
+  return Object.keys(authParams).length > 0 ? authParams : null
+}
+
+function normalizeDigestAuthValue(key: string, value: string) {
+  if (key === "qop") {
+    return selectDigestQop(value)
+  }
+
+  if (key === "algorithm") {
+    return normalizeDigestAlgorithm(value)
+  }
+
+  return value
+}
+
+function selectDigestQop(value: string) {
+  const qopOptions = value
+    .split(",")
+    .map((option) => option.trim().toLowerCase())
+    .filter(Boolean)
+
+  if (qopOptions.includes("auth")) {
+    return "auth"
+  }
+
+  if (qopOptions.includes("auth-int")) {
+    return "auth-int"
+  }
+
+  return value
+}
+
+function normalizeDigestAlgorithm(value: string) {
+  const normalizedAlgorithm = value.trim().toLowerCase()
+
+  if (normalizedAlgorithm === "md5-sess") {
+    return "MD5-sess"
+  }
+
+  if (normalizedAlgorithm === "md5") {
+    return "MD5"
+  }
+
+  return value
 }

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -216,7 +216,10 @@ function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase()
 
-    if (!key || digestHeader[index] !== "=") continue
+    if (!key || digestHeader[index] !== "=") {
+      if (index === keyStart) index++
+      continue
+    }
 
     index++
 

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -79,6 +79,7 @@ export interface DigestAuthInfo {
 }
 
 type DigestAuthHeaderParams = Record<string, string>
+const DIGEST_DIRECTIVE_NAME_PATTERN = /^[a-z0-9_-]+$/i
 
 function extractDigestChallenge(header: string) {
   let index = 0
@@ -216,8 +217,14 @@ function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase()
 
-    if (!key || digestHeader[index] !== "=") {
+    const hasAssignment = digestHeader[index] === "="
+    const isValidDirectiveName = DIGEST_DIRECTIVE_NAME_PATTERN.test(key)
+
+    if (!key || !hasAssignment || !isValidDirectiveName) {
       if (index === keyStart) index++
+      else if (hasAssignment) {
+        index = skipDigestDirectiveValue(digestHeader, index + 1)
+      }
       continue
     }
 
@@ -275,7 +282,13 @@ function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
       value = digestHeader.slice(valueStart, index).trim()
     }
 
-    authParams[key] = normalizeDigestAuthValue(key, value)
+    const normalizedValue = normalizeDigestAuthValue(key, value)
+
+    if (!normalizedValue && (key === "qop" || key === "algorithm")) {
+      return null
+    }
+
+    authParams[key] = normalizedValue
   }
 
   return Object.keys(authParams).length > 0 ? authParams : null
@@ -307,7 +320,7 @@ function selectDigestQop(value: string) {
     return "auth-int"
   }
 
-  return value
+  return ""
 }
 
 function normalizeDigestAlgorithm(value: string) {
@@ -321,5 +334,38 @@ function normalizeDigestAlgorithm(value: string) {
     return "MD5"
   }
 
-  return value
+  return ""
+}
+
+function skipDigestDirectiveValue(header: string, index: number) {
+  while (index < header.length && /\s/.test(header[index])) {
+    index++
+  }
+
+  if (header[index] === '"') {
+    index++
+
+    while (index < header.length) {
+      const char = header[index]
+
+      if (char === "\\") {
+        index += 2
+        continue
+      }
+
+      index++
+
+      if (char === '"') {
+        break
+      }
+    }
+
+    return index
+  }
+
+  while (index < header.length && header[index] !== ",") {
+    index++
+  }
+
+  return index
 }

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -80,6 +80,45 @@ export interface DigestAuthInfo {
 
 type DigestAuthHeaderParams = Record<string, string>
 
+function extractDigestChallenge(header: string) {
+  let index = 0
+
+  while (index < header.length) {
+    while (index < header.length && /[\s,]/.test(header[index])) {
+      index++
+    }
+
+    if (
+      header.slice(index, index + 6).toLowerCase() === "digest" &&
+      /\s/.test(header[index + 6] ?? "")
+    ) {
+      return header.slice(index + 6).trim()
+    }
+
+    let inQuotes = false
+
+    while (index < header.length) {
+      const char = header[index]
+
+      if (char === "\\" && inQuotes) {
+        index += 2
+        continue
+      }
+
+      if (char === '"') {
+        inQuotes = !inQuotes
+      } else if (!inQuotes && char === ",") {
+        index++
+        break
+      }
+
+      index++
+    }
+  }
+
+  return header.trim()
+}
+
 export async function fetchInitialDigestAuthInfo(
   url: string,
   method: string
@@ -151,7 +190,7 @@ export async function fetchInitialDigestAuthInfo(
 
 // Utility function to parse Digest auth header values
 function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
-  const digestHeader = header.replace(/^.*?\bDigest\s+/i, "").trim()
+  const digestHeader = extractDigestChallenge(header)
 
   if (!digestHeader) return null
 
@@ -177,7 +216,7 @@ function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
 
     const key = digestHeader.slice(keyStart, index).trim().toLowerCase()
 
-    if (!key || digestHeader[index] !== "=") break
+    if (!key || digestHeader[index] !== "=") continue
 
     index++
 
@@ -215,7 +254,18 @@ function parseDigestAuthHeader(header: string): DigestAuthHeaderParams | null {
     } else {
       const valueStart = index
 
-      while (index < digestHeader.length && digestHeader[index] !== ",") {
+      while (index < digestHeader.length) {
+        if (digestHeader[index] !== ",") {
+          index++
+          continue
+        }
+
+        if (key !== "qop") break
+
+        const rest = digestHeader.slice(index + 1)
+
+        if (/^\s*[a-z0-9_-]+\s*=/i.test(rest)) break
+
         index++
       }
 


### PR DESCRIPTION
## Summary
- harden Digest auth challenge parsing in both `@hoppscotch/common` and `@hoppscotch/cli`
- preserve quoted directive values that contain `=`, accept unquoted directives like `algorithm=MD5`, and normalize `qop` lists to a supported mode
- fix the CLI digest auth path to honor a user-provided nonce override instead of always reusing the fetched server nonce

## Root cause
Both packages parsed `WWW-Authenticate` Digest challenges with a regex plus `split("=")`. That broke real challenges in a few ways:
- quoted values such as `nonce="abc=="` and `opaque="xyz=="` were truncated
- unquoted directives like `algorithm=MD5` were ignored
- `qop="auth,auth-int"` was forwarded as a raw list instead of selecting a single supported `qop`
- the CLI request path also ignored a configured digest nonce override

## Testing
- `corepack pnpm exec vitest run src/helpers/auth/__tests__/digest.spec.ts`
- `corepack pnpm do-typecheck`
- `corepack pnpm exec vitest run src/__tests__/unit/digest-auth.spec.ts src/__tests__/unit/pre-request-digest.spec.ts`
- `corepack pnpm do-typecheck`
- `corepack pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Digest auth challenge parsing in `@hoppscotch/common` and `@hoppscotch/cli` to handle mixed `WWW-Authenticate` headers, avoid hangs, and reject unsupported challenges. The CLI now honors a user-provided nonce.

- **Bug Fixes**
  - Robust scheme isolation across mixed headers; ignore keyless tokens; skip malformed directives without loops.
  - Preserve quoted values (including “=”), handle escapes; accept unquoted directives and `qop` lists.
  - Normalize `qop` (prefer `auth`, else `auth-int`) and `algorithm` (`MD5`/`MD5-sess`; default to `MD5`); reject unsupported values.
  - CLI respects the nonce override; unit tests added in both packages.

<sup>Written for commit dc67419ca61f9196e3cf07f3e4c2978d99bc1ef9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

