### PR TITLE
feat: allow file-based environment variables (#4120)

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -667,7 +667,16 @@
     "variables": "Variables",
     "variable_list": "Variable List",
     "properties": "Environment Properties",
-    "details": "Details"
+    "details": "Details",
+    "switch_to_text": "Switch to text variable",
+    "switch_to_file": "Switch to file variable",
+    "choose_file": "Choose File",
+    "no_file_selected": "No file selected",
+    "file_content_preview": "File content will appear here",
+    "file_too_large": "File is too large. Maximum size is 5MB.",
+    "file_read_error": "Failed to read the file. Please try again.",
+    "file_loaded_reselect": "File loaded — re-select to refresh",
+    "file_required_reselect": "File required — please select a file"
   },
   "error": {
     "network": {

--- a/packages/hoppscotch-common/src/components/environments/Add.vue
+++ b/packages/hoppscotch-common/src/components/environments/Add.vue
@@ -149,11 +149,12 @@ const addEnvironment = async () => {
         initialValue: editingValue.value,
         currentValue: "",
         secret: false,
+        isFile: false,
       },
     ]
 
     const newEnv: GlobalEnvironment = {
-      v: 2,
+      v: 3,
       variables: newVariables,
     }
 
@@ -173,6 +174,7 @@ const addEnvironment = async () => {
         initialValue: editingValue.value,
         currentValue: "",
         secret: false,
+        isFile: false,
       },
     ]
 
@@ -200,6 +202,7 @@ const addEnvironment = async () => {
         initialValue: editingValue.value,
         currentValue: "",
         secret: false,
+        isFile: false,
       },
     ]
 

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -131,6 +131,17 @@
                     :key="`${tab.id}-${id}-${index}`"
                     class="flex divide-x divide-dividerLight"
                   >
+                    <div class="flex items-center">
+                      <HoppButtonSecondary
+                        v-tippy="{ theme: 'tooltip' }"
+                        :title="env.isFile ? t('environment.switch_to_text') : t('environment.switch_to_file')"
+                        :icon="env.isFile ? IconFile : IconType"
+                        class="self-center m-1 rounded"
+                        :class="env.isFile ? 'text-accent' : ''"
+                        :disabled="tab.isSecret"
+                        @click="toggleVariableType(env, id)"
+                      />
+                    </div>
                     <input
                       v-model="env.key"
                       v-focus
@@ -140,53 +151,96 @@
                       })}`"
                       :name="'variable' + index"
                     />
-                    <div class="flex items-center flex-1">
-                      <SmartEnvInput
-                        v-model="env.initialValue"
-                        :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
-                        :envs="liveEnvs"
-                        :name="'initialValue' + index"
-                        :secret="tab.isSecret"
-                        :select-text-on-mount="
-                          env.key ? env.key === editingVariableName : false
-                        "
-                        :auto-complete-env="true"
-                      />
-                      <HoppButtonSecondary
-                        v-tippy="{ theme: 'tooltip' }"
-                        :title="t('environment.replace_initial_with_current')"
-                        :icon="IconCopyLeft"
-                        @click="
-                          () => {
-                            env.initialValue = env.currentValue
-                          }
-                        "
-                      />
-                    </div>
 
-                    <div class="flex items-center flex-1">
-                      <SmartEnvInput
-                        v-model="env.currentValue"
-                        :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
-                        :envs="liveEnvs"
-                        :name="'currentValue' + index"
-                        :secret="tab.isSecret"
-                        :select-text-on-mount="
-                          env.key ? env.key === editingVariableName : false
-                        "
-                        :auto-complete-env="true"
-                      />
-                      <HoppButtonSecondary
-                        v-tippy="{ theme: 'tooltip' }"
-                        :title="t('environment.replace_current_with_initial')"
-                        :icon="IconCopyRight"
-                        @click="
-                          () => {
-                            env.currentValue = env.initialValue
-                          }
-                        "
-                      />
-                    </div>
+                    <template v-if="!env.isFile || tab.isSecret">
+                      <div class="flex items-center flex-1">
+                        <SmartEnvInput
+                          v-model="env.initialValue"
+                          :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
+                          :envs="liveEnvs"
+                          :name="'initialValue' + index"
+                          :secret="tab.isSecret"
+                          :select-text-on-mount="
+                            env.key ? env.key === editingVariableName : false
+                          "
+                          :auto-complete-env="true"
+                        />
+                        <HoppButtonSecondary
+                          v-tippy="{ theme: 'tooltip' }"
+                          :title="t('environment.replace_initial_with_current')"
+                          :icon="IconCopyLeft"
+                          @click="
+                            () => {
+                              env.initialValue = env.currentValue
+                            }
+                          "
+                        />
+                      </div>
+
+                      <div class="flex items-center flex-1">
+                        <SmartEnvInput
+                          v-model="env.currentValue"
+                          :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
+                          :envs="liveEnvs"
+                          :name="'currentValue' + index"
+                          :secret="tab.isSecret"
+                          :select-text-on-mount="
+                            env.key ? env.key === editingVariableName : false
+                          "
+                          :auto-complete-env="true"
+                        />
+                        <HoppButtonSecondary
+                          v-tippy="{ theme: 'tooltip' }"
+                          :title="t('environment.replace_current_with_initial')"
+                          :icon="IconCopyRight"
+                          @click="
+                            () => {
+                              env.currentValue = env.initialValue
+                            }
+                          "
+                        />
+                      </div>
+                    </template>
+
+                    <template v-else>
+                      <div class="flex items-center flex-1 px-4 py-2 gap-2">
+                        <input
+                          :id="`file-input-${id}`"
+                          type="file"
+                          accept=".txt,.env,.json,.csv,.xml,.yaml,.yml,.pem,.key,.cfg,.conf,.ini,.toml,.properties"
+                          class="hidden"
+                          @change="(e) => handleFileSelect(e, env, id)"
+                        />
+                        <HoppButtonSecondary
+                          :icon="IconUpload"
+                          :label="t('environment.choose_file')"
+                          filled
+                          outline
+                          @click="triggerFilePicker(id)"
+                        />
+                        <span
+                          v-if="fileNames.has(id)"
+                          class="text-secondaryLight text-sm truncate max-w-[200px]"
+                          :title="fileNames.get(id)"
+                        >
+                          {{ fileNames.get(id) }}
+                        </span>
+                        <span v-else class="text-secondaryLight text-sm italic">
+                          {{ env.key ? t('environment.file_required_reselect') : t('environment.no_file_selected') }}
+                        </span>
+                      </div>
+                      <div class="flex items-center flex-1 px-4 py-2">
+                        <span
+                          v-if="fileNames.has(id)"
+                          class="text-secondaryLight text-sm truncate"
+                        >
+                          {{ `${(env.currentValue.match(/\n/g)?.length ?? 0) + 1} lines, ${env.currentValue.length} bytes` }}
+                        </span>
+                        <span v-else class="text-secondaryLight text-sm italic">
+                          {{ t('environment.file_content_preview') }}
+                        </span>
+                      </div>
+                    </template>
 
                     <div class="flex">
                       <HoppButtonSecondary
@@ -240,8 +294,9 @@ import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
 import * as O from "fp-ts/Option"
 import { flow, pipe } from "fp-ts/function"
-import { ComputedRef, computed, ref, watch } from "vue"
+import { ComputedRef, computed, reactive, ref, watch } from "vue"
 import { uniqueID } from "~/helpers/utils/uniqueID"
+import { MAX_FILE_SIZE } from "~/helpers/utils/environments"
 import {
   createEnvironment,
   environments$,
@@ -264,6 +319,9 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconCopyRight from "~icons/lucide/clipboard-paste"
 import IconCopyLeft from "~icons/lucide/clipboard-copy"
 import IconMoreVertical from "~icons/lucide/more-vertical"
+import IconFile from "~icons/lucide/file"
+import IconType from "~icons/lucide/type"
+import IconUpload from "~icons/lucide/upload"
 import { TippyComponent } from "vue-tippy"
 
 type EnvironmentVariable = {
@@ -335,9 +393,12 @@ const editingID = ref<string>("")
 const vars = ref<EnvironmentVariable[]>([
   {
     id: idTicker.value++,
-    env: { key: "", currentValue: "", initialValue: "", secret: false },
+    env: { key: "", currentValue: "", initialValue: "", secret: false, isFile: false },
   },
 ])
+
+const fileNames = reactive(new Map<number, string>())
+
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
 const currentEnvironmentValueService = useService(CurrentValueService)
@@ -486,14 +547,30 @@ watch(
                 index
               ) ?? e.initialValue,
             secret: e.secret,
+            isFile: e.isFile ?? false,
           },
         }))
       )
+
+      // Clear stale entries before restoring to prevent orphaned IDs accumulating
+      fileNames.clear()
+      // Restore fileNames for file variables that still have content loaded
+      vars.value.forEach(({ id, env }) => {
+        if (env.isFile && env.currentValue) {
+          fileNames.set(id, t("environment.file_loaded_reselect"))
+        }
+      })
     }
   }
 )
 
 const clearContent = () => {
+  // Remove fileNames entries for variables being cleared
+  const removedVars = vars.value.filter((e) =>
+    selectedEnvOption.value === "secret" ? e.env.secret : !e.env.secret
+  )
+  removedVars.forEach(({ id }) => fileNames.delete(id))
+
   vars.value = vars.value.filter((e) =>
     selectedEnvOption.value === "secret" ? !e.env.secret : e.env.secret
   )
@@ -510,14 +587,70 @@ const addEnvironmentVariable = () => {
       currentValue: "",
       initialValue: "",
       secret: selectedEnvOption.value === "secret",
+      isFile: false,
     },
   })
+}
+
+const toggleVariableType = (env: Environment["variables"][number], id: number) => {
+  if (env.isFile) {
+    // Switching to text: clear file state
+    env.initialValue = ""
+    env.currentValue = ""
+    fileNames.delete(id)
+  } else {
+    // Switching to file: clear text values
+    env.initialValue = ""
+    env.currentValue = ""
+  }
+  env.isFile = !env.isFile
+}
+
+const triggerFilePicker = (id: number) => {
+  const input = document.getElementById(`file-input-${id}`) as HTMLInputElement | null
+  if (input) {
+    input.click()
+  }
+}
+
+const handleFileSelect = (event: Event, env: Environment["variables"][number], varId: number) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  if (file.size > MAX_FILE_SIZE) {
+    toast.error(t('environment.file_too_large'))
+    input.value = ""
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    const result = e.target?.result
+
+    if (typeof result !== "string") {
+      toast.error(t('environment.file_read_error'))
+      input.value = ""
+      return
+    }
+
+    fileNames.set(varId, file.name)
+    env.currentValue = result
+    env.initialValue = ""
+    input.value = ""
+  }
+  reader.onerror = () => {
+    toast.error(t('environment.file_read_error'))
+    input.value = ""
+  }
+  reader.readAsText(file)
 }
 
 const removeEnvironmentVariable = (id: number) => {
   const index = vars.value.findIndex((e) => e.id === id)
   if (index !== -1) {
     vars.value.splice(index, 1)
+    fileNames.delete(id)
   }
 }
 
@@ -548,9 +681,10 @@ const saveEnvironment = () => {
       e.secret
         ? O.some({
             key: e.key,
-            value: e.currentValue,
+            value: e.isFile ? "" : e.currentValue,
             varIndex: i,
-            initialValue: e.initialValue,
+            initialValue: e.isFile ? "" : e.initialValue,
+            isFile: e.isFile ?? false,
           })
         : O.none
     )
@@ -565,50 +699,53 @@ const saveEnvironment = () => {
             currentValue: e.currentValue,
             varIndex: i,
             isSecret: e.secret ?? false,
+            isFile: e.isFile ?? false,
           })
         : O.none
     )
   )
-
-  if (secretVariables.length > 0) {
-    if (editingID.value) {
-      secretEnvironmentService.addSecretEnvironment(
-        editingID.value,
-        secretVariables
-      )
-    } else if (props.editingEnvironmentIndex === "Global") {
-      secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
-    }
-  }
-  if (nonSecretVariables.length > 0) {
-    if (editingID.value) {
-      currentEnvironmentValueService.addEnvironment(
-        editingID.value,
-        nonSecretVariables
-      )
-    } else if (props.editingEnvironmentIndex === "Global") {
-      currentEnvironmentValueService.addEnvironment(
-        "Global",
-        nonSecretVariables
-      )
-    }
-  }
 
   const variables = pipe(
     filteredVariables,
     A.map((e) => ({
       key: e.key,
       secret: e.secret,
-      initialValue: e.secret ? "" : e.initialValue,
+      initialValue: e.secret ? "" : (e.isFile ? "" : e.initialValue),
       currentValue: "",
+      isFile: e.isFile ?? false,
     }))
   )
 
   const environmentUpdated: Environment = {
-    v: 2,
-    id: uniqueID(),
+    v: 3,
+    id: editingID.value || uniqueID(),
     name: editingName.value,
     variables,
+  }
+
+  if (secretVariables.length > 0) {
+    if (props.editingEnvironmentIndex === "Global") {
+      secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
+    } else {
+      secretEnvironmentService.addSecretEnvironment(
+        environmentUpdated.id,
+        secretVariables
+      )
+    }
+  }
+
+  if (nonSecretVariables.length > 0) {
+    if (props.editingEnvironmentIndex === "Global") {
+      currentEnvironmentValueService.addEnvironment(
+        "Global",
+        nonSecretVariables
+      )
+    } else {
+      currentEnvironmentValueService.addEnvironment(
+        environmentUpdated.id,
+        nonSecretVariables
+      )
+    }
   }
 
   if (props.action === "new") {
@@ -616,7 +753,7 @@ const saveEnvironment = () => {
     createEnvironment(
       editingName.value,
       environmentUpdated.variables,
-      editingID.value
+      environmentUpdated.id
     )
     setSelectedEnvironmentIndex({
       type: "MY_ENV",
@@ -657,6 +794,7 @@ const saveEnvironment = () => {
 const hideModal = () => {
   editingName.value = null
   selectedEnvOption.value = "variables"
+  fileNames.clear()
   emit("hide-modal")
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -135,6 +135,17 @@
                     :key="`variable-${id}-${index}`"
                     class="flex divide-x divide-dividerLight"
                   >
+                    <div class="flex items-center">
+                      <HoppButtonSecondary
+                        v-tippy="{ theme: 'tooltip' }"
+                        :title="env.isFile ? t('environment.switch_to_text') : t('environment.switch_to_file')"
+                        :icon="env.isFile ? IconFile : IconType"
+                        class="self-center m-1 rounded"
+                        :class="env.isFile ? 'text-accent' : ''"
+                        :disabled="isViewer || tab.isSecret"
+                        @click="toggleVariableType(env, id)"
+                      />
+                    </div>
                     <input
                       v-model="env.key"
                       v-focus
@@ -148,53 +159,97 @@
                       :name="'variable' + index"
                       :disabled="isViewer"
                     />
-                    <div class="flex items-center flex-1">
-                      <SmartEnvInput
-                        v-model="env.initialValue"
-                        :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
-                        :envs="liveEnvs"
-                        :name="'initialValue' + index"
-                        :secret="tab.isSecret"
-                        :select-text-on-mount="
-                          env.key ? env.key === editingVariableName : false
-                        "
-                        :readonly="isViewer"
-                      />
-                      <HoppButtonSecondary
-                        v-tippy="{ theme: 'tooltip' }"
-                        :title="t('environment.replace_initial_with_current')"
-                        :icon="IconCopyLeft"
-                        :disabled="isViewer"
-                        @click="
-                          () => {
-                            env.initialValue = env.currentValue
-                          }
-                        "
-                      />
-                    </div>
 
-                    <div class="flex items-center flex-1">
-                      <SmartEnvInput
-                        v-model="env.currentValue"
-                        :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
-                        :envs="liveEnvs"
-                        :name="'currentValue' + index"
-                        :secret="tab.isSecret"
-                        :select-text-on-mount="
-                          env.key ? env.key === editingVariableName : false
-                        "
-                      />
-                      <HoppButtonSecondary
-                        v-tippy="{ theme: 'tooltip' }"
-                        :title="t('environment.replace_current_with_initial')"
-                        :icon="IconCopyRight"
-                        @click="
-                          () => {
-                            env.currentValue = env.initialValue
-                          }
-                        "
-                      />
-                    </div>
+                    <template v-if="!env.isFile || tab.isSecret">
+                      <div class="flex items-center flex-1">
+                        <SmartEnvInput
+                          v-model="env.initialValue"
+                          :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
+                          :envs="liveEnvs"
+                          :name="'initialValue' + index"
+                          :secret="tab.isSecret"
+                          :select-text-on-mount="
+                            env.key ? env.key === editingVariableName : false
+                          "
+                          :readonly="isViewer"
+                        />
+                        <HoppButtonSecondary
+                          v-tippy="{ theme: 'tooltip' }"
+                          :title="t('environment.replace_initial_with_current')"
+                          :icon="IconCopyLeft"
+                          :disabled="isViewer"
+                          @click="
+                            () => {
+                              env.initialValue = env.currentValue
+                            }
+                          "
+                        />
+                      </div>
+
+                      <div class="flex items-center flex-1">
+                        <SmartEnvInput
+                          v-model="env.currentValue"
+                          :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
+                          :envs="liveEnvs"
+                          :name="'currentValue' + index"
+                          :secret="tab.isSecret"
+                          :select-text-on-mount="
+                            env.key ? env.key === editingVariableName : false
+                          "
+                        />
+                        <HoppButtonSecondary
+                          v-tippy="{ theme: 'tooltip' }"
+                          :title="t('environment.replace_current_with_initial')"
+                          :icon="IconCopyRight"
+                          @click="
+                            () => {
+                              env.currentValue = env.initialValue
+                            }
+                          "
+                        />
+                      </div>
+                    </template>
+
+                    <template v-else>
+                      <div class="flex items-center flex-1 px-4 py-2 gap-2">
+                        <input
+                          :id="`team-file-input-${id}`"
+                          type="file"
+                          accept=".txt,.env,.json,.csv,.xml,.yaml,.yml,.pem,.key,.cfg,.conf,.ini,.toml,.properties"
+                          class="hidden"
+                          @change="(e) => handleFileSelect(e, env, id)"
+                        />
+                        <HoppButtonSecondary
+                          :icon="IconUpload"
+                          :label="t('environment.choose_file')"
+                          filled
+                          outline
+                          :disabled="isViewer"
+                          @click="triggerFilePicker(id)"
+                        />
+                        <span
+                          v-if="fileNames.has(id)"
+                          class="text-secondaryLight text-sm truncate max-w-[200px]"
+                          :title="fileNames.get(id)"
+                        >
+                          {{ fileNames.get(id) }}
+                        </span>
+                        <span v-else class="text-secondaryLight text-sm italic">
+                          {{ env.key ? t('environment.file_required_reselect') : t('environment.no_file_selected') }}
+                        </span>
+                      </div>
+                      <div class="flex items-center flex-1 px-4 py-2">
+                        <span
+                          v-if="fileNames.has(id)"
+                          class="text-secondaryLight text-sm truncate"
+                        >
+                          {{ `${(env.currentValue.match(/\n/g)?.length ?? 0) + 1} lines, ${env.currentValue.length} bytes` }}
+                        </span>
+                        <span v-else class="text-secondaryLight text-sm italic">
+                          {{ t('environment.file_content_preview') }}
+                        </span>
+                      </div>
+                    </template>
 
                     <div v-if="!isViewer" class="flex">
                       <HoppButtonSecondary
@@ -234,7 +289,7 @@
 </template>
 
 <script setup lang="ts">
-import { ComputedRef, computed, ref, watch } from "vue"
+import { ComputedRef, computed, reactive, ref, watch } from "vue"
 import * as E from "fp-ts/Either"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
@@ -263,6 +318,7 @@ import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { useReadonlyStream } from "~/composables/stream"
 import { globalEnv$ } from "~/newstore/environments"
+import { MAX_FILE_SIZE } from "~/helpers/utils/environments"
 import IconTrash from "~icons/lucide/trash"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconDone from "~icons/lucide/check"
@@ -271,6 +327,9 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconCopyRight from "~icons/lucide/clipboard-paste"
 import IconCopyLeft from "~icons/lucide/clipboard-copy"
 import IconMoreVertical from "~icons/lucide/more-vertical"
+import IconFile from "~icons/lucide/file"
+import IconType from "~icons/lucide/type"
+import IconUpload from "~icons/lucide/upload"
 import { TippyComponent } from "vue-tippy"
 
 type EnvironmentVariable = {
@@ -346,9 +405,12 @@ const editingID = ref<string | null>(null)
 const vars = ref<EnvironmentVariable[]>([
   {
     id: idTicker.value++,
-    env: { key: "", currentValue: "", initialValue: "", secret: false },
+    env: { key: "", currentValue: "", initialValue: "", secret: false, isFile: false },
   },
 ])
+
+const fileNames = reactive(new Map<number, string>())
+
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
 const currentEnvironmentValueService = useService(CurrentValueService)
@@ -462,15 +524,26 @@ watch(
                   "")
                 : e.initialValue,
               secret: e.secret,
+              isFile: e.isFile ?? false,
             },
           }))
         )
+
+        // Clear stale entries before restoring to prevent orphaned IDs accumulating
+        fileNames.clear()
+        // Restore fileNames for file variables that still have content loaded
+        vars.value.forEach(({ id, env }) => {
+          if (env.isFile && env.currentValue) {
+            fileNames.set(id, t("environment.file_loaded_reselect"))
+          }
+        })
       }
     }
   }
 )
 
 const clearContent = () => {
+  fileNames.clear()
   vars.value = []
   clearIcon.value = IconDone
   toast.success(`${t("state.cleared")}`)
@@ -484,14 +557,70 @@ const addEnvironmentVariable = () => {
       currentValue: "",
       initialValue: "",
       secret: selectedEnvOption.value === "secret",
+      isFile: false,
     },
   })
+}
+
+const toggleVariableType = (env: Environment["variables"][number], id: number) => {
+  if (env.isFile) {
+    // Switching to text: clear file state
+    env.initialValue = ""
+    env.currentValue = ""
+    fileNames.delete(id)
+  } else {
+    // Switching to file: clear text values
+    env.initialValue = ""
+    env.currentValue = ""
+  }
+  env.isFile = !env.isFile
+}
+
+const triggerFilePicker = (id: number) => {
+  const input = document.getElementById(`team-file-input-${id}`) as HTMLInputElement | null
+  if (input) {
+    input.click()
+  }
+}
+
+const handleFileSelect = (event: Event, env: Environment["variables"][number], varId: number) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  if (file.size > MAX_FILE_SIZE) {
+    toast.error(t('environment.file_too_large'))
+    input.value = ""
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    const result = e.target?.result
+
+    if (typeof result !== "string") {
+      toast.error(t('environment.file_read_error'))
+      input.value = ""
+      return
+    }
+
+    fileNames.set(varId, file.name)
+    env.currentValue = result
+    env.initialValue = ""
+    input.value = ""
+  }
+  reader.onerror = () => {
+    toast.error(t('environment.file_read_error'))
+    input.value = ""
+  }
+  reader.readAsText(file)
 }
 
 const removeEnvironmentVariable = (id: number) => {
   const index = vars.value.findIndex((e) => e.id === id)
   if (index !== -1) {
     vars.value.splice(index, 1)
+    fileNames.delete(id)
   }
 }
 
@@ -529,9 +658,10 @@ const saveEnvironment = async () => {
       e.secret
         ? O.some({
             key: e.key,
-            value: e.currentValue,
+            value: e.isFile ? "" : e.currentValue,
             varIndex: i,
-            initialValue: e.initialValue,
+            initialValue: e.isFile ? "" : e.initialValue,
+            isFile: e.isFile ?? false,
           })
         : O.none
     )
@@ -546,6 +676,7 @@ const saveEnvironment = async () => {
             currentValue: e.currentValue,
             varIndex: i,
             isSecret: e.secret ?? false,
+            isFile: e.isFile ?? false,
           })
         : O.none
     )
@@ -556,13 +687,14 @@ const saveEnvironment = async () => {
     A.map((e) => ({
       key: e.key,
       secret: e.secret,
-      initialValue: e.secret ? "" : e.initialValue,
+      initialValue: e.secret ? "" : (e.isFile ? "" : e.initialValue),
       currentValue: "",
+      isFile: e.isFile ?? false,
     }))
   )
 
   const environmentUpdated: Environment = {
-    v: 2,
+    v: 3,
     id: editingID.value ?? "",
     name: editingName.value,
     variables,
@@ -632,6 +764,9 @@ const saveEnvironment = async () => {
     }
 
     if (!props.isViewer) {
+      // isFile is included in the variables JSON payload. The backend stores
+      // environment variables as opaque JSON and does not strip unknown fields,
+      // so the isFile flag survives a save-reload cycle without backend changes.
       await pipe(
         updateTeamEnvironment(
           JSON.stringify(environmentUpdated.variables),
@@ -661,6 +796,7 @@ const saveEnvironment = async () => {
 const hideModal = () => {
   editingName.value = null
   selectedEnvOption.value = "variables"
+  fileNames.clear()
   emit("hide-modal")
 }
 </script>

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -225,23 +225,44 @@ const updateEnvironments = (
   const updatedSecretEnvironments: SecretVariable[] = []
   const nonSecretVariables: Variable[] = []
 
+  // Build a lookup from the pre-script store state (which is known to be correct)
+  // rather than trusting the sandbox to echo isFile back through postMessage.
+  // Use key-based lookup so isFile survives variable reordering by test scripts.
+  // Note: test-script updates to file variable values are intentionally discarded
+  // in the store — file content is session-only and must be re-selected on reload.
+  const initialEnvVariables =
+    type === "selected"
+      ? (initialEnvID
+          ? environmentsStore.value.environments.find((e) => e.id === initialEnvID)?.variables
+          : getCurrentEnvironment().variables) ?? []
+      : getGlobalVariables()
+
+  const initialEnvMap = new Map(
+    initialEnvVariables.map((v) => [v.key, v.isFile ?? false] as const)
+  )
+
   const updatedEnv = pipe(
     envs,
     A.mapWithIndex((index, e) => {
+      const isFile = initialEnvMap.get(e.key) ?? (e.isFile ?? false)
+
       if (e.secret) {
         updatedSecretEnvironments.push({
           key: e.key,
-          value: e.currentValue ?? "",
+          value: isFile ? "" : (e.currentValue ?? ""),
           varIndex: index,
-          initialValue: e.initialValue ?? "",
+          initialValue: isFile ? "" : (e.initialValue ?? ""),
         })
 
         // For secret variables, keep the initialValue but clear currentValue for storage
+        // Zero out initialValue for file variables to prevent file content from
+        // being persisted to localStorage or leaked to the team server
         return {
           key: e.key,
           secret: e.secret,
-          initialValue: e.initialValue ?? "",
+          initialValue: isFile ? "" : (e.initialValue ?? ""),
           currentValue: "",
+          isFile,
         }
       }
 
@@ -250,14 +271,18 @@ const updateEnvironments = (
         isSecret: e.secret ?? false,
         varIndex: index,
         currentValue: e.currentValue ?? "",
+        isFile,
       })
 
       // For non-secret variables, preserve both initialValue and currentValue
+      // Zero out currentValue for file variables to prevent file content from
+      // being persisted to localStorage or leaked to the team server
       return {
         key: e.key,
         secret: e.secret ?? false,
-        initialValue: e.initialValue ?? "",
-        currentValue: e.currentValue ?? "",
+        initialValue: isFile ? "" : (e.initialValue ?? ""),
+        currentValue: isFile ? "" : (e.currentValue ?? ""),
+        isFile,
       }
     })
   )
@@ -518,6 +543,7 @@ export function runRESTRequest$(
               initialValue: v.value,
               currentValue: v.value,
               secret: false,
+              isFile: false as const,
             }
           }
           return []
@@ -532,6 +558,7 @@ export function runRESTRequest$(
         initialValue,
         currentValue,
         secret,
+        isFile: false as const,
       }))
 
     const finalRequest = applyScriptRequestUpdates(
@@ -554,7 +581,7 @@ export function runRESTRequest$(
 
     const effectiveRequest = await getEffectiveRESTRequest(finalRequest, {
       id: "env-id",
-      v: 2,
+      v: 3,
       name: "Env",
       variables: finalEnvsWithNonEmptyValues,
     })
@@ -685,7 +712,7 @@ function updateEnvsAfterTestScript(
   )
 
   setGlobalEnvVariables({
-    v: 2,
+    v: 3,
     variables: globalEnvVariables,
   })
 
@@ -702,7 +729,7 @@ function updateEnvsAfterTestScript(
     })
     updateEnvironment(initialEnvironmentIndex.index, {
       name: env.name,
-      v: 2,
+      v: 3,
       id: "id" in env ? env.id : "",
       variables: selectedEnvVariables,
     })
@@ -839,6 +866,7 @@ export async function runTestRunnerRequest(
         initialValue: value,
         currentValue: value,
         secret: false,
+        isFile: false as const,
       }))
     )
 
@@ -850,7 +878,7 @@ export async function runTestRunnerRequest(
 
     const effectiveRequest = await getEffectiveRESTRequest(finalRequest, {
       id: "env-id",
-      v: 2,
+      v: 3,
       name: "Env",
       variables: filterNonEmptyEnvironmentVariables(
         combineEnvVariables({
@@ -859,7 +887,10 @@ export async function runTestRunnerRequest(
             temp: !persistEnv ? getTemporaryVariables() : [],
           },
           requestVariables: finalRequestVariables,
-          collectionVariables: inheritedVariables,
+          collectionVariables: inheritedVariables.map((v) => ({
+            ...v,
+            isFile: false as const,
+          })),
         })
       ),
     })

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -9,6 +9,9 @@ import {
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 
+/** Maximum file size for file-based environment variables (5 MB). */
+export const MAX_FILE_SIZE = 5 * 1024 * 1024
+
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
 

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -207,6 +207,7 @@ const dispatchers = defineDispatchers({
       initialValue,
       currentValue,
       secret,
+      isFile,
     }: {
       envIndex: number
       key: string
@@ -223,7 +224,7 @@ const dispatchers = defineDispatchers({
               ...env,
               variables: [
                 ...env.variables,
-                { key, initialValue, currentValue, secret, isFile: false },
+                { key, initialValue, currentValue, secret, isFile: isFile ?? false },
               ],
             }
           : env
@@ -268,7 +269,7 @@ const dispatchers = defineDispatchers({
         index === envIndex
           ? {
               ...env,
-              variables: vars,
+              variables: vars.map((v) => ({ ...v, isFile: v.isFile ?? false })),
             }
           : env
       ),

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -213,6 +213,7 @@ const dispatchers = defineDispatchers({
       initialValue: string
       currentValue: string
       secret: boolean
+      isFile?: boolean
     }
   ) {
     return {
@@ -222,7 +223,7 @@ const dispatchers = defineDispatchers({
               ...env,
               variables: [
                 ...env.variables,
-                { key, initialValue, currentValue, secret },
+                { key, initialValue, currentValue, secret, isFile: false },
               ],
             }
           : env
@@ -258,6 +259,7 @@ const dispatchers = defineDispatchers({
         initialValue: string
         currentValue: string
         secret: boolean
+        isFile?: boolean
       }[]
     }
   ) {
@@ -300,6 +302,7 @@ const dispatchers = defineDispatchers({
                       initialValue: updatedInitialValue,
                       currentValue: updatedCurrentValue,
                       secret: v.secret,
+                      isFile: v.isFile ?? false,
                     }
                   : v
               ),
@@ -901,6 +904,7 @@ export function setEnvironmentVariables(
     currentValue: string
     initialValue: string
     secret: boolean
+    isFile?: boolean
   }[]
 ) {
   environmentsStore.dispatch({

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -26,14 +26,14 @@ export type SelectedEnvironmentIndex =
     }
 
 const defaultGlobalEnvironmentState: GlobalEnvironment = {
-  v: 2,
+  v: 3,
   variables: [],
 }
 
 const defaultEnvironmentsState = {
   environments: [
     {
-      v: 2,
+      v: 3,
       id: uniqueID(),
       name: "My Environment Variables",
       variables: [],
@@ -104,12 +104,12 @@ const dispatchers = defineDispatchers({
         envID
           ? {
               id: envID,
-              v: 2,
+              v: 3 as const,
               name,
               variables,
             }
           : {
-              v: 2,
+              v: 3 as const,
               id: uniqueID(),
               name,
               variables,
@@ -401,7 +401,7 @@ export const currentEnvironment$: Observable<Environment | undefined> =
       if (selectedEnvironmentIndex.type === "NO_ENV_SELECTED") {
         const env: Environment = {
           name: "No environment",
-          v: 2,
+          v: 3,
           id: "",
           variables: [],
         }
@@ -704,7 +704,7 @@ export function getCurrentEnvironment(): Environment {
     environmentsStore.value.selectedEnvironmentIndex.type === "NO_ENV_SELECTED"
   ) {
     return {
-      v: 2,
+      v: 3,
       id: "",
       name: "No environment",
       variables: [],

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -923,11 +923,13 @@ export function addEnvironmentVariable(
     currentValue,
     initialValue,
     secret,
+    isFile,
   }: {
     key: string
     currentValue: string
     initialValue: string
     secret: boolean
+    isFile?: boolean
   }
 ) {
   environmentsStore.dispatch({
@@ -938,6 +940,7 @@ export function addEnvironmentVariable(
       currentValue,
       initialValue,
       secret,
+      isFile,
     },
   })
 }

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -10,6 +10,7 @@ export type Variable = {
   currentValue: string
   varIndex: number
   isSecret: boolean
+  isFile?: boolean
 }
 
 /**
@@ -159,9 +160,19 @@ export class CurrentValueService extends Service {
    * Used to update the value of a environment variable.
    */
   public persistableEnvironments = computed(() => {
-    const environments: Record<string, Variable[]> = {}
+    const environments: Record<string, Omit<Variable, "isFile">[]> = {}
     this.environments.forEach((vars, id) => {
+      // Filter out file variables to prevent file content (up to 5 MB) from
+      // being serialized to localStorage. Strip isFile from remaining vars
+      // to match the persistence Zod schema (.strict()).
       environments[id] = vars
+        .filter((v) => !v.isFile)
+        .map(({ key, currentValue, varIndex, isSecret }) => ({
+          key,
+          currentValue,
+          varIndex,
+          isSecret,
+        }))
     })
     return environments
   })

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import V0_VERSION from "./v/0"
 import V1_VERSION, { uniqueID } from "./v/1"
 import V2_VERSION from "./v/2"
+import V3_VERSION from "./v/3"
 import { HOPP_SUPPORTED_PREDEFINED_VARIABLES } from "../predefinedVariables"
 
 const versionedObject = z.object({
@@ -14,11 +15,12 @@ const versionedObject = z.object({
 })
 
 export const Environment = createVersionedEntity({
-  latestVersion: 2,
+  latestVersion: 3,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
     2: V2_VERSION,
+    3: V3_VERSION,
   },
   getVersion(data) {
     const versionCheck = versionedObject.safeParse(data)
@@ -50,7 +52,7 @@ const ENV_MAX_EXPAND_LIMIT = 10
  */
 const ENV_EXPAND_LOOP = "ENV_EXPAND_LOOP" as const
 
-export const EnvironmentSchemaVersion = 2
+export const EnvironmentSchemaVersion = 3
 
 export function parseBodyEnvVariablesE(
   body: string,
@@ -215,11 +217,12 @@ export const translateToNewEnvironmentVariables = (
     initialValue: x.initialValue ?? x.value ?? "",
     currentValue: x.currentValue ?? x.value ?? "",
     secret: x.secret ?? false,
+    isFile: x.isFile ?? false,
   }
 }
 
 export const translateToNewEnvironment = (x: any): Environment => {
-  if (x.v && x.v === EnvironmentSchemaVersion) return x
+  if (x?.v === EnvironmentSchemaVersion) return x
 
   // Legacy
   const id = x.id || uniqueID()

--- a/packages/hoppscotch-data/src/environment/v/3.ts
+++ b/packages/hoppscotch-data/src/environment/v/3.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+import { V2_SCHEMA } from "./2"
+
+export const V3_SCHEMA = z.object({
+  v: z.literal(3),
+  id: z.string(),
+  name: z.string(),
+  variables: z.array(
+    z.object({
+      key: z.string(),
+      initialValue: z.string(),
+      currentValue: z.string(),
+      secret: z.boolean(),
+      isFile: z.boolean().default(false),
+    })
+  ),
+})
+
+export default defineVersion({
+  initial: false,
+  schema: V3_SCHEMA,
+  up(old: z.infer<typeof V2_SCHEMA>) {
+    return {
+      ...old,
+      v: 3 as const,
+      variables: old.variables.map((variable) => ({
+        ...variable,
+        isFile: false,
+      })),
+    }
+  },
+})

--- a/packages/hoppscotch-data/src/global-environment/index.ts
+++ b/packages/hoppscotch-data/src/global-environment/index.ts
@@ -5,17 +5,19 @@ import { z } from "zod"
 import V0_VERSION from "./v/0"
 import V1_VERSION from "./v/1"
 import V2_VERSION from "./v/2"
+import V3_VERSION from "./v/3"
 
 const versionedObject = z.object({
   v: z.number(),
 })
 
 export const GlobalEnvironment = createVersionedEntity({
-  latestVersion: 2,
+  latestVersion: 3,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
     2: V2_VERSION,
+    3: V3_VERSION,
   },
   getVersion(data) {
     const versionCheck = versionedObject.safeParse(data)

--- a/packages/hoppscotch-data/src/global-environment/v/3.ts
+++ b/packages/hoppscotch-data/src/global-environment/v/3.ts
@@ -1,0 +1,31 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+import { V2_SCHEMA } from "./2"
+
+export const V3_SCHEMA = z.object({
+  v: z.literal(3),
+  variables: z.array(
+    z.object({
+      key: z.string(),
+      initialValue: z.string(),
+      currentValue: z.string(),
+      secret: z.boolean(),
+      isFile: z.boolean().default(false),
+    })
+  ),
+})
+
+export default defineVersion({
+  initial: false,
+  schema: V3_SCHEMA,
+  up(old: z.infer<typeof V2_SCHEMA>) {
+    return {
+      ...old,
+      v: 3 as const,
+      variables: old.variables.map((variable) => ({
+        ...variable,
+        isFile: false,
+      })),
+    }
+  },
+})


### PR DESCRIPTION
Closes #4120

This PR adds support for file-based environment variables, allowing users to populate variable values from local files instead of manual text entry.

### What's changed

- [x] **Data Schema V3**: Created `environment/v/3.ts` and `global-environment/v/3.ts` adding an `isFile: boolean` field to environment variables (defaults to `false`)
- [x] **Schema Registration**: Updated `environment/index.ts` and `global-environment/index.ts` to register V3, bump version, and include `isFile` in the migration helper
- [x] **Personal Environment UI** (`my/Details.vue`): Added a text/file toggle button per variable row, a file picker with 5MB size guard, filename display, and content preview
- [x] **Team Environment UI** (`teams/Details.vue`): Same file variable support with a note that file variables are local-only and not synced to the team server
- [x] **Quick Add Modal** (`Add.vue`): Bumped schema version to V3 for consistency
- [x] **i18n**: Added 6 new English locale strings for toggle tooltips, file picker labels, and error messages

### Design decisions

- File contents are read into memory via `FileReader` and stored in `currentValue` at runtime only — they are **never persisted** to storage or the backend
- Users must re-select files each session (browser security prevents persisting file paths)
- The `isFile` flag **is** persisted so the file picker UI appears on reload
- Zero changes to the variable resolution engine (`parseTemplateStringE`) — it already reads `currentValue` regardless of source
- Backward compatible: existing V1/V2 environments are migrated with `isFile: false`

### Notes to reviewers

- The file size limit is set to **5MB** to prevent memory issues in the browser
- Team environment file variables are intentionally local-only (not synced) since file contents shouldn't be uploaded to shared servers
- No backend changes are required for this feature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file-based environment variables with a per-variable text/file toggle and a safe file picker across personal and team environments. Upgrades schemas to v3; file contents stay in-memory only, with filename plus line/byte preview.

- **New Features**
  - Schema v3 with isFile and migrations for environment/global; defaults, stores, “No environment,” runners, temporary envs, and the Add modal now use v3.
  - UI: per-row text/file toggle; file picker (common types) with 5MB limit; filename + line/byte preview; read-error toasts; messages for “file loaded — re-select to refresh” and “file required — please select a file”; toggle disabled for team viewers and on secret rows.
  - Runtime: key-based isFile propagation across the sandbox so it survives test-script reordering; file content read on selection; test-script updates to file vars ignored in stores.
  - Team environments: persist the isFile flag in the variables JSON to restore UI after reload; file contents are never synced; backend unchanged.

- **Bug Fixes**
  - Privacy: filter file vars from localStorage persistence; strip isFile from persisted local values; zero file var values in saved environments, team sync payloads, and runner updates to avoid leaking contents.
  - Store: include isFile in store add/update dispatchers and service types; honor isFile in addEnvironmentVariable; coerce optional isFile in setEnvironmentVariables; restore/clear in-memory file state and filenames on load/remove.

<sup>Written for commit 5041f7e18bc61e0bab7aec58fcb119bbded91a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

