### PR TITLE
fix(common): variable hover tooltip was not clickable (disappeared)

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -561,3 +561,18 @@ details[open] summary .indicator {
 .gql-operation-highlight {
   @apply opacity-100;
 }
+
+/*
+ * Standardizes interactive tooltip behavior by extending the hover area.
+ * This prevents tooltips from hiding when the cursor moves across small
+ * gaps between the trigger text and the tooltip box.
+ */
+.hopp-tooltip-interactive-wrapper {
+  &::before {
+    content: "";
+    @apply absolute;
+    @apply -inset-3;
+    @apply z-[-1];
+    @apply pointer-events-auto;
+  }
+}

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -573,8 +573,7 @@ details[open] summary .indicator {
   &::before {
     content: "";
     @apply absolute;
-    @apply -inset-3;
-    @apply z-[-1];
+    @apply -inset-2;
     @apply pointer-events-auto;
   }
 }

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -568,6 +568,8 @@ details[open] summary .indicator {
  * gaps between the trigger text and the tooltip box.
  */
 .hopp-tooltip-interactive-wrapper {
+  @apply relative;
+
   &::before {
     content: "";
     @apply absolute;

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -42,6 +42,7 @@ import {
   HOPP_ENVIRONMENT_REGEX,
 } from "~/helpers/environment-regex"
 import {
+  stabilizeTooltipHover,
   constrainTooltipToViewport,
   createTooltipValueRow,
 } from "~/helpers/utils/tooltip"
@@ -312,6 +313,9 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
           // Apply viewport-aware overflow constraints to the tooltip
           constrainTooltipToViewport(dom, tooltipContainer)
+
+          // Apply an interactive bridge to stabilize hover transitions
+          stabilizeTooltipHover(dom)
 
           return { dom }
         },

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppPredefinedVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppPredefinedVariables.ts
@@ -10,6 +10,7 @@ import { HOPP_SUPPORTED_PREDEFINED_VARIABLES } from "@hoppscotch/data"
 import IconSquareAsterisk from "~icons/lucide/square-asterisk?raw"
 import { isComment } from "./helpers"
 import {
+  stabilizeTooltipHover,
   constrainTooltipToViewport,
   truncateText,
 } from "~/helpers/utils/tooltip"
@@ -145,6 +146,9 @@ const cursorTooltipField = () =>
 
           // Apply viewport-aware overflow constraints
           constrainTooltipToViewport(dom, tooltipContainer)
+
+          // Apply an interactive bridge to stabilize hover transitions
+          stabilizeTooltipHover(dom)
 
           return { dom }
         },

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/tooltip.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/tooltip.spec.ts
@@ -6,6 +6,7 @@ import {
   applyTooltipOverflowStyles,
   createTooltipValueRow,
   constrainTooltipToViewport,
+  stabilizeTooltipHover,
   TOOLTIP_MAX_VALUE_LENGTH,
   TOOLTIP_MAX_HEIGHT_PX,
   TOOLTIP_MAX_WIDTH_PX,
@@ -371,6 +372,24 @@ describe("constrainTooltipToViewport", () => {
     expect(parseInt(tooltipBox.style.maxWidth)).toBeLessThanOrEqual(
       TOOLTIP_MAX_WIDTH_PX
     )
+  })
+})
+
+// ─── stabilizeTooltipHover ───────────────────────────────────────
+
+describe("stabilizeTooltipHover", () => {
+  test("adds 'hopp-tooltip-interactive-wrapper' class to element", () => {
+    const el = document.createElement("div")
+    stabilizeTooltipHover(el)
+    expect(el.classList.contains("hopp-tooltip-interactive-wrapper")).toBe(true)
+  })
+
+  test("does not remove existing classes", () => {
+    const el = document.createElement("div")
+    el.className = "existing-class"
+    stabilizeTooltipHover(el)
+    expect(el.className).toContain("existing-class")
+    expect(el.className).toContain("hopp-tooltip-interactive-wrapper")
   })
 })
 

--- a/packages/hoppscotch-common/src/helpers/utils/tooltip.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/tooltip.ts
@@ -195,3 +195,14 @@ export function constrainTooltipToViewport(
   tooltipContent.style.overflow = "hidden"
   tooltipContent.style.boxSizing = "border-box"
 }
+
+/**
+ * Standardized helper to stabilize interactive tooltips in CodeMirror.
+ * Adds a CSS-based bridge to extend the hover area, allowing the user
+ * to move the cursor into the tooltip without it closing.
+ *
+ * @param dom - The outer tooltip container element (.tippy-box)
+ */
+export function stabilizeTooltipHover(dom: HTMLElement): void {
+  dom.classList.add("hopp-tooltip-interactive-wrapper")
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6154 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

This pull request introduces a more robust way to handle interactive tooltips in the code editor. It specifically addresses the "hover gap" issue where tooltips would prematurely disappear when the user moved their cursor from the trigger text (e.g., `<<variable>>`) toward the tooltip content or the "Edit" button.

We solve this by implementing an invisible "hover bridge" using CSS pseudo-elements, which extends the interactive area of the tooltip. This ensures a seamless transition for the cursor, regardless of small rendering offsets or "dead zones" between the editor line and the floating tooltip box.

#### Showcase:

https://github.com/user-attachments/assets/94ee231c-855e-46b8-bc5a-94361d2def5c

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

- **Standardized hover stabilization:** added `stabilizeTooltipHover` in `tooltip.ts`. This helper applies a new `.hopp-tooltip-interactive-wrapper` class to tooltip containers.
- **CSS hover bridge:** defined a new utility in styles.scss that uses a `::before` pseudo-element with an inset margin. This creates an invisible hit-zone around the tooltip, preventing it from closing during mouse transitions.
- **Consistent integration:** applied this stabilization to both **Environment Variable** and **Predefined Variable** tooltip extensions in CodeMirror.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

This method was a quick fix by extending the physical hover area (the "bridge"), we keep the UI responsive while making the interaction feel "sticky" and intentional.