### PR TITLE
feat: enhance CORS error messaging in browser interceptor

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,9 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}",
+      "cors_heading": "Security Policy Warning (CORS)",
+      "cors_description": "The browser blocked this request because of its Security Policy (CORS). You can bypass this by using the Hoppscotch Browser Extension or the Proxy interceptor. {message}"
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
@@ -66,6 +66,9 @@ export class BrowserKernelInterceptorService
               heading: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
+                    if (error.message === "Failed to fetch") {
+                      return t("error.network.cors_heading")
+                    }
                     return t("error.network.heading")
                   case "timeout":
                     return t("error.timeout.heading")
@@ -88,6 +91,11 @@ export class BrowserKernelInterceptorService
               description: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
+                    if (error.message === "Failed to fetch") {
+                      return t("error.network.cors_description", {
+                        message: error.message,
+                      })
+                    }
                     return t("error.network.description", {
                       message: error.message,
                       cause: error.cause ?? t("error.unknown.cause"),


### PR DESCRIPTION


<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve CORS error clarity in the browser interceptor by showing a specific Security Policy (CORS) warning and guidance. Users now see actionable steps to bypass the block via the Hoppscotch Browser Extension or the Proxy interceptor.

- New Features
  - Detects `"Failed to fetch"` network errors and displays CORS-specific heading and description from i18n.
  - Adds `error.network.cors_heading` and `error.network.cors_description` strings in `hoppscotch-common` with clear guidance.

<sup>Written for commit 51e0f0d4c299da2554bb70ae01e6695d70d29fc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

