### PR TITLE
fix(common): add missing aria-labels to icon-only sidenav links

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Sidenav.vue
+++ b/packages/hoppscotch-common/src/components/app/Sidenav.vue
@@ -10,7 +10,7 @@
           content: !EXPAND_NAVIGATION ? t(navigation.title) : null,
         }"
         :to="navigation.target"
-        :aria-label="t(navigation.title)"
+        :aria-label="!EXPAND_NAVIGATION ? t(navigation.title) : null"
         class="nav-link"
         tabindex="0"
         :exact="navigation.exact"

--- a/packages/hoppscotch-common/src/components/app/Sidenav.vue
+++ b/packages/hoppscotch-common/src/components/app/Sidenav.vue
@@ -10,6 +10,7 @@
           content: !EXPAND_NAVIGATION ? t(navigation.title) : null,
         }"
         :to="navigation.target"
+        :aria-label="t(navigation.title)"
         class="nav-link"
         tabindex="0"
         :exact="navigation.exact"


### PR DESCRIPTION
Adds an accessible name to the primary sidebar navigation links so screen readers can announce each destination when the sidenav is collapsed to icon-only mode.

### What's changed

- Adds `:aria-label="t(navigation.title)"` to the primary nav link in `Sidenav.vue`.
- Reuses the existing translated navigation title, so the accessible name stays localised and aligned with the visible nav text.
- Improves screen reader support for collapsed sidenav navigation without changing layout or behaviour.

### Notes to reviewers

- Greptile flagged the `aria-label` as redundant when the sidenav is expanded; that is fair as a best-practice nit, but both the visible text and the label come from the same i18n key, so there is no behavioural divergence worth blocking on here.
- No tracked issue is linked; this is a small, standalone accessibility improvement.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add localized aria-labels to icon‑only sidenav links so screen readers announce destinations when the sidebar is collapsed. The label uses the translated navigation title and is omitted when expanded, so behavior stays the same.

<sup>Written for commit 719e30aa47cc70ccfaecdc64f25bf35531a76246. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


