### PR TITLE
Feat/i18n inherited headers

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1192,6 +1192,7 @@
     "go_to_authorization_tab": "Go to Authorization tab",
     "go_to_body_tab": "Go to Body tab",
     "header_list": "Header List",
+    "inherited_header_description": "This header is inherited from Parent Collection {parent}",
     "invalid_name": "Please provide a name for the request",
     "method": "Method",
     "moved": "Request moved",

--- a/packages/hoppscotch-common/src/components/history/rest/Card.vue
+++ b/packages/hoppscotch-common/src/components/history/rest/Card.vue
@@ -58,6 +58,16 @@
                 }
               "
             />
+            <HoppSmartItem
+              :icon="IconCopy"
+              :label="`${t('action.copy_url')}`"
+              @click="
+                () => {
+                  copyUrl()
+                  hide()
+                }
+              "
+            />
           </div>
         </template>
       </tippy>
@@ -90,10 +100,13 @@ import { useI18n } from "@composables/i18n"
 import { RESTHistoryEntry } from "~/newstore/history"
 import { shortDateTime } from "~/helpers/utils/date"
 import IconSave from "~icons/lucide/save"
+import IconCopy from "~icons/lucide/copy"
 import IconStar from "~icons/lucide/star"
 import IconStarOff from "~icons/hopp/star-off"
 import IconTrash from "~icons/lucide/trash"
 import { TippyComponent } from "vue-tippy"
+import { useToast } from "@composables/toast"
+import { copyToClipboard } from "~/helpers/utils/clipboard"
 
 const props = defineProps<{
   entry: RESTHistoryEntry
@@ -112,6 +125,12 @@ const options = ref<TippyComponent | null>(null)
 const addToCollectionAction = ref<HTMLButtonElement | null>(null)
 
 const t = useI18n()
+const toast = useToast()
+
+const copyUrl = () => {
+  copyToClipboard(props.entry.request.endpoint)
+  toast.success(`${t("state.copied_to_clipboard")}`)
+}
 
 const duration = computed(() => {
   if (props.entry.responseMeta.duration) {

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -215,9 +215,11 @@
               <HoppButtonSecondary
                 v-tippy="{ theme: 'tooltip' }"
                 :icon="IconInfo"
-                :title="`This header is inherited from Parent Collection ${
-                  header.inheritedFrom ?? ''
-                }`"
+                :title="
+                t('request.inherited_header_description', {
+                  parent: header.inheritedFrom ?? '',
+                })
+              "
               />
             </span>
           </div>


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Copy URL” action to REST history cards and localizes the inherited header tooltip for better usability and translation coverage.

- New Features
  - History: Added “Copy URL” option to history card menu; copies the endpoint to clipboard and shows a success toast.
  - Headers: Localized the inherited header tooltip using `t('request.inherited_header_description', { parent })`; added the `inherited_header_description` key to `en.json`.

<sup>Written for commit a3dd8cb9eddaba8758250dbbf37c2c444713b77e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

