### PR TITLE
fix(common): preserve '=' in cURL cookie import values

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,35 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl 'https://www.example.com/v1' -b 'cookie1="subprop1=val1"'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://www.example.com/v1",
+      auth: {
+        authType: "inherit",
+        authActive: true,
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "Cookie",
+          value: 'cookie1="subprop1=val1"',
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
@@ -58,7 +58,11 @@ const parseCookieString = (cookieString: string): Record<string, string> => {
     .map((pair) => pair.trim())
     .filter(Boolean)
     .reduce((acc, pair) => {
-      const [key, value] = pair.split("=", 2)
+      const separatorIndex = pair.indexOf("=")
+      const key =
+        separatorIndex === -1 ? pair : pair.slice(0, separatorIndex)
+      const value =
+        separatorIndex === -1 ? "" : pair.slice(separatorIndex + 1)
       return { ...acc, [key]: value || "" }
     }, {})
 }


### PR DESCRIPTION
Closes #5498

This fixes cURL imports that use `-b` with a quoted cookie value containing `=`. The current parser splits cookie pairs with `split("=", 2)`, which truncates everything after the second `=` and produces an incomplete `Cookie` header.

### What's changed
- parse each imported cookie pair at the first `=` only so the rest of the value is preserved
- add a regression sample for `curl 'https://www.example.com/v1' -b 'cookie1="subprop1=val1"'`

### Notes to reviewers
- scope is limited to the cURL cookie import helper used by `-b` / `--cookie`
- validation: `pnpm --filter @hoppscotch/common exec vitest run src/helpers/curl/__tests__/curlparser.spec.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL `-b/--cookie` import to preserve '=' inside cookie values so the full `Cookie` header is kept. Closes #5498.

- **Bug Fixes**
  - Parse cookie pairs at the first '=' to keep the entire value.
  - Add a regression test for `-b 'cookie1="subprop1=val1"'`.

<sup>Written for commit 087dc06a35e5252312281db2bf0155a7fd67666f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

