### PR TITLE
feat(common): parse Content-Disposition header for download filename`

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/AudioLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/AudioLensRenderer.vue
@@ -114,7 +114,8 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   computed(() => props.response.body),
   t("filename.lens", {
     request_name: props.response.req.name,
-  })
+  }),
+  computed(() => props.response.headers)
 )
 
 /**

--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -181,10 +181,14 @@ const { responseBodyText } = useResponseBody(props.response)
 const filename = t("filename.lens", {
   request_name: responseName.value,
 })
+const htmlResponseHeaders = computed(() =>
+  "headers" in props.response ? props.response.headers : undefined
+)
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   "text/html",
   responseBodyText,
-  `${filename}.html`
+  `${filename}.html`,
+  htmlResponseHeaders
 )
 
 const defaultPreview = computedAsync(

--- a/packages/hoppscotch-common/src/components/lenses/renderers/ImageLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/ImageLensRenderer.vue
@@ -108,7 +108,8 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   computed(() => props.response.body),
   t("filename.lens", {
     request_name: props.response.req.name,
-  })
+  }),
+  computed(() => props.response.headers)
 )
 
 watch(props.response, () => {

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -499,12 +499,17 @@ const eraseResponse = () => {
   if (!props.isEditable && !props.isTestRunner) emit("update:response", null)
 }
 
+const jsonResponseHeaders = computed(() =>
+  "headers" in props.response ? props.response.headers : undefined
+)
+
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   "application/json",
   jsonBodyText,
   t("filename.lens", {
     request_name: responseName.value,
-  })
+  }),
+  jsonResponseHeaders
 )
 
 // Template refs

--- a/packages/hoppscotch-common/src/components/lenses/renderers/PDFLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/PDFLensRenderer.vue
@@ -96,7 +96,8 @@ const filename = t("filename.lens", {
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   "application/pdf",
   computed(() => props.response.body),
-  `${filename}.pdf`
+  `${filename}.pdf`,
+  computed(() => props.response.headers)
 )
 
 /**

--- a/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
@@ -204,12 +204,17 @@ const responseName = computed(() => {
   return props.response.name
 })
 
+const responseHeaders = computed(() =>
+  "headers" in props.response ? props.response.headers : undefined
+)
+
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   responseType.value,
   rawResponseBody,
   t("filename.lens", {
     request_name: responseName.value,
-  })
+  }),
+  responseHeaders
 )
 
 const { copyIcon, copyResponse } = useCopyResponse(responseBodyText)

--- a/packages/hoppscotch-common/src/components/lenses/renderers/VideoLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/VideoLensRenderer.vue
@@ -114,7 +114,8 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   computed(() => props.response.body),
   t("filename.lens", {
     request_name: props.response.req.name,
-  })
+  }),
+  computed(() => props.response.headers)
 )
 
 /**

--- a/packages/hoppscotch-common/src/components/lenses/renderers/XMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/XMLLensRenderer.vue
@@ -194,10 +194,15 @@ const filename = t("filename.lens", {
   request_name: responseName.value,
 })
 
+const xmlResponseHeaders = computed(() =>
+  "headers" in props.response ? props.response.headers : undefined
+)
+
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   responseType.value,
   responseBodyText,
-  `${filename}.xml`
+  `${filename}.xml`,
+  xmlResponseHeaders
 )
 
 const { copyIcon, copyResponse } = useCopyResponse(responseBodyText)

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -1,5 +1,9 @@
-import { HoppRESTResponse } from "@helpers/types/HoppRESTResponse"
+import {
+  HoppRESTResponse,
+  HoppRESTResponseHeader,
+} from "@helpers/types/HoppRESTResponse"
 import { copyToClipboard } from "@helpers/utils/clipboard"
+import { filenameFromResponseHeaders } from "@helpers/utils/content-disposition"
 import { refAutoReset } from "@vueuse/core"
 import { computed, ComputedRef, ref, Ref, watch } from "vue"
 
@@ -57,7 +61,8 @@ export type downloadResponseReturnType = (() => void) | Ref<any>
 export function useDownloadResponse(
   contentType: string,
   responseBody: Ref<string | ArrayBuffer>,
-  filename: string
+  filename: string,
+  responseHeaders?: Ref<ReadonlyArray<HoppRESTResponseHeader> | undefined>
 ) {
   const downloadIcon = refAutoReset(IconDownload, 1000)
 
@@ -67,11 +72,16 @@ export function useDownloadResponse(
   const downloadResponse = async () => {
     const dataToWrite = responseBody.value
 
-    // TODO: Look at the mime type and determine extension ?
+    // RFC 6266: when the server sets Content-Disposition with a filename,
+    // prefer that over the request-name-derived default so browsers behave
+    // the same way native HTTP clients do for file downloads.
+    const suggestedFilename =
+      filenameFromResponseHeaders(responseHeaders?.value) ?? filename
+
     const result = await platform.kernelIO.saveFileWithDialog({
       data: dataToWrite,
       contentType: contentType,
-      suggestedFilename: filename,
+      suggestedFilename,
     })
 
     // Assume success if unknown as we cannot determine

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/content-disposition.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/content-disposition.spec.ts
@@ -115,6 +115,22 @@ describe("parseContentDisposition", () => {
     expect(parseContentDisposition(header).filename).toBe("fallback.txt")
   })
 
+  test("falls back to filename when ISO-8859-1 filename* has malformed percent-encoding", () => {
+    // The Latin-1 branch used to silently pass malformed input through via
+    // String.prototype.replace, so a broken filename* would override the
+    // legacy filename. Explicitly reject bare `%` (followed by non-hex) and
+    // truncated `%X` so the fallback kicks in for both charsets.
+    const truncated =
+      "attachment; filename=\"fallback.txt\"; filename*=iso-8859-1''%A"
+    const nonHex =
+      "attachment; filename=\"fallback.txt\"; filename*=iso-8859-1''%ZZ"
+    const barePercent =
+      "attachment; filename=\"fallback.txt\"; filename*=iso-8859-1''abc%"
+    expect(parseContentDisposition(truncated).filename).toBe("fallback.txt")
+    expect(parseContentDisposition(nonHex).filename).toBe("fallback.txt")
+    expect(parseContentDisposition(barePercent).filename).toBe("fallback.txt")
+  })
+
   test("tolerates extra whitespace around parameters", () => {
     expect(
       parseContentDisposition("attachment ;   filename = report.pdf  ").filename
@@ -160,14 +176,26 @@ describe("filenameFromResponseHeaders", () => {
     ).toBeNull()
   })
 
-  test("returns the filename for the first Content-Disposition header only", () => {
-    // Duplicate headers are unusual but legal — stick with the first hit so
-    // behaviour is deterministic.
+  test("returns the filename from the first Content-Disposition header that carries one", () => {
+    // Duplicate headers are unusual but legal. When the first header has a
+    // filename we stop there so behaviour is deterministic...
     expect(
       filenameFromResponseHeaders([
         { key: "Content-Disposition", value: "attachment; filename=a.pdf" },
         { key: "Content-Disposition", value: "attachment; filename=b.pdf" },
       ])
     ).toBe("a.pdf")
+  })
+
+  test("skips Content-Disposition headers that carry no filename", () => {
+    // ...but if the first header is a bare `attachment` with no filename,
+    // we keep scanning so a later header with a real filename isn't
+    // silently dropped.
+    expect(
+      filenameFromResponseHeaders([
+        { key: "Content-Disposition", value: "attachment" },
+        { key: "Content-Disposition", value: "attachment; filename=b.pdf" },
+      ])
+    ).toBe("b.pdf")
   })
 })

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/content-disposition.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/content-disposition.spec.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect } from "vitest"
+
+import {
+  filenameFromResponseHeaders,
+  parseContentDisposition,
+} from "../content-disposition"
+
+// The Content-Disposition header is one of the messier bits of the HTTP spec —
+// RFC 6266 layers on top of RFC 2183, and RFC 5987 adds a `filename*` variant
+// for non-ASCII names. Servers also send all sorts of slightly-wrong values in
+// the wild, so these tests cover both the strict spec examples and the broken
+// shapes we have to be lenient about.
+describe("parseContentDisposition", () => {
+  test("returns empty result for a null or empty header", () => {
+    expect(parseContentDisposition(null)).toEqual({ type: "", filename: null })
+    expect(parseContentDisposition(undefined)).toEqual({
+      type: "",
+      filename: null,
+    })
+    expect(parseContentDisposition("")).toEqual({ type: "", filename: null })
+  })
+
+  test("parses a bare disposition type with no filename", () => {
+    expect(parseContentDisposition("attachment")).toEqual({
+      type: "attachment",
+      filename: null,
+    })
+    expect(parseContentDisposition("inline")).toEqual({
+      type: "inline",
+      filename: null,
+    })
+  })
+
+  test("lowercases the disposition type for consistent comparison", () => {
+    expect(parseContentDisposition("ATTACHMENT").type).toBe("attachment")
+    expect(parseContentDisposition("Attachment; filename=a.txt").type).toBe(
+      "attachment"
+    )
+  })
+
+  test("extracts an unquoted filename", () => {
+    expect(
+      parseContentDisposition("attachment; filename=report.pdf").filename
+    ).toBe("report.pdf")
+  })
+
+  test("extracts a quoted filename and strips the surrounding quotes", () => {
+    expect(
+      parseContentDisposition('attachment; filename="annual report.pdf"')
+        .filename
+    ).toBe("annual report.pdf")
+  })
+
+  test("respects backslash escapes inside a quoted filename", () => {
+    // RFC 2616 quoted-string: \" is a literal quote, \\ is a literal backslash
+    expect(
+      parseContentDisposition('attachment; filename="with\\"quote.pdf"')
+        .filename
+    ).toBe('with"quote.pdf')
+  })
+
+  test("does not split on a semicolon inside a quoted filename", () => {
+    expect(
+      parseContentDisposition('attachment; filename="a;b.txt"').filename
+    ).toBe("a;b.txt")
+  })
+
+  test("strips directory components to prevent path traversal", () => {
+    // RFC 6266 §4.3 — recipients must not treat path separators as part of
+    // the filename. Both POSIX and Windows separators need stripping.
+    expect(
+      parseContentDisposition('attachment; filename="../../etc/passwd"')
+        .filename
+    ).toBe("passwd")
+    expect(
+      parseContentDisposition('attachment; filename="C:\\\\temp\\\\x.txt"')
+        .filename
+    ).toBe("x.txt")
+  })
+
+  test("decodes an RFC 5987 UTF-8 filename", () => {
+    // Example straight out of RFC 5987 §3.2.2
+    expect(
+      parseContentDisposition(
+        "attachment; filename*=UTF-8''%E2%82%AC%20rates.txt"
+      ).filename
+    ).toBe("€ rates.txt")
+  })
+
+  test("decodes an RFC 5987 ISO-8859-1 filename", () => {
+    expect(
+      parseContentDisposition(
+        "attachment; filename*=iso-8859-1'en'%A3%20rates.txt"
+      ).filename
+    ).toBe("£ rates.txt")
+  })
+
+  test("prefers filename* over the legacy filename when both are present", () => {
+    // Clients that understand filename* are expected to use it — the legacy
+    // filename is the ASCII fallback for older UAs.
+    const header =
+      "attachment; filename=\"fallback.txt\"; filename*=UTF-8''r%C3%A9sum%C3%A9.txt"
+    expect(parseContentDisposition(header).filename).toBe("résumé.txt")
+  })
+
+  test("falls back to filename when filename* uses an unknown charset", () => {
+    const header =
+      "attachment; filename=\"fallback.txt\"; filename*=gb2312''abc.txt"
+    expect(parseContentDisposition(header).filename).toBe("fallback.txt")
+  })
+
+  test("falls back to filename when filename* has malformed percent-encoding", () => {
+    const header =
+      "attachment; filename=\"fallback.txt\"; filename*=UTF-8''%E2%82"
+    expect(parseContentDisposition(header).filename).toBe("fallback.txt")
+  })
+
+  test("tolerates extra whitespace around parameters", () => {
+    expect(
+      parseContentDisposition("attachment ;   filename = report.pdf  ").filename
+    ).toBe("report.pdf")
+  })
+
+  test("returns null filename when only unrelated parameters are present", () => {
+    expect(
+      parseContentDisposition(
+        'attachment; size=1234; creation-date="Tue, 01 Jan 2026 00:00:00 GMT"'
+      ).filename
+    ).toBeNull()
+  })
+})
+
+describe("filenameFromResponseHeaders", () => {
+  test("returns null when headers are missing or undefined", () => {
+    expect(filenameFromResponseHeaders(undefined)).toBeNull()
+    expect(filenameFromResponseHeaders(null)).toBeNull()
+    expect(filenameFromResponseHeaders([])).toBeNull()
+  })
+
+  test("finds the header regardless of case", () => {
+    expect(
+      filenameFromResponseHeaders([
+        { key: "Content-Type", value: "application/pdf" },
+        { key: "content-disposition", value: "attachment; filename=a.pdf" },
+      ])
+    ).toBe("a.pdf")
+
+    expect(
+      filenameFromResponseHeaders([
+        { key: "CONTENT-DISPOSITION", value: "attachment; filename=b.pdf" },
+      ])
+    ).toBe("b.pdf")
+  })
+
+  test("returns null when the header is present but carries no filename", () => {
+    expect(
+      filenameFromResponseHeaders([
+        { key: "Content-Disposition", value: "attachment" },
+      ])
+    ).toBeNull()
+  })
+
+  test("returns the filename for the first Content-Disposition header only", () => {
+    // Duplicate headers are unusual but legal — stick with the first hit so
+    // behaviour is deterministic.
+    expect(
+      filenameFromResponseHeaders([
+        { key: "Content-Disposition", value: "attachment; filename=a.pdf" },
+        { key: "Content-Disposition", value: "attachment; filename=b.pdf" },
+      ])
+    ).toBe("a.pdf")
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/utils/content-disposition.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/content-disposition.ts
@@ -25,6 +25,13 @@ const decodeRfc5987 = (value: string): string | null => {
   const encoded = value.slice(secondQuote + 1)
   if (!RFC5987_CHARSET_RE.test(charset)) return null
 
+  // Any `%` not followed by two hex digits means the encoding is malformed.
+  // The UTF-8 branch gets this check for free via `decodeURIComponent`, but
+  // the ISO-8859-1 branch uses `String.prototype.replace` which would
+  // silently pass bad input through, letting a broken `filename*` override
+  // an otherwise-valid `filename` fallback.
+  if (/%(?![0-9A-Fa-f]{2})/.test(encoded)) return null
+
   try {
     if (charset.toLowerCase() === "iso-8859-1") {
       // Latin-1: percent-decode bytes then map each to its Unicode codepoint
@@ -119,8 +126,14 @@ export const parseContentDisposition = (
 }
 
 /**
- * Finds the `Content-Disposition` response header and returns the filename
- * declared in its `filename*` or `filename` parameter, if any.
+ * Finds the first `Content-Disposition` response header that declares a
+ * filename (via `filename*` or `filename`) and returns it, or `null` if
+ * no such header is present.
+ *
+ * Multiple `Content-Disposition` headers on the same response are unusual
+ * but legal — we skip any that carry only a disposition type (e.g. bare
+ * `attachment`) and keep searching, so a valid filename in a later header
+ * is not silently discarded by an earlier one.
  */
 export const filenameFromResponseHeaders = (
   headers: ReadonlyArray<HoppRESTResponseHeader> | undefined | null
@@ -129,7 +142,8 @@ export const filenameFromResponseHeaders = (
 
   for (const h of headers) {
     if (h.key.toLowerCase() === "content-disposition") {
-      return parseContentDisposition(h.value).filename
+      const filename = parseContentDisposition(h.value).filename
+      if (filename !== null) return filename
     }
   }
   return null

--- a/packages/hoppscotch-common/src/helpers/utils/content-disposition.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/content-disposition.ts
@@ -1,0 +1,136 @@
+import { HoppRESTResponseHeader } from "~/helpers/types/HoppRESTResponse"
+
+export type ParsedContentDisposition = {
+  type: string
+  filename: string | null
+}
+
+// RFC 5987: filename*=charset'lang'percent-encoded-string
+// Only UTF-8 and ISO-8859-1 are defined; everything else gets rejected.
+const RFC5987_CHARSET_RE = /^(utf-8|iso-8859-1)$/i
+
+const stripPathComponents = (name: string): string => {
+  // Some servers send directory segments in the filename — RFC 6266 §4.3 says
+  // receivers MUST strip them to avoid writing outside the intended target.
+  const lastSlash = Math.max(name.lastIndexOf("/"), name.lastIndexOf("\\"))
+  return lastSlash >= 0 ? name.slice(lastSlash + 1) : name
+}
+
+const decodeRfc5987 = (value: string): string | null => {
+  const firstQuote = value.indexOf("'")
+  const secondQuote = value.indexOf("'", firstQuote + 1)
+  if (firstQuote < 0 || secondQuote < 0) return null
+
+  const charset = value.slice(0, firstQuote)
+  const encoded = value.slice(secondQuote + 1)
+  if (!RFC5987_CHARSET_RE.test(charset)) return null
+
+  try {
+    if (charset.toLowerCase() === "iso-8859-1") {
+      // Latin-1: percent-decode bytes then map each to its Unicode codepoint
+      return encoded.replace(/%([0-9A-Fa-f]{2})/g, (_, hex) =>
+        String.fromCharCode(parseInt(hex, 16))
+      )
+    }
+    return decodeURIComponent(encoded)
+  } catch {
+    return null
+  }
+}
+
+const unquote = (value: string): string => {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    // RFC 2616 quoted-string: a backslash escapes the next character
+    return value.slice(1, -1).replace(/\\(.)/g, "$1")
+  }
+  return value
+}
+
+/**
+ * Parses a Content-Disposition header value per RFC 6266.
+ *
+ * Extracts the disposition type and filename, preferring the RFC 5987
+ * `filename*` parameter (which supports non-ASCII characters) over the legacy
+ * `filename` parameter when both are present.
+ *
+ * Returns `{ type: "", filename: null }` when the header is absent or
+ * unparseable rather than throwing, so callers can fall back to their default.
+ */
+export const parseContentDisposition = (
+  header: string | null | undefined
+): ParsedContentDisposition => {
+  if (!header) return { type: "", filename: null }
+
+  // Split on the first semicolon that is not inside a quoted string.
+  // A naive `split(";")` breaks filenames containing a literal `;`.
+  const parts: string[] = []
+  let buf = ""
+  let inQuotes = false
+  let escape = false
+  for (let i = 0; i < header.length; i++) {
+    const ch = header[i]
+    if (escape) {
+      buf += ch
+      escape = false
+      continue
+    }
+    if (ch === "\\" && inQuotes) {
+      buf += ch
+      escape = true
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      buf += ch
+      continue
+    }
+    if (ch === ";" && !inQuotes) {
+      parts.push(buf)
+      buf = ""
+      continue
+    }
+    buf += ch
+  }
+  if (buf) parts.push(buf)
+
+  const type = parts.shift()?.trim().toLowerCase() ?? ""
+
+  let filename: string | null = null
+  let filenameStar: string | null = null
+
+  for (const raw of parts) {
+    const eq = raw.indexOf("=")
+    if (eq < 0) continue
+    const key = raw.slice(0, eq).trim().toLowerCase()
+    const value = raw.slice(eq + 1).trim()
+
+    if (key === "filename*" && filenameStar === null) {
+      filenameStar = decodeRfc5987(value)
+    } else if (key === "filename" && filename === null) {
+      filename = unquote(value)
+    }
+  }
+
+  const chosen = filenameStar ?? filename
+  if (!chosen) return { type, filename: null }
+
+  const sanitized = stripPathComponents(chosen).trim()
+  return { type, filename: sanitized || null }
+}
+
+/**
+ * Finds the `Content-Disposition` response header and returns the filename
+ * declared in its `filename*` or `filename` parameter, if any.
+ */
+export const filenameFromResponseHeaders = (
+  headers: ReadonlyArray<HoppRESTResponseHeader> | undefined | null
+): string | null => {
+  if (!headers) return null
+
+  for (const h of headers) {
+    if (h.key.toLowerCase() === "content-disposition") {
+      return parseContentDisposition(h.value).filename
+    }
+  }
+  return null
+}


### PR DESCRIPTION
```
## Summary

Closes #6168.

When a response sets `Content-Disposition: attachment; filename=...`, use that filename as the default suggestion in the save-file dialog instead of the request-name-derived placeholder — matching the browser and `curl -OJ` behaviour per RFC 6266.

## Changes

- Add `parseContentDisposition` / `filenameFromResponseHeaders` helpers in `helpers/utils/content-disposition.ts`, including RFC 5987 `filename*=UTF-8''...` decoding, ISO-8859-1 fallback, backslash-escape handling inside quoted strings, and path-component stripping (RFC 6266 §4.3) to prevent traversal
- Extend `useDownloadResponse` with an optional `responseHeaders` ref; the parsed filename takes precedence over the passed-in default
- Wire response headers through the Raw / JSON / XML / HTML / PDF / Image / Audio / Video lens renderers (every call site that has access to `response.headers`); the Codegen, ResponseInterface, LogEntry, and EditCookie call sites remain unchanged because the new param is optional

## Tests

New vitest suite `helpers/utils/__tests__/content-disposition.spec.ts` covers 21 cases including:

- Null / empty / bare-type headers
- Unquoted and quoted filenames
- Semicolon inside quoted filename (not treated as parameter separator)
- Backslash escapes inside quoted strings (`\"` → `"`)
- Path-component stripping for `../../etc/passwd` and Windows `C:\temp\x.txt`
- RFC 5987 UTF-8 decoding (`€ rates.txt`, `résumé.txt`)
- RFC 5987 ISO-8859-1 decoding (`£ rates.txt`)
- `filename*` preferred over `filename` when both present
- `filename` fallback when `filename*` charset is unknown (e.g. `gb2312`)
- `filename` fallback when `filename*` percent-encoding is malformed
- Case-insensitive header lookup in `filenameFromResponseHeaders`
- Deterministic behaviour when multiple `Content-Disposition` headers are present

All 21 cases pass. Also smoke-tested the parser logic against the 17 distinct spec fixtures via a standalone Node script to confirm behaviour independent of the Vue/TS toolchain.

## Type of Change

- [x] New feature

## Testing

- [x] Tests added/updated
- [x] Manually verified parser logic against RFC 6266 / RFC 5987 examples

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the `Content-Disposition` filename for download suggestions across response lenses. Matches browser and curl -OJ behavior, and safely handles encodings and path traversal. Also hardens parsing to handle malformed input and multiple headers correctly.

- **New Features**
  - Added `parseContentDisposition` and `filenameFromResponseHeaders` with RFC 5987 decoding (UTF-8, ISO-8859-1), quoted-string escapes, and path-component stripping.
  - Extended `useDownloadResponse` to accept `responseHeaders`; the parsed filename, if present, overrides the default.
  - Wired response headers through Raw, JSON, XML, HTML, PDF, Image, Audio, and Video lens renderers.

- **Bug Fixes**
  - Reject malformed RFC 5987 percent-encoding in `filename*` (including ISO-8859-1) so we fall back to `filename` when needed.
  - When multiple `Content-Disposition` headers exist, skip entries without a filename and use the first one that provides it.

<sup>Written for commit 8e91e843cdf29dd87dfbd227116f6fddf7d64d89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

