### PR TITLE
fix(common): preserve disabled state and escape special chars for urlencoded Postman body imports

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -10,6 +10,7 @@ import {
   knownContentTypes,
   makeCollection,
   makeRESTRequest,
+  rawKeyValueEntriesToString,
   ValidContentTypes,
   HoppRESTRequestResponses,
   makeHoppRESTResponseOriginalRequest,
@@ -31,7 +32,6 @@ import {
   VariableDefinition,
   VariableList,
 } from "postman-collection"
-import { stringArrayJoin } from "~/helpers/functional/array"
 import { PMRawLanguage } from "~/types/pm-coll-exts"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
@@ -409,13 +409,12 @@ const getHoppReqBody = ({
       contentType: "application/x-www-form-urlencoded",
       body: pipe(
         body.urlencoded?.all() ?? [],
-        A.map(
-          (param) =>
-            `${replacePMVarTemplating(
-              param.key ?? ""
-            )}: ${replacePMVarTemplating(String(param.value ?? ""))}`
-        ),
-        stringArrayJoin("\n")
+        A.map((param) => ({
+          active: !param.disabled,
+          key: replacePMVarTemplating(param.key ?? ""),
+          value: replacePMVarTemplating(String(param.value ?? "")),
+        })),
+        rawKeyValueEntriesToString
       ),
     }
   } else if (body.mode === "raw") {


### PR DESCRIPTION
```
## Summary

- `getHoppReqBody`'s `urlencoded` branch in `helpers/import-export/import/postman.ts` built the body string by hand as `` `${key}: ${value}` `` joined with `\n`, silently dropping `param.disabled`. Every other import path in the same file (`headers`, `params`, `formdata`) respects the disabled flag via `active: !param.disabled` — urlencoded was the outlier. A Postman collection with disabled urlencoded fields imported as if every field were enabled.
- Same path also emitted `:`, `#`, or `\n` in keys/values verbatim, so the raw key-value parser that reads the body back could treat a literal `:` in the user's key as the key/value separator or split the entry on a `\n` inside the value.

## Changes

- Construct `RawKeyValueEntry[]` with `active: !param.disabled` and run it through `rawKeyValueEntriesToString` from `@hoppscotch/data`. That helper already writes the `# ` prefix for inactive entries and applies `applyEscapeIfNeeded` (JSON-quoted escaping) when keys/values contain `SPECIAL_CHARS`.
- Drops the now-orphaned `stringArrayJoin` import from `~/helpers/functional/array` (it was only used by this branch).

## Verification

Before (Postman field `disabled: true`, `key: "foo"`, `value: "bar"`):

    foo: bar          ← imported as active

After:

    # foo: bar        ← imported as inactive, round-trips correctly

Before (Postman field `key: "x:y"`, `value: "a\nb"`):

    x:y: a
    b                 ← parser splits on literal `:` and `\n`

After:

    "x:y": "a\nb"     ← escaped, parser round-trips correctly

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Manually traced every sibling import branch in the same file to confirm the `disabled` asymmetry
- [x] Cross-checked `rawKeyValueEntriesToString` and `applyEscapeIfNeeded` in `packages/hoppscotch-data/src/rawKeyValue.ts` to confirm the escape / inactive-prefix behaviour is what we want for round-trip parsing
- [ ] No unit tests added — `helpers/import-export/import/postman.ts` has no existing test harness and `getHoppReqBody` is not exported, so a test would require bootstrapping a `postman-collection` `Item` fixture through the top-level importer. Happy to add an end-to-end test if the reviewer prefers.

## Related Issues

N/A — code review. No existing issue or PR tracks this asymmetry (verified via GitHub search).

## Checklist

- [x] Code follows project style guidelines (uses the project's own `rawKeyValueEntriesToString` helper)
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes importing of urlencoded Postman bodies by preserving disabled params and escaping special characters. Prevents accidentally sending disabled fields and avoids parsing issues with colons, hashes, and newlines.

- **Bug Fixes**
  - Build body via `rawKeyValueEntriesToString` from `@hoppscotch/data` with `active: !param.disabled`.
  - Escape keys/values with special chars and prefix inactive entries with `# ` for correct round-trip parsing.

- **Refactors**
  - Remove unused `stringArrayJoin` import.

<sup>Written for commit 7e5b53c48ed6459661a71250a2d59217819c4240. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

