### PR TITLE
feat(common): bind request tabs to workspace scope (#6102)

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod"
 
 import { Service } from "dioc"
 import { StorageLike, watchDebounced } from "@vueuse/core"
+import { computed } from "vue"
 import { assign, clone, isEmpty, cloneDeep } from "lodash-es"
 
 import {
@@ -184,22 +185,33 @@ const migrations: Migration[] = [
       const tabKeys = [STORE_KEYS.REST_TABS, STORE_KEYS.GQL_TABS]
       for (const baseKey of tabKeys) {
         const legacy = await Store.get<any>(STORE_NAMESPACE, baseKey)
-        if (E.isRight(legacy) && legacy.right) {
-          const setResult = await Store.set(
-            STORE_NAMESPACE,
-            `${baseKey}:personal`,
-            legacy.right
+        if (!E.isRight(legacy) || !legacy.right) continue
+
+        const scopedKey = `${baseKey}:personal`
+
+        // Don't clobber an existing scoped payload. A pre-release/partial
+        // rollout could have already written `restTabs:personal`; overwriting
+        // it with the legacy unscoped blob would lose the user's data.
+        const existingScoped = await Store.get<any>(STORE_NAMESPACE, scopedKey)
+        if (E.isRight(existingScoped) && existingScoped.right) {
+          await Store.remove(STORE_NAMESPACE, baseKey)
+          continue
+        }
+
+        const setResult = await Store.set(
+          STORE_NAMESPACE,
+          scopedKey,
+          legacy.right
+        )
+        // Only remove the legacy key after the scoped write succeeds;
+        // otherwise an interrupted migration would lose the user's tabs.
+        if (E.isRight(setResult)) {
+          await Store.remove(STORE_NAMESPACE, baseKey)
+        } else {
+          console.error(
+            `Migration v2 failed to write ${scopedKey}; keeping legacy key`,
+            setResult.left
           )
-          // Only remove the legacy key after the scoped write succeeds;
-          // otherwise an interrupted migration would lose the user's tabs.
-          if (E.isRight(setResult)) {
-            await Store.remove(STORE_NAMESPACE, baseKey)
-          } else {
-            console.error(
-              `Migration v2 failed to write ${baseKey}:personal; keeping legacy key`,
-              setResult.left
-            )
-          }
         }
       }
     },
@@ -1013,12 +1025,19 @@ export class PersistenceService extends Service {
     return `${baseKey}:${scopeKey}`
   }
 
+  private scopedBackupKey(baseKey: string, scopeKey: string): string {
+    return `${baseKey}:${scopeKey}-backup`
+  }
+
   // Schema-validate raw REST tab state and apply it to the tab service.
-  // On validation failure, shows a toast, writes a `-backup` key, and falls
-  // back to loading the raw state to match legacy behavior. Returns true if
-  // any state was applied (even via the legacy fallback), false if the data
-  // was unparseable.
-  private async applyRESTTabsPersistedState(raw: any): Promise<boolean> {
+  // On validation failure, shows a toast, writes a scoped `-backup` key, and
+  // falls back to loading the raw state to match legacy behavior. Returns
+  // true if any state was applied (even via the legacy fallback), false if
+  // the data was unparseable.
+  private async applyRESTTabsPersistedState(
+    raw: any,
+    scopeKey: string
+  ): Promise<boolean> {
     try {
       const orderedDocs = fixBrokenRequestVersion(
         cloneDeep(raw.orderedDocs) ?? []
@@ -1032,7 +1051,11 @@ export class PersistenceService extends Service {
         return true
       }
       this.showErrorToast(STORE_KEYS.REST_TABS)
-      await Store.set(STORE_NAMESPACE, `${STORE_KEYS.REST_TABS}-backup`, raw)
+      await Store.set(
+        STORE_NAMESPACE,
+        this.scopedBackupKey(STORE_KEYS.REST_TABS, scopeKey),
+        raw
+      )
       console.error(`Failed parsing persisted REST_TABS:`, JSON.stringify(raw))
       // NOTE: Still loading data to match legacy behavior
       this.restTabService.loadTabsFromPersistedState(raw)
@@ -1043,7 +1066,10 @@ export class PersistenceService extends Service {
     }
   }
 
-  private async applyGQLTabsPersistedState(raw: any): Promise<boolean> {
+  private async applyGQLTabsPersistedState(
+    raw: any,
+    scopeKey: string
+  ): Promise<boolean> {
     try {
       const result = GQL_TAB_STATE_SCHEMA.safeParse(raw)
       if (result.success) {
@@ -1053,7 +1079,11 @@ export class PersistenceService extends Service {
         return true
       }
       this.showErrorToast(STORE_KEYS.GQL_TABS)
-      await Store.set(STORE_NAMESPACE, `${STORE_KEYS.GQL_TABS}-backup`, raw)
+      await Store.set(
+        STORE_NAMESPACE,
+        this.scopedBackupKey(STORE_KEYS.GQL_TABS, scopeKey),
+        raw
+      )
       console.error(`Failed parsing persisted GQL_TABS:`, JSON.stringify(raw))
       // NOTE: Still loading data to match legacy behavior
       this.gqlTabService.loadTabsFromPersistedState(raw)
@@ -1072,19 +1102,23 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      await this.applyRESTTabsPersistedState(loadResult.right)
+      await this.applyRESTTabsPersistedState(loadResult.right, scopeKey)
     }
 
+    // Pair the scope key with the state so the scope captured at change time
+    // wins, not the scope at flush time. Otherwise a workspace switch during
+    // the debounce window writes the old scope's state under the new scope's
+    // key, reintroducing cross-workspace tab leakage.
     watchDebounced(
-      this.restTabService.persistableTabState,
-      async (newData) => {
+      computed(() => ({
+        scopeKey: this.restTabService.currentScopeKey.value,
+        state: this.restTabService.persistableTabState.value,
+      })),
+      async ({ scopeKey, state }) => {
         await Store.set(
           STORE_NAMESPACE,
-          this.scopedStoreKey(
-            STORE_KEYS.REST_TABS,
-            this.restTabService.currentScopeKey.value
-          ),
-          newData
+          this.scopedStoreKey(STORE_KEYS.REST_TABS, scopeKey),
+          state
         )
       },
       { debounce: 500, deep: true }
@@ -1099,19 +1133,19 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      await this.applyGQLTabsPersistedState(loadResult.right)
+      await this.applyGQLTabsPersistedState(loadResult.right, scopeKey)
     }
 
     watchDebounced(
-      this.gqlTabService.persistableTabState,
-      async (newData) => {
+      computed(() => ({
+        scopeKey: this.gqlTabService.currentScopeKey.value,
+        state: this.gqlTabService.persistableTabState.value,
+      })),
+      async ({ scopeKey, state }) => {
         await Store.set(
           STORE_NAMESPACE,
-          this.scopedStoreKey(
-            STORE_KEYS.GQL_TABS,
-            this.gqlTabService.currentScopeKey.value
-          ),
-          newData
+          this.scopedStoreKey(STORE_KEYS.GQL_TABS, scopeKey),
+          state
         )
       },
       { debounce: 500, deep: true }
@@ -1149,7 +1183,10 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      const applied = await this.applyRESTTabsPersistedState(loadResult.right)
+      const applied = await this.applyRESTTabsPersistedState(
+        loadResult.right,
+        newScopeKey
+      )
       if (applied) return
     }
 
@@ -1174,7 +1211,10 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      const applied = await this.applyGQLTabsPersistedState(loadResult.right)
+      const applied = await this.applyGQLTabsPersistedState(
+        loadResult.right,
+        newScopeKey
+      )
       if (applied) return
     }
 

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -185,8 +185,21 @@ const migrations: Migration[] = [
       for (const baseKey of tabKeys) {
         const legacy = await Store.get<any>(STORE_NAMESPACE, baseKey)
         if (E.isRight(legacy) && legacy.right) {
-          await Store.set(STORE_NAMESPACE, `${baseKey}:personal`, legacy.right)
-          await Store.remove(STORE_NAMESPACE, baseKey)
+          const setResult = await Store.set(
+            STORE_NAMESPACE,
+            `${baseKey}:personal`,
+            legacy.right
+          )
+          // Only remove the legacy key after the scoped write succeeds;
+          // otherwise an interrupted migration would lose the user's tabs.
+          if (E.isRight(setResult)) {
+            await Store.remove(STORE_NAMESPACE, baseKey)
+          } else {
+            console.error(
+              `Migration v2 failed to write ${baseKey}:personal; keeping legacy key`,
+              setResult.left
+            )
+          }
         }
       }
     },
@@ -1000,6 +1013,57 @@ export class PersistenceService extends Service {
     return `${baseKey}:${scopeKey}`
   }
 
+  // Schema-validate raw REST tab state and apply it to the tab service.
+  // On validation failure, shows a toast, writes a `-backup` key, and falls
+  // back to loading the raw state to match legacy behavior. Returns true if
+  // any state was applied (even via the legacy fallback), false if the data
+  // was unparseable.
+  private async applyRESTTabsPersistedState(raw: any): Promise<boolean> {
+    try {
+      const orderedDocs = fixBrokenRequestVersion(
+        cloneDeep(raw.orderedDocs) ?? []
+      )
+      const transformedTabs = { ...raw, orderedDocs }
+      const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
+      if (result.success) {
+        this.restTabService.loadTabsFromPersistedState(
+          result.data as PersistableTabState<HoppTabDocument>
+        )
+        return true
+      }
+      this.showErrorToast(STORE_KEYS.REST_TABS)
+      await Store.set(STORE_NAMESPACE, `${STORE_KEYS.REST_TABS}-backup`, raw)
+      console.error(`Failed parsing persisted REST_TABS:`, JSON.stringify(raw))
+      // NOTE: Still loading data to match legacy behavior
+      this.restTabService.loadTabsFromPersistedState(raw)
+      return true
+    } catch (_e) {
+      console.error(`Failed parsing persisted REST_TABS:`, raw)
+      return false
+    }
+  }
+
+  private async applyGQLTabsPersistedState(raw: any): Promise<boolean> {
+    try {
+      const result = GQL_TAB_STATE_SCHEMA.safeParse(raw)
+      if (result.success) {
+        this.gqlTabService.loadTabsFromPersistedState(
+          result.data as PersistableTabState<HoppGQLDocument>
+        )
+        return true
+      }
+      this.showErrorToast(STORE_KEYS.GQL_TABS)
+      await Store.set(STORE_NAMESPACE, `${STORE_KEYS.GQL_TABS}-backup`, raw)
+      console.error(`Failed parsing persisted GQL_TABS:`, JSON.stringify(raw))
+      // NOTE: Still loading data to match legacy behavior
+      this.gqlTabService.loadTabsFromPersistedState(raw)
+      return true
+    } catch (_e) {
+      console.error(`Failed parsing persisted GQL_TABS:`, raw)
+      return false
+    }
+  }
+
   private async setupRESTTabsPersistence() {
     const scopeKey = this.restTabService.currentScopeKey.value
     const loadResult = await Store.get<any>(
@@ -1007,40 +1071,8 @@ export class PersistenceService extends Service {
       this.scopedStoreKey(STORE_KEYS.REST_TABS, scopeKey)
     )
 
-    try {
-      if (E.isRight(loadResult) && loadResult.right) {
-        // Correcting the request schema for broken data
-        const orderedDocs = fixBrokenRequestVersion(
-          cloneDeep(loadResult.right.orderedDocs) ?? []
-        )
-
-        const transformedTabs = {
-          ...loadResult.right,
-          orderedDocs,
-        }
-        const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
-        if (result.success) {
-          // SAFETY: We know the schema matches
-          this.restTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppTabDocument>
-          )
-        } else {
-          this.showErrorToast(STORE_KEYS.REST_TABS)
-          await Store.set(
-            STORE_NAMESPACE,
-            `${STORE_KEYS.REST_TABS}-backup`,
-            loadResult.right
-          )
-          console.error(
-            `Failed parsing persisted REST_TABS:`,
-            JSON.stringify(loadResult.right)
-          )
-          // NOTE: Still loading data to match legacy behavior
-          this.restTabService.loadTabsFromPersistedState(loadResult.right)
-        }
-      }
-    } catch (_e) {
-      console.error(`Failed parsing persisted REST_TABS:`, loadResult)
+    if (E.isRight(loadResult) && loadResult.right) {
+      await this.applyRESTTabsPersistedState(loadResult.right)
     }
 
     watchDebounced(
@@ -1066,32 +1098,8 @@ export class PersistenceService extends Service {
       this.scopedStoreKey(STORE_KEYS.GQL_TABS, scopeKey)
     )
 
-    try {
-      if (E.isRight(loadResult) && loadResult.right) {
-        const result = GQL_TAB_STATE_SCHEMA.safeParse(loadResult.right)
-
-        if (result.success) {
-          // SAFETY: We know the schema matches
-          this.gqlTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppGQLDocument>
-          )
-        } else {
-          this.showErrorToast(STORE_KEYS.GQL_TABS)
-          await Store.set(
-            STORE_NAMESPACE,
-            `${STORE_KEYS.GQL_TABS}-backup`,
-            loadResult.right
-          )
-          console.error(
-            `Failed parsing persisted GQL_TABS:`,
-            JSON.stringify(loadResult.right)
-          )
-          // NOTE: Still loading data to match legacy behavior
-          this.gqlTabService.loadTabsFromPersistedState(loadResult.right)
-        }
-      }
-    } catch (_e) {
-      console.error(`Failed parsing persisted GQL_TABS:`, loadResult)
+    if (E.isRight(loadResult) && loadResult.right) {
+      await this.applyGQLTabsPersistedState(loadResult.right)
     }
 
     watchDebounced(
@@ -1141,27 +1149,8 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      try {
-        const orderedDocs = fixBrokenRequestVersion(
-          cloneDeep(loadResult.right.orderedDocs) ?? []
-        )
-        const transformedTabs = { ...loadResult.right, orderedDocs }
-        const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
-        if (result.success) {
-          this.restTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppTabDocument>
-          )
-          return
-        }
-        // NOTE: Fallback to legacy behavior on schema mismatch
-        this.restTabService.loadTabsFromPersistedState(loadResult.right)
-        return
-      } catch (_e) {
-        console.error(
-          `Failed parsing persisted REST_TABS for scope ${newScopeKey}:`,
-          loadResult
-        )
-      }
+      const applied = await this.applyRESTTabsPersistedState(loadResult.right)
+      if (applied) return
     }
 
     this.restTabService.resetToDefault()
@@ -1185,22 +1174,8 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      try {
-        const result = GQL_TAB_STATE_SCHEMA.safeParse(loadResult.right)
-        if (result.success) {
-          this.gqlTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppGQLDocument>
-          )
-          return
-        }
-        this.gqlTabService.loadTabsFromPersistedState(loadResult.right)
-        return
-      } catch (_e) {
-        console.error(
-          `Failed parsing persisted GQL_TABS for scope ${newScopeKey}:`,
-          loadResult
-        )
-      }
+      const applied = await this.applyGQLTabsPersistedState(loadResult.right)
+      if (applied) return
     }
 
     this.gqlTabService.resetToDefault()
@@ -1280,7 +1255,10 @@ export class PersistenceService extends Service {
     baseKey: (typeof STORE_KEYS)[keyof typeof STORE_KEYS],
     scopeKey: string
   ): Promise<T | null> {
-    const r = await Store.get<T>(STORE_NAMESPACE, `${baseKey}:${scopeKey}`)
+    const r = await Store.get<T>(
+      STORE_NAMESPACE,
+      this.scopedStoreKey(baseKey, scopeKey)
+    )
 
     if (E.isLeft(r)) return null
 

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -1102,7 +1102,11 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      await this.applyRESTTabsPersistedState(loadResult.right, scopeKey)
+      const applied = await this.applyRESTTabsPersistedState(
+        loadResult.right,
+        scopeKey
+      )
+      if (!applied) this.restTabService.resetToDefault()
     }
 
     // Pair the scope key with the state so the scope captured at change time
@@ -1133,7 +1137,11 @@ export class PersistenceService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      await this.applyGQLTabsPersistedState(loadResult.right, scopeKey)
+      const applied = await this.applyGQLTabsPersistedState(
+        loadResult.right,
+        scopeKey
+      )
+      if (!applied) this.gqlTabService.resetToDefault()
     }
 
     watchDebounced(

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -176,6 +176,21 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    // Moves legacy unscoped tab state (shared across workspaces) into the
+    // personal workspace scope so each workspace can own its own tab set.
+    version: 2,
+    migrate: async () => {
+      const tabKeys = [STORE_KEYS.REST_TABS, STORE_KEYS.GQL_TABS]
+      for (const baseKey of tabKeys) {
+        const legacy = await Store.get<any>(STORE_NAMESPACE, baseKey)
+        if (E.isRight(legacy) && legacy.right) {
+          await Store.set(STORE_NAMESPACE, `${baseKey}:personal`, legacy.right)
+          await Store.remove(STORE_NAMESPACE, baseKey)
+        }
+      }
+    },
+  },
 ]
 
 /**
@@ -235,7 +250,7 @@ export class PersistenceService extends Service {
     )
     const perhapsVersion = E.isRight(versionResult) ? versionResult.right : "0"
     const currentVersion = perhapsVersion ?? "0"
-    const targetVersion = "1"
+    const targetVersion = "2"
 
     if (currentVersion !== targetVersion) {
       for (const migration of migrations) {
@@ -981,10 +996,15 @@ export class PersistenceService extends Service {
     })
   }
 
+  private scopedStoreKey(baseKey: string, scopeKey: string): string {
+    return `${baseKey}:${scopeKey}`
+  }
+
   private async setupRESTTabsPersistence() {
+    const scopeKey = this.restTabService.currentScopeKey.value
     const loadResult = await Store.get<any>(
       STORE_NAMESPACE,
-      STORE_KEYS.REST_TABS
+      this.scopedStoreKey(STORE_KEYS.REST_TABS, scopeKey)
     )
 
     try {
@@ -1026,16 +1046,24 @@ export class PersistenceService extends Service {
     watchDebounced(
       this.restTabService.persistableTabState,
       async (newData) => {
-        await Store.set(STORE_NAMESPACE, STORE_KEYS.REST_TABS, newData)
+        await Store.set(
+          STORE_NAMESPACE,
+          this.scopedStoreKey(
+            STORE_KEYS.REST_TABS,
+            this.restTabService.currentScopeKey.value
+          ),
+          newData
+        )
       },
       { debounce: 500, deep: true }
     )
   }
 
   private async setupGQLTabsPersistence() {
+    const scopeKey = this.gqlTabService.currentScopeKey.value
     const loadResult = await Store.get<any>(
       STORE_NAMESPACE,
-      STORE_KEYS.GQL_TABS
+      this.scopedStoreKey(STORE_KEYS.GQL_TABS, scopeKey)
     )
 
     try {
@@ -1069,10 +1097,113 @@ export class PersistenceService extends Service {
     watchDebounced(
       this.gqlTabService.persistableTabState,
       async (newData) => {
-        await Store.set(STORE_NAMESPACE, STORE_KEYS.GQL_TABS, newData)
+        await Store.set(
+          STORE_NAMESPACE,
+          this.scopedStoreKey(
+            STORE_KEYS.GQL_TABS,
+            this.gqlTabService.currentScopeKey.value
+          ),
+          newData
+        )
       },
       { debounce: 500, deep: true }
     )
+  }
+
+  /**
+   * Switches REST + GraphQL tab persistence to the given workspace scope.
+   * Flushes the current in-memory state to the old scope's key, then loads the
+   * new scope's state (or resets to a default tab if the new scope is empty).
+   */
+  public async switchTabsScope(newScopeKey: string): Promise<void> {
+    await Promise.all([
+      this.switchRESTTabsScope(newScopeKey),
+      this.switchGQLTabsScope(newScopeKey),
+    ])
+  }
+
+  private async switchRESTTabsScope(newScopeKey: string): Promise<void> {
+    const oldScopeKey = this.restTabService.currentScopeKey.value
+    if (oldScopeKey === newScopeKey) return
+
+    // Flush current state to the old scope
+    await Store.set(
+      STORE_NAMESPACE,
+      this.scopedStoreKey(STORE_KEYS.REST_TABS, oldScopeKey),
+      this.restTabService.persistableTabState.value
+    )
+
+    this.restTabService.currentScopeKey.value = newScopeKey
+
+    const loadResult = await Store.get<any>(
+      STORE_NAMESPACE,
+      this.scopedStoreKey(STORE_KEYS.REST_TABS, newScopeKey)
+    )
+
+    if (E.isRight(loadResult) && loadResult.right) {
+      try {
+        const orderedDocs = fixBrokenRequestVersion(
+          cloneDeep(loadResult.right.orderedDocs) ?? []
+        )
+        const transformedTabs = { ...loadResult.right, orderedDocs }
+        const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
+        if (result.success) {
+          this.restTabService.loadTabsFromPersistedState(
+            result.data as PersistableTabState<HoppTabDocument>
+          )
+          return
+        }
+        // NOTE: Fallback to legacy behavior on schema mismatch
+        this.restTabService.loadTabsFromPersistedState(loadResult.right)
+        return
+      } catch (_e) {
+        console.error(
+          `Failed parsing persisted REST_TABS for scope ${newScopeKey}:`,
+          loadResult
+        )
+      }
+    }
+
+    this.restTabService.resetToDefault()
+  }
+
+  private async switchGQLTabsScope(newScopeKey: string): Promise<void> {
+    const oldScopeKey = this.gqlTabService.currentScopeKey.value
+    if (oldScopeKey === newScopeKey) return
+
+    await Store.set(
+      STORE_NAMESPACE,
+      this.scopedStoreKey(STORE_KEYS.GQL_TABS, oldScopeKey),
+      this.gqlTabService.persistableTabState.value
+    )
+
+    this.gqlTabService.currentScopeKey.value = newScopeKey
+
+    const loadResult = await Store.get<any>(
+      STORE_NAMESPACE,
+      this.scopedStoreKey(STORE_KEYS.GQL_TABS, newScopeKey)
+    )
+
+    if (E.isRight(loadResult) && loadResult.right) {
+      try {
+        const result = GQL_TAB_STATE_SCHEMA.safeParse(loadResult.right)
+        if (result.success) {
+          this.gqlTabService.loadTabsFromPersistedState(
+            result.data as PersistableTabState<HoppGQLDocument>
+          )
+          return
+        }
+        this.gqlTabService.loadTabsFromPersistedState(loadResult.right)
+        return
+      } catch (_e) {
+        console.error(
+          `Failed parsing persisted GQL_TABS for scope ${newScopeKey}:`,
+          loadResult
+        )
+      }
+    }
+
+    this.gqlTabService.resetToDefault()
   }
 
   public async setupFirst() {
@@ -1136,6 +1267,20 @@ export class PersistenceService extends Service {
     key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
   ): Promise<T | null> {
     const r = await Store.get<T>(STORE_NAMESPACE, key)
+
+    if (E.isLeft(r)) return null
+
+    return r.right ?? null
+  }
+
+  /**
+   * Like getNullable, but reads from a workspace-scoped key composed of `baseKey:scopeKey`.
+   */
+  public async getScopedNullable<T>(
+    baseKey: (typeof STORE_KEYS)[keyof typeof STORE_KEYS],
+    scopeKey: string
+  ): Promise<T | null> {
+    const r = await Store.get<T>(STORE_NAMESPACE, `${baseKey}:${scopeKey}`)
 
     if (E.isLeft(r)) return null
 

--- a/packages/hoppscotch-common/src/services/tab/__tests__/tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/tab.service.spec.ts
@@ -24,6 +24,17 @@ class MockTabService extends TabService<{ request: string }> {
     this.watchCurrentTabID()
   }
 
+  protected createDefaultTab() {
+    return {
+      id: "test",
+      document: { request: "test request" },
+    }
+  }
+
+  protected async loadPersistedState() {
+    return null
+  }
+
   public getMRUOrder(): string[] {
     return [...this.mruOrder]
   }

--- a/packages/hoppscotch-common/src/services/tab/graphql.ts
+++ b/packages/hoppscotch-common/src/services/tab/graphql.ts
@@ -6,7 +6,7 @@ import { computed } from "vue"
 import { Container } from "dioc"
 import { getService } from "~/modules/dioc"
 import { PersistenceService, STORE_KEYS } from "../persistence"
-import { PersistableTabState } from "."
+import { HoppTab, PersistableTabState } from "."
 
 export class GQLTabService extends TabService<HoppGQLDocument> {
   public static readonly ID = "GQL_TAB_SERVICE"
@@ -16,7 +16,14 @@ export class GQLTabService extends TabService<HoppGQLDocument> {
   constructor(c: Container) {
     super(c)
 
-    this.tabMap.set("test", {
+    const defaultTab = this.createDefaultTab()
+    this.tabMap.set(defaultTab.id, defaultTab)
+
+    this.watchCurrentTabID()
+  }
+
+  protected createDefaultTab(): HoppTab<HoppGQLDocument> {
+    return {
       id: "test",
       document: {
         request: getDefaultGQLRequest(),
@@ -24,9 +31,7 @@ export class GQLTabService extends TabService<HoppGQLDocument> {
         optionTabPreference: "query",
         cursorPosition: 0,
       },
-    })
-
-    this.watchCurrentTabID()
+    }
   }
 
   // override persistableTabState to remove response from the document
@@ -46,9 +51,9 @@ export class GQLTabService extends TabService<HoppGQLDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppGQLDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getNullable<
+    const savedState = await persistenceService.getScopedNullable<
       PersistableTabState<HoppGQLDocument>
-    >(STORE_KEYS.GQL_TABS)
+    >(STORE_KEYS.GQL_TABS, this.currentScopeKey.value)
     return savedState
   }
 

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -5,7 +5,7 @@ import { HoppRESTSaveContext, HoppTabDocument } from "~/helpers/rest/document"
 import { getService } from "~/modules/dioc"
 import { PersistenceService, STORE_KEYS } from "../persistence"
 import { TabService } from "./tab"
-import { PersistableTabState } from "."
+import { HoppTab, PersistableTabState } from "."
 
 export class RESTTabService extends TabService<HoppTabDocument> {
   public static readonly ID = "REST_TAB_SERVICE"
@@ -15,7 +15,14 @@ export class RESTTabService extends TabService<HoppTabDocument> {
   constructor(c: Container) {
     super(c)
 
-    this.tabMap.set("test", {
+    const defaultTab = this.createDefaultTab()
+    this.tabMap.set(defaultTab.id, defaultTab)
+
+    this.watchCurrentTabID()
+  }
+
+  protected createDefaultTab(): HoppTab<HoppTabDocument> {
+    return {
       id: "test",
       document: {
         type: "request",
@@ -23,9 +30,7 @@ export class RESTTabService extends TabService<HoppTabDocument> {
         isDirty: false,
         optionTabPreference: "params",
       },
-    })
-
-    this.watchCurrentTabID()
+    }
   }
 
   // override persistableTabState to remove response from the document
@@ -64,9 +69,9 @@ export class RESTTabService extends TabService<HoppTabDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppTabDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getNullable<
+    const savedState = await persistenceService.getScopedNullable<
       PersistableTabState<HoppTabDocument>
-    >(STORE_KEYS.REST_TABS)
+    >(STORE_KEYS.REST_TABS, this.currentScopeKey.value)
     return savedState
   }
 

--- a/packages/hoppscotch-common/src/services/tab/tab.ts
+++ b/packages/hoppscotch-common/src/services/tab/tab.ts
@@ -28,6 +28,10 @@ export abstract class TabService<Doc>
   protected recentlyClosedTabs: Array<{ tab: HoppTab<Doc>; index: number }> = []
   protected readonly MAX_CLOSED_TABS_HISTORY = 10
 
+  // Identifies the currently-active workspace scope for tab persistence.
+  // Defaults to "personal"; updated to "team:<teamID>" when switching to a team workspace.
+  public currentScopeKey = ref<string>("personal")
+
   // MRU (Most Recently Used) tracking
   // mruOrder[0] is the most recently used tab, mruOrder[n-1] is the least recently used
   protected mruOrder: string[] = ["test"]
@@ -75,6 +79,22 @@ export abstract class TabService<Doc>
   }
 
   protected abstract loadPersistedState(): Promise<PersistableTabState<Doc> | null>
+
+  protected abstract createDefaultTab(): HoppTab<Doc>
+
+  public resetToDefault(): void {
+    this.tabMap.clear()
+    this.tabOrdering.value = []
+    this.mruOrder = []
+    this.mruNavigationIndex = -1
+    this.recentlyClosedTabs = []
+
+    const defaultTab = this.createDefaultTab()
+    this.tabMap.set(defaultTab.id, defaultTab)
+    this.tabOrdering.value.push(defaultTab.id)
+    this.currentTabID.value = defaultTab.id
+    this.mruOrder.push(defaultTab.id)
+  }
 
   public createNewTab(document: Doc, switchToIt = true): HoppTab<Doc> {
     const id = this.generateNewTabID()

--- a/packages/hoppscotch-common/src/services/tab/tab.ts
+++ b/packages/hoppscotch-common/src/services/tab/tab.ts
@@ -144,6 +144,9 @@ export abstract class TabService<Doc>
       this.tabOrdering.value = []
       this.mruOrder = []
       this.mruNavigationIndex = -1
+      // Clear recently-closed history so "Reopen Closed Tab" cannot revive
+      // tabs from a previous workspace after a scope switch.
+      this.recentlyClosedTabs = []
 
       for (const doc of data.orderedDocs) {
         this.tabMap.set(doc.tabID, {

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -33,7 +33,11 @@ export type Workspace = PersonalWorkspace | TeamWorkspace
  * team workspaces are keyed by team ID.
  */
 export function scopeKeyForWorkspace(workspace: Workspace): string {
-  return workspace.type === "team" ? `team:${workspace.teamID}` : "personal"
+  // Treat an empty teamID as personal so it can't produce a degenerate
+  // `team:` scope key (matches the empty-teamID fallback in setupWorkspaceSync).
+  return workspace.type === "team" && workspace.teamID
+    ? `team:${workspace.teamID}`
+    : "personal"
 }
 
 export type WorkspaceServiceEvent = {

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -147,6 +147,20 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
           return
         }
 
+        // Scope tab state to the new workspace first — independent of auth
+        // and network. Keeping this outside the doc-fetch try/catch ensures
+        // tab state always stays consistent with the displayed workspace
+        // even if auth wait or doc fetches fail.
+        if (!this.areWorkspacesEqual(newWorkspace, oldWorkspace)) {
+          try {
+            await this.persistenceService.switchTabsScope(
+              scopeKeyForWorkspace(newWorkspace)
+            )
+          } catch (error) {
+            console.error("Failed to switch tab scope:", error)
+          }
+        }
+
         try {
           // Ensure authentication is ready before fetching docs
           if (user) {
@@ -167,14 +181,6 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
             if (user) {
               await this.documentationService.fetchUserPublishedDocs()
             }
-          }
-
-          // Scope tab state to the new workspace so tabs from one workspace
-          // don't leak into another.
-          if (!this.areWorkspacesEqual(newWorkspace, oldWorkspace)) {
-            await this.persistenceService.switchTabsScope(
-              scopeKeyForWorkspace(newWorkspace)
-            )
           }
         } catch (error) {
           console.error("Failed to sync workspace data:", error)

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -8,6 +8,7 @@ import { min } from "lodash-es"
 import { TeamAccessRole } from "~/helpers/backend/graphql"
 import { TeamCollectionsService } from "./team-collection.service"
 import { DocumentationService } from "./documentation.service"
+import { PersistenceService } from "./persistence"
 
 /**
  * Defines a workspace and its information
@@ -25,6 +26,15 @@ export type TeamWorkspace = {
 }
 
 export type Workspace = PersonalWorkspace | TeamWorkspace
+
+/**
+ * Derives a stable key that identifies a workspace for per-workspace
+ * persistence (e.g., tab state). Personal workspaces share a single key;
+ * team workspaces are keyed by team ID.
+ */
+export function scopeKeyForWorkspace(workspace: Workspace): string {
+  return workspace.type === "team" ? `team:${workspace.teamID}` : "personal"
+}
 
 export type WorkspaceServiceEvent = {
   type: "managed-team-list-adapter-polled"
@@ -49,6 +59,7 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
 
   private teamCollectionService = this.bind(TeamCollectionsService)
   private documentationService = this.bind(DocumentationService)
+  private persistenceService = this.bind(PersistenceService)
 
   private currentUser = useStreamStatic(
     platform.auth.getCurrentUserStream(),
@@ -152,6 +163,14 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
             if (user) {
               await this.documentationService.fetchUserPublishedDocs()
             }
+          }
+
+          // Scope tab state to the new workspace so tabs from one workspace
+          // don't leak into another.
+          if (!this.areWorkspacesEqual(newWorkspace, oldWorkspace)) {
+            await this.persistenceService.switchTabsScope(
+              scopeKeyForWorkspace(newWorkspace)
+            )
           }
         } catch (error) {
           console.error("Failed to sync workspace data:", error)


### PR DESCRIPTION
Closes #6102

Request tabs were persisted under a single shared key, so open tabs from one workspace stayed visible when switching to another. This PR scopes REST and GraphQL tab state per workspace (Option 2 —hibernate/restore from the issue), so each workspace owns its own tab set and switching hibernates the old scope and restores the new.

I added reproducing videos at the issue ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes REST and GraphQL request tabs to the active workspace. Switching workspaces hibernates the old tabs and restores the new workspace’s tabs immediately to prevent leakage and UI mismatches (Option 2 from #6102), and resets to a default tab when persisted state is unparseable.

- **New Features**
  - Per-workspace tab keys (`personal`, `team:<id>`).
  - Hibernate/restore on switch; flushes old scope, clears recently closed, and falls back to a default tab if none or load fails; tab scope switches before auth/doc sync to keep tabs consistent.
  - Safer persistence and migration: v2 moves legacy unscoped tabs to `personal`; schema-validated loads with scoped `-backup` on errors; debounced writes pair state with the active scope to avoid cross-scope races.

<sup>Written for commit 347a7f6a6f6d08882e6d4a6068229102d02b73b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

