### PR TITLE
feat(common): Allow editting Collection variables through the modal

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -61,6 +61,7 @@
             v-model="editableCollection.variables"
             :inherited-properties="editingProperties.inheritedProperties"
             :has-team-write-access="hasTeamWriteAccess"
+            :variable-to-focus="variableToFocus"
           />
         </HoppSmartTab>
 
@@ -184,12 +185,14 @@ const props = withDefaults(
     modelValue: string
     showDetails?: boolean
     hasTeamWriteAccess?: boolean
+    variableToFocus?: { name: string; isSecret: boolean } | null
   }>(),
   {
     show: false,
     loadingState: false,
     showDetails: false,
     hasTeamWriteAccess: true,
+    variableToFocus: null,
   }
 )
 

--- a/packages/hoppscotch-common/src/components/collections/Variables.vue
+++ b/packages/hoppscotch-common/src/components/collections/Variables.vue
@@ -116,11 +116,7 @@
               >
                 <input
                   v-model="env.key"
-                  v-focus="
-                    variableToFocus?.name === env.key &&
-                    !!variableToFocus?.isSecret === !!env.secret &&
-                    !variableToFocus?.isSecret
-                  "
+                  v-focus="false"
                   class="flex flex-1 bg-transparent px-4 py-2 text-secondaryDark"
                   :placeholder="`${t('count.variable', {
                     count: index + 1,
@@ -166,7 +162,7 @@
                       variableToFocus?.name === env.key &&
                       !!variableToFocus?.isSecret === !!env.secret
                     "
-                    :select-text-on-mount="variableToFocus?.name === env.key"
+                    :cursor-at-end-on-mount="variableToFocus?.name === env.key"
                   />
                   <HoppButtonSecondary
                     v-tippy="{ theme: 'tooltip' }"
@@ -208,7 +204,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconCopyRight from "~icons/lucide/clipboard-paste"
 import IconCopyLeft from "~icons/lucide/clipboard-copy"
 import IconMoreVertical from "~icons/lucide/more-vertical"
-import { computed, ComputedRef, Ref, ref, watch, nextTick } from "vue"
+import { computed, ComputedRef, Ref, ref, watch } from "vue"
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { useColorMode } from "~/composables/theming"
@@ -340,18 +336,6 @@ watch(
       } else {
         selectedEnvOption.value = "variables"
       }
-
-      nextTick(() => {
-        const index = vars.value.findIndex(
-          (v) => v.key === focusInfo.name && !!v.secret === !!focusInfo.isSecret
-        )
-        if (index !== -1) {
-          const el = document.getElementsByName("variable" + index)[0]
-          if (el instanceof HTMLInputElement) {
-            el.focus()
-          }
-        }
-      })
     }
   },
   { immediate: true }

--- a/packages/hoppscotch-common/src/components/collections/Variables.vue
+++ b/packages/hoppscotch-common/src/components/collections/Variables.vue
@@ -116,7 +116,11 @@
               >
                 <input
                   v-model="env.key"
-                  v-focus
+                  v-focus="
+                    variableToFocus?.name === env.key &&
+                    !!variableToFocus?.isSecret === !!env.secret &&
+                    !variableToFocus?.isSecret
+                  "
                   class="flex flex-1 bg-transparent px-4 py-2 text-secondaryDark"
                   :placeholder="`${t('count.variable', {
                     count: index + 1,
@@ -158,6 +162,11 @@
                     :auto-complete-env="true"
                     :name="'currentValue' + index"
                     :secret="tab.isSecret"
+                    :focus="
+                      variableToFocus?.name === env.key &&
+                      !!variableToFocus?.isSecret === !!env.secret
+                    "
+                    :select-text-on-mount="variableToFocus?.name === env.key"
                   />
                   <HoppButtonSecondary
                     v-tippy="{ theme: 'tooltip' }"
@@ -199,7 +208,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconCopyRight from "~icons/lucide/clipboard-paste"
 import IconCopyLeft from "~icons/lucide/clipboard-copy"
 import IconMoreVertical from "~icons/lucide/more-vertical"
-import { computed, ComputedRef, Ref, ref } from "vue"
+import { computed, ComputedRef, Ref, ref, watch, nextTick } from "vue"
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { useColorMode } from "~/composables/theming"
@@ -223,6 +232,7 @@ const props = defineProps<{
   modelValue: HoppCollectionVariable[]
   inheritedProperties?: HoppInheritedProperty
   hasTeamWriteAccess: boolean
+  variableToFocus?: { name: string; isSecret: boolean } | null
 }>()
 
 type SelectedEnv = "variables" | "secret"
@@ -320,4 +330,30 @@ const clearContent = () => {
 const removeEnvironmentVariable = (index: number) => {
   vars.value.splice(index, 1)
 }
+
+watch(
+  () => props.variableToFocus,
+  (focusInfo) => {
+    if (focusInfo) {
+      if (focusInfo.isSecret) {
+        selectedEnvOption.value = "secret"
+      } else {
+        selectedEnvOption.value = "variables"
+      }
+
+      nextTick(() => {
+        const index = vars.value.findIndex(
+          (v) => v.key === focusInfo.name && !!v.secret === !!focusInfo.isSecret
+        )
+        if (index !== -1) {
+          const el = document.getElementsByName("variable" + index)[0]
+          if (el instanceof HTMLInputElement) {
+            el.focus()
+          }
+        }
+      })
+    }
+  },
+  { immediate: true }
+)
 </script>

--- a/packages/hoppscotch-common/src/components/collections/Variables.vue
+++ b/packages/hoppscotch-common/src/components/collections/Variables.vue
@@ -116,7 +116,6 @@
               >
                 <input
                   v-model="env.key"
-                  v-focus="false"
                   class="flex flex-1 bg-transparent px-4 py-2 text-secondaryDark"
                   :placeholder="`${t('count.variable', {
                     count: index + 1,

--- a/packages/hoppscotch-common/src/components/collections/Variables.vue
+++ b/packages/hoppscotch-common/src/components/collections/Variables.vue
@@ -160,9 +160,20 @@
                     :secret="tab.isSecret"
                     :focus="
                       variableToFocus?.name === env.key &&
-                      !!variableToFocus?.isSecret === !!env.secret
+                      !!variableToFocus?.isSecret === !!env.secret &&
+                      index ===
+                        tab.variables.findIndex(
+                          (v) => v.key === variableToFocus?.name
+                        )
                     "
-                    :cursor-at-end-on-mount="variableToFocus?.name === env.key"
+                    :cursor-at-end-on-mount="
+                      variableToFocus?.name === env.key &&
+                      !!variableToFocus?.isSecret === !!env.secret &&
+                      index ===
+                        tab.variables.findIndex(
+                          (v) => v.key === variableToFocus?.name
+                        )
+                    "
                   />
                   <HoppButtonSecondary
                     v-tippy="{ theme: 'tooltip' }"

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3694,14 +3694,32 @@ defineActionHandler(
         foundCollection = teamMatch.node
         collectionPath = teamMatch.path
 
-        // Switch to team collections if not already there
-        if (collectionsType.value.type !== "team-collections") {
+        // Switch to team collections and workspace if not already there
+        const activeTeamID = teamCollectionService.activeTeamID
+        if (activeTeamID) {
           const currentWorkspace = workspaceService.currentWorkspace.value
+          const isCorrectTeamWorkspace =
+            currentWorkspace.type === "team" &&
+            currentWorkspace.teamID === activeTeamID
 
-          if (currentWorkspace.type === "team") {
-            collectionsType.value = {
-              type: "team-collections",
-              selectedTeam: currentWorkspace,
+          if (isCorrectTeamWorkspace) {
+            if (collectionsType.value.type !== "team-collections") {
+              collectionsType.value = {
+                type: "team-collections",
+                selectedTeam: currentWorkspace,
+              }
+            }
+          } else {
+            const teamWorkspace =
+              workspaceService.managedTeamListAdapter.teamList.value.find(
+                (t) => t.teamID === activeTeamID
+              )
+            if (teamWorkspace) {
+              workspaceService.changeWorkspace(teamWorkspace)
+              collectionsType.value = {
+                type: "team-collections",
+                selectedTeam: teamWorkspace,
+              }
             }
           }
         }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -382,6 +382,7 @@ import {
   sortRESTCollection,
   sortRESTFolder,
 } from "~/newstore/collections"
+import { resolveCollectionPath } from "~/helpers/collection/resolveCollectionPath"
 
 import { useLocalState } from "~/newstore/localstate"
 import { currentReorderingStatus$ } from "~/newstore/reordering"
@@ -3673,71 +3674,28 @@ defineActionHandler(
     let collectionPath = sourceEnvID
 
     // Recursive search in personal collections to find the node and its index path
-    const findInPersonal = (
-      collections: HoppCollection[] | undefined,
-      currentPath: number[] = []
-    ): { collection: HoppCollection; path: string } | undefined => {
-      if (!collections) return undefined
-      for (let i = 0; i < collections.length; i++) {
-        const coll = collections[i]
-        const path = [...currentPath, i]
-        const strPath = path.join("/")
 
-        if (
-          coll._ref_id === sourceEnvID ||
-          coll.id === sourceEnvID ||
-          strPath === sourceEnvID
-        ) {
-          return { collection: coll, path: strPath }
-        }
-        if (coll.folders && coll.folders.length > 0) {
-          const found = findInPersonal(coll.folders, path)
-          if (found) return found
-        }
-      }
-      return undefined
-    }
-
-    const personalMatch = findInPersonal(restCollectionStore.value.state)
+    const personalMatch = resolveCollectionPath(
+      restCollectionStore.value.state,
+      sourceEnvID
+    )
 
     if (personalMatch) {
-      foundCollection = personalMatch.collection
+      foundCollection = personalMatch.node
       collectionPath = personalMatch.path
 
-      // Switch to personal collections if not already there
       if (collectionsType.value.type !== "my-collections") {
         switchToMyCollections()
       }
     } else {
       // Recursive search in team collections to find the node and its ID path
-      const findInTeam = (
-        collections: TeamCollection[],
-        currentPath: string = ""
-      ): { collection: TeamCollection; path: string } | undefined => {
-        for (const coll of collections) {
-          const path = currentPath ? `${currentPath}/${coll.id}` : coll.id
-          if (coll.id === sourceEnvID) {
-            return { collection: coll, path }
-          }
-          if (coll.folders && coll.folders.length > 0) {
-            const found = findInTeam(coll.folders, path)
-            if (found) return found
-          }
-          // Note: TeamCollection has .children sometimes instead of .folders depending on how it's fetched,
-          // but teamCollectionService.collections suelen tener .children o .folders.
-          // Checking .children as well just in case.
-          if ((coll as any).children && (coll as any).children.length > 0) {
-            const found = findInTeam((coll as any).children, path)
-            if (found) return found
-          }
-        }
-        return undefined
-      }
-
-      const teamMatch = findInTeam(teamCollectionService.collections.value)
+      const teamMatch = resolveCollectionPath(
+        teamCollectionService.collections.value,
+        sourceEnvID
+      )
 
       if (teamMatch) {
-        foundCollection = teamMatch.collection
+        foundCollection = teamMatch.node
         collectionPath = teamMatch.path
 
         // Switch to team collections if not already there

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3666,10 +3666,6 @@ defineActionHandler("modals.collection.import", () => {
 defineActionHandler(
   "modals.collection.properties.open",
   async ({ sourceEnvID, variableName, isSecret }) => {
-    console.log(
-      `[modals.collection.properties.open] Action triggered. sourceEnvID=${sourceEnvID}, variableName=${variableName}`
-    )
-
     let foundCollection: HoppCollection | TeamCollection | undefined
     let collectionPath = sourceEnvID
 
@@ -3713,10 +3709,6 @@ defineActionHandler(
     }
 
     if (foundCollection) {
-      console.log(
-        `[modals.collection.properties.open] Resolved path: ${collectionPath}. Calling editProperties.`
-      )
-
       variableToFocus.value = { name: variableName, isSecret: !!isSecret }
 
       await editProperties({
@@ -3727,9 +3719,6 @@ defineActionHandler(
       // Force to variables tab
       collectionPropertiesModalActiveTab.value = "variables"
     } else {
-      console.error(
-        `[modals.collection.properties.open] Could not resolve collection for ID: ${sourceEnvID}`
-      )
       toast.error(t("collection.not_found"))
     }
   }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3656,4 +3656,123 @@ defineActionHandler("collection.new", () => {
 defineActionHandler("modals.collection.import", () => {
   displayModalImportExport(true)
 })
+
+defineActionHandler(
+  "modals.collection.properties.open",
+  async ({ sourceEnvID, variableName }) => {
+    console.log(
+      `[modals.collection.properties.open] Action triggered. sourceEnvID=${sourceEnvID}, variableName=${variableName}`
+    )
+
+    let foundCollection: HoppCollection | TeamCollection | undefined
+    let collectionPath = sourceEnvID
+
+    // Recursive search in personal collections to find the node and its index path
+    const findInPersonal = (
+      collections: HoppCollection[] | undefined,
+      currentPath: number[] = []
+    ): { collection: HoppCollection; path: string } | undefined => {
+      if (!collections) return undefined
+      for (let i = 0; i < collections.length; i++) {
+        const coll = collections[i]
+        const path = [...currentPath, i]
+        const strPath = path.join("/")
+
+        if (
+          coll._ref_id === sourceEnvID ||
+          coll.id === sourceEnvID ||
+          strPath === sourceEnvID
+        ) {
+          return { collection: coll, path: strPath }
+        }
+        if (coll.folders && coll.folders.length > 0) {
+          const found = findInPersonal(coll.folders, path)
+          if (found) return found
+        }
+      }
+      return undefined
+    }
+
+    const personalMatch = findInPersonal(restCollectionStore.value.state)
+
+    if (personalMatch) {
+      foundCollection = personalMatch.collection
+      collectionPath = personalMatch.path
+
+      // Switch to personal collections if not already there
+      if (collectionsType.value.type !== "my-collections") {
+        switchToMyCollections()
+      }
+    } else {
+      // Recursive search in team collections to find the node and its ID path
+      const findInTeam = (
+        collections: TeamCollection[],
+        currentPath: string = ""
+      ): { collection: TeamCollection; path: string } | undefined => {
+        for (const coll of collections) {
+          const path = currentPath ? `${currentPath}/${coll.id}` : coll.id
+          if (coll.id === sourceEnvID) {
+            return { collection: coll, path }
+          }
+          if (coll.folders && coll.folders.length > 0) {
+            const found = findInTeam(coll.folders, path)
+            if (found) return found
+          }
+          // Note: TeamCollection has .children sometimes instead of .folders depending on how it's fetched,
+          // but teamCollectionService.collections suelen tener .children o .folders.
+          // Checking .children as well just in case.
+          if ((coll as any).children && (coll as any).children.length > 0) {
+            const found = findInTeam((coll as any).children, path)
+            if (found) return found
+          }
+        }
+        return undefined
+      }
+
+      const teamMatch = findInTeam(teamCollectionService.collections.value)
+
+      if (teamMatch) {
+        foundCollection = teamMatch.collection
+        collectionPath = teamMatch.path
+
+        // Switch to team collections if not already there
+        if (collectionsType.value.type !== "team-collections") {
+          const teamID =
+            workspaceService.currentWorkspace.value.type === "team"
+              ? workspaceService.currentWorkspace.value.teamID
+              : null
+
+          if (teamID) {
+            collectionsType.value = {
+              type: "team-collections",
+              selectedTeam: {
+                teamID,
+                // We don't have the full team object here easily, but selectedTeam is often used for teamID
+              } as any,
+            }
+          }
+        }
+      }
+    }
+
+    if (foundCollection) {
+      console.log(
+        `[modals.collection.properties.open] Resolved path: ${collectionPath}. Calling editProperties.`
+      )
+
+      await editProperties({
+        collection: foundCollection,
+        collectionIndex: collectionPath,
+      })
+
+      // Force to variables tab
+      collectionPropertiesModalActiveTab.value = "variables"
+    } else {
+      console.error(
+        `[modals.collection.properties.open] Could not resolve collection for ID: ${sourceEnvID}`
+      )
+      toast.error(t("collection.not_found"))
+    }
+  }
+)
 </script>

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -247,6 +247,7 @@
       v-model="collectionPropertiesModalActiveTab"
       :show="showModalEditProperties"
       :editing-properties="editingProperties"
+      :variable-to-focus="variableToFocus"
       :show-details="
         collectionsType.type === 'team-collections' && hasTeamWriteAccess
       "
@@ -544,6 +545,7 @@ watch(
 const persistenceService = useService(PersistenceService)
 
 const collectionPropertiesModalActiveTab = ref<RESTOptionTabs>("headers")
+const variableToFocus = ref<{ name: string; isSecret: boolean } | null>(null)
 
 onMounted(async () => {
   const localOAuthTempConfig =
@@ -859,7 +861,10 @@ const displayModalImportExport = async (
 const displayModalEditProperties = (show: boolean) => {
   showModalEditProperties.value = show
 
-  if (!show) resetSelectedData()
+  if (!show) {
+    resetSelectedData()
+    variableToFocus.value = null
+  }
 }
 
 const displayConfirmModal = (show: boolean) => {
@@ -3659,7 +3664,7 @@ defineActionHandler("modals.collection.import", () => {
 
 defineActionHandler(
   "modals.collection.properties.open",
-  async ({ sourceEnvID, variableName }) => {
+  async ({ sourceEnvID, variableName, isSecret }) => {
     console.log(
       `[modals.collection.properties.open] Action triggered. sourceEnvID=${sourceEnvID}, variableName=${variableName}`
     )
@@ -3759,6 +3764,8 @@ defineActionHandler(
       console.log(
         `[modals.collection.properties.open] Resolved path: ${collectionPath}. Calling editProperties.`
       )
+
+      variableToFocus.value = { name: variableName, isSecret: !!isSecret }
 
       await editProperties({
         collection: foundCollection,

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -865,6 +865,7 @@ const displayModalEditProperties = (show: boolean) => {
   if (!show) {
     resetSelectedData()
     variableToFocus.value = null
+    collectionPropertiesModalActiveTab.value = "headers"
   }
 }
 

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3700,18 +3700,12 @@ defineActionHandler(
 
         // Switch to team collections if not already there
         if (collectionsType.value.type !== "team-collections") {
-          const teamID =
-            workspaceService.currentWorkspace.value.type === "team"
-              ? workspaceService.currentWorkspace.value.teamID
-              : null
+          const currentWorkspace = workspaceService.currentWorkspace.value
 
-          if (teamID) {
+          if (currentWorkspace.type === "team") {
             collectionsType.value = {
               type: "team-collections",
-              selectedTeam: {
-                teamID,
-                // We don't have the full team object here easily, but selectedTeam is often used for teamID
-              } as any,
+              selectedTeam: currentWorkspace,
             }
           }
         }

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -122,6 +122,7 @@ const props = withDefaults(
     secret?: boolean
     autoCompleteEnv?: boolean
     autoCompleteEnvSource?: AggregateEnvironment[] | null
+    cursorAtEndOnMount?: boolean
   }>(),
   {
     modelValue: "",
@@ -139,6 +140,7 @@ const props = withDefaults(
     secret: false,
     autoCompleteEnv: false,
     autoCompleteEnvSource: null,
+    cursorAtEndOnMount: false,
   }
 )
 
@@ -659,6 +661,16 @@ const triggerTextSelection = () => {
   })
 }
 
+const triggerCursorAtEnd = () => {
+  nextTick(() => {
+    view.value?.focus()
+    const pos = view.value?.state.doc.length ?? 0
+    view.value?.dispatch({
+      selection: EditorSelection.create([EditorSelection.range(pos, pos)]),
+    })
+  })
+}
+
 /**
  * Focuses the input editor
  */
@@ -674,6 +686,7 @@ onMounted(() => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
     if (props.selectTextOnMount) triggerTextSelection()
+    if (props.cursorAtEndOnMount) triggerCursorAtEnd()
     if (props.focus) view.value?.focus()
     platform.ui?.onCodemirrorInstanceMount?.(editor.value)
   }
@@ -683,6 +696,7 @@ watch(editor, () => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
     if (props.selectTextOnMount) triggerTextSelection()
+    if (props.cursorAtEndOnMount) triggerCursorAtEnd()
   } else {
     view.value?.destroy()
     view.value = undefined

--- a/packages/hoppscotch-common/src/helpers/actions.ts
+++ b/packages/hoppscotch-common/src/helpers/actions.ts
@@ -198,6 +198,7 @@ type HoppActionArgsMap = {
   "modals.collection.properties.open": {
     sourceEnvID: string
     variableName: string
+    isSecret?: boolean
   }
 }
 

--- a/packages/hoppscotch-common/src/helpers/actions.ts
+++ b/packages/hoppscotch-common/src/helpers/actions.ts
@@ -77,6 +77,7 @@ export type HoppAction =
   | "flyouts.chat.open" // Shows the keybinds flyout
   | "flyouts.keybinds.toggle" // Shows the keybinds flyout
   | "modals.collection.import" // Shows the collection import modal
+  | "modals.collection.properties.open" // Opens the collection properties modal
   | "modals.search.toggle" // Shows the search modal
   | "modals.support.toggle" // Shows the support modal
   | "modals.share.toggle" // Shows the share modal
@@ -192,6 +193,10 @@ type HoppActionArgsMap = {
   }
   "modals.environment.add": {
     envName: string
+    variableName: string
+  }
+  "modals.collection.properties.open": {
+    sourceEnvID: string
     variableName: string
   }
 }

--- a/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
@@ -46,8 +46,14 @@ describe("resolveCollectionPath", () => {
       expect((result?.node as any).name).toBe("Coll 0")
     })
 
-    it("resolves nested folder by index path", () => {
+    it("resolves root collection 1 when targetID is '1'", () => {
       const result = resolveCollectionPath(mockCollections, "1")
+      expect(result?.path).toBe("1")
+      expect((result?.node as any).name).toBe("Coll 1")
+    })
+
+    it("resolves nested folder by full index path", () => {
+      const result = resolveCollectionPath(mockCollections, "0/1")
       expect(result?.path).toBe("0/1")
       expect((result?.node as any).name).toBe("Folder 0/1")
     })

--- a/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest"
+import { resolveCollectionPath } from "../resolveCollectionPath"
+import { HoppCollection } from "@hoppscotch/data"
+import { TeamCollection } from "~/helpers/teams/TeamCollection"
+
+describe("resolveCollectionPath", () => {
+  describe("Personal Collections (index-based)", () => {
+    const mockCollections: HoppCollection[] = [
+      {
+        name: "Coll 0",
+        folders: [
+          { name: "Folder 0/0", folders: [], requests: [] },
+          {
+            name: "Folder 0/1",
+            folders: [{ name: "Subfolder 0/1/0", folders: [], requests: [] }],
+            requests: [],
+          },
+        ],
+        requests: [],
+      } as any,
+      { name: "Coll 1", folders: [], requests: [] } as any,
+    ]
+
+    it("resolves root collection by index", () => {
+      const result = resolveCollectionPath(mockCollections, "0")
+      expect(result?.path).toBe("0")
+      expect((result?.node as any).name).toBe("Coll 0")
+    })
+
+    it("resolves nested folder by index path", () => {
+      const result = resolveCollectionPath(mockCollections, "1")
+      expect(result?.path).toBe("0/1")
+      expect((result?.node as any).name).toBe("Folder 0/1")
+    })
+
+    it("resolves deeply nested folder by path", () => {
+      const result = resolveCollectionPath(mockCollections, "0/1/0")
+      expect(result?.path).toBe("0/1/0")
+      expect((result?.node as any).name).toBe("Subfolder 0/1/0")
+    })
+
+    it("returns null if not found", () => {
+      const result = resolveCollectionPath(mockCollections, "99")
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("Team Collections (ID-based)", () => {
+    const mockTeamCols: TeamCollection[] = [
+      {
+        id: "team-1",
+        title: "Team Coll 1",
+        children: [
+          { id: "folder-a", title: "Folder A", children: [] },
+          {
+            id: "folder-b",
+            title: "Folder B",
+            children: [{ id: "sub-x", title: "Sub X", children: [] }],
+          },
+        ],
+      } as any,
+    ]
+
+    it("resolves root team collection by ID", () => {
+      const result = resolveCollectionPath(mockTeamCols, "team-1")
+      expect(result?.path).toBe("team-1")
+      expect((result?.node as any).title).toBe("Team Coll 1")
+    })
+
+    it("resolves nested team folder by ID", () => {
+      const result = resolveCollectionPath(mockTeamCols, "folder-b")
+      expect(result?.path).toBe("team-1/folder-b")
+    })
+
+    it("resolves deeply nested team folder", () => {
+      const result = resolveCollectionPath(mockTeamCols, "sub-x")
+      expect(result?.path).toBe("team-1/folder-b/sub-x")
+    })
+  })
+
+  describe("Integration with Action Handler (Modal Logic)", () => {
+    const mockCollections: HoppCollection[] = [
+      {
+        name: "Coll 0",
+        folders: [{ name: "Folder 0/0", folders: [], requests: [] }],
+        requests: [],
+      } as any,
+    ]
+
+    it("correctly identifies if a collection is root", () => {
+      const rootRes = resolveCollectionPath(mockCollections, "0")
+      const isRoot = rootRes?.path.split("/").length === 1
+      expect(isRoot).toBe(true)
+
+      resolveCollectionPath(mockCollections, "0") // Searching for subfolder "0" inside root "0"
+      // Note: in the real app these would be unique IDs or paths
+      const nestedPath = "0/0"
+      const isNestedRoot = nestedPath.split("/").length === 1
+      expect(isNestedRoot).toBe(false)
+    })
+
+    it("provides the correct node for editProperties", () => {
+      const result = resolveCollectionPath(mockCollections, "0")
+      expect(result?.node).toBe(mockCollections[0])
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/__tests__/resolveCollectionPath.spec.ts
@@ -7,18 +7,37 @@ describe("resolveCollectionPath", () => {
   describe("Personal Collections (index-based)", () => {
     const mockCollections: HoppCollection[] = [
       {
+        v: 1,
         name: "Coll 0",
         folders: [
-          { name: "Folder 0/0", folders: [], requests: [] },
           {
+            v: 1,
+            name: "Folder 0/0",
+            folders: [],
+            requests: [],
+          },
+          {
+            v: 1,
             name: "Folder 0/1",
-            folders: [{ name: "Subfolder 0/1/0", folders: [], requests: [] }],
+            folders: [
+              {
+                v: 1,
+                name: "Subfolder 0/1/0",
+                folders: [],
+                requests: [],
+              },
+            ],
             requests: [],
           },
         ],
         requests: [],
       } as any,
-      { name: "Coll 1", folders: [], requests: [] } as any,
+      {
+        v: 1,
+        name: "Coll 1",
+        folders: [],
+        requests: [],
+      } as any,
     ]
 
     it("resolves root collection by index", () => {
@@ -51,11 +70,21 @@ describe("resolveCollectionPath", () => {
         id: "team-1",
         title: "Team Coll 1",
         children: [
-          { id: "folder-a", title: "Folder A", children: [] },
+          {
+            id: "folder-a",
+            title: "Folder A",
+            children: [],
+          },
           {
             id: "folder-b",
             title: "Folder B",
-            children: [{ id: "sub-x", title: "Sub X", children: [] }],
+            children: [
+              {
+                id: "sub-x",
+                title: "Sub X",
+                children: [],
+              },
+            ],
           },
         ],
       } as any,
@@ -81,8 +110,16 @@ describe("resolveCollectionPath", () => {
   describe("Integration with Action Handler (Modal Logic)", () => {
     const mockCollections: HoppCollection[] = [
       {
+        v: 1,
         name: "Coll 0",
-        folders: [{ name: "Folder 0/0", folders: [], requests: [] }],
+        folders: [
+          {
+            v: 1,
+            name: "Folder 0/0",
+            folders: [],
+            requests: [],
+          },
+        ],
         requests: [],
       } as any,
     ]

--- a/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
@@ -20,14 +20,10 @@ export function resolveCollectionPath(
     // For Personal: path is index. For Team: path is ID.
     const isPersonal = "v" in coll
     const collID = isPersonal ? i.toString() : coll.id
-    const collRefID = isPersonal ? coll._ref_id : undefined
+    const collRefID = isPersonal ? coll._ref_id : coll.id
     const collPath = currentPath ? `${currentPath}/${collID}` : collID
 
-    if (
-      collID === targetID ||
-      (collRefID && collRefID === targetID) ||
-      collPath === targetID
-    ) {
+    if ((collRefID && collRefID === targetID) || collPath === targetID) {
       return { path: collPath, node: coll }
     }
 

--- a/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
@@ -18,20 +18,21 @@ export function resolveCollectionPath(
   for (let i = 0; i < collections.length; i++) {
     const coll = collections[i]
     // For Personal: path is index. For Team: path is ID.
-    const collID = "id" in coll ? (coll as any).id : i.toString()
-    const collRefID = (coll as any)._ref_id
+    const isPersonal = "v" in coll
+    const collID = isPersonal ? i.toString() : coll.id
+    const collRefID = isPersonal ? coll._ref_id : undefined
     const collPath = currentPath ? `${currentPath}/${collID}` : collID
 
     if (
       collID === targetID ||
-      collRefID === targetID ||
+      (collRefID && collRefID === targetID) ||
       collPath === targetID
     ) {
       return { path: collPath, node: coll }
     }
 
-    // Recursively check folders/sub-collections
-    const children = "folders" in coll ? coll.folders : coll.children
+    // Recursively check sub-nodes (Team collections use .children, Personal collections use .folders)
+    const children = isPersonal ? coll.folders : coll.children
     if (children && children.length > 0) {
       const found = resolveCollectionPath(children, targetID, collPath)
       if (found) return found

--- a/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/resolveCollectionPath.ts
@@ -1,0 +1,41 @@
+import { HoppCollection } from "@hoppscotch/data"
+import { TeamCollection } from "~/helpers/teams/TeamCollection"
+
+type CollectionPathResult = {
+  path: string
+  node: HoppCollection | TeamCollection
+}
+
+/**
+ * Recursively search a collection tree to find a specific collection or folder by its ID or index path.
+ * Supports both Personal (index-based paths like '0/1') and Team (ID-based paths) structures.
+ */
+export function resolveCollectionPath(
+  collections: (HoppCollection | TeamCollection)[],
+  targetID: string,
+  currentPath = ""
+): CollectionPathResult | null {
+  for (let i = 0; i < collections.length; i++) {
+    const coll = collections[i]
+    // For Personal: path is index. For Team: path is ID.
+    const collID = "id" in coll ? (coll as any).id : i.toString()
+    const collRefID = (coll as any)._ref_id
+    const collPath = currentPath ? `${currentPath}/${collID}` : collID
+
+    if (
+      collID === targetID ||
+      collRefID === targetID ||
+      collPath === targetID
+    ) {
+      return { path: collPath, node: coll }
+    }
+
+    // Recursively check folders/sub-collections
+    const children = "folders" in coll ? coll.folders : coll.children
+    if (children && children.length > 0) {
+      const found = resolveCollectionPath(children, targetID, collPath)
+      if (found) return found
+    }
+  }
+  return null
+}

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -209,10 +209,10 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           ? IconGlobe
           : tooltipEnv?.sourceEnv === "RequestVariable"
             ? IconVariable
-            : selectedEnvType === "TEAM_ENV"
-              ? IconUsers
-              : tooltipEnv?.sourceEnv === "CollectionVariable"
-                ? IconLibrary
+            : tooltipEnv?.sourceEnvID
+              ? IconLibrary
+              : selectedEnvType === "TEAM_ENV"
+                ? IconUsers
                 : IconUser
       }</span>`
 

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -246,6 +246,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             invokeAction("modals.collection.properties.open", {
               sourceEnvID: tooltipEnv.sourceEnvID,
               variableName: parsedEnvKey,
+              isSecret: tooltipEnv.secret,
             })
           } else {
             invokeAction(invokeActionType, {

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -242,6 +242,11 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           ) {
             restTabs.currentActiveTab.value.document.optionTabPreference =
               "requestVariables"
+          } else if (tooltipEnv?.sourceEnvID) {
+            invokeAction("modals.collection.properties.open", {
+              sourceEnvID: tooltipEnv.sourceEnvID,
+              variableName: parsedEnvKey,
+            })
           } else {
             invokeAction(invokeActionType, {
               envName: tooltipEnv?.sourceEnv === "Global" ? "Global" : envName,
@@ -251,8 +256,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           }
         })
         editIcon.innerHTML = `<span class="inline-flex items-center justify-center my-1">${IconEdit}</span>`
-        if (tooltipEnv?.sourceEnv !== "CollectionVariable")
-          tooltip.appendChild(editIcon)
+        tooltip.appendChild(editIcon)
       }
 
       return {

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -127,7 +127,10 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
         (env) => env.key === parsedEnvKey
       )
       const currentSelectedEnvironment = getCurrentEnvironment()
-      const envName = tooltipEnv?.sourceEnv ?? "Choose an Environment"
+      const envName =
+        tooltipEnv?.sourceEnvName ??
+        tooltipEnv?.sourceEnv ??
+        "Choose an Environment"
 
       let envInitialValue = tooltipEnv?.initialValue
 

--- a/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
@@ -49,9 +49,10 @@ export const transformInheritedCollectionVariablesToAggregateEnv = (
             getCurrentValue(secret, index, parentID, showSecret) ??
             currentValue,
           initialValue,
-          sourceEnv: parentName || "CollectionVariable",
+          sourceEnv: "CollectionVariable",
           secret,
           sourceEnvID: parentID,
+          sourceEnvName: parentName,
         })
       )
   )

--- a/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
@@ -40,18 +40,20 @@ export const transformInheritedCollectionVariablesToAggregateEnv = (
   showSecret: boolean = true
 ): AggregateEnvironment[] => {
   // Flatten the inherited variables into a single array
-  const flattened = variables.flatMap(({ parentID, inheritedVariables }) =>
-    inheritedVariables.map(
-      ({ currentValue, initialValue, key, secret }, index) => ({
-        key,
-        currentValue:
-          getCurrentValue(secret, index, parentID, showSecret) ?? currentValue,
-        initialValue,
-        sourceEnv: "CollectionVariable",
-        secret,
-        sourceEnvID: parentID,
-      })
-    )
+  const flattened = variables.flatMap(
+    ({ parentID, parentName, inheritedVariables }) =>
+      inheritedVariables.map(
+        ({ currentValue, initialValue, key, secret }, index) => ({
+          key,
+          currentValue:
+            getCurrentValue(secret, index, parentID, showSecret) ??
+            currentValue,
+          initialValue,
+          sourceEnv: parentName || "CollectionVariable",
+          secret,
+          sourceEnvID: parentID,
+        })
+      )
   )
 
   // Later values override earlier ones

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -421,6 +421,7 @@ export type AggregateEnvironment = {
   secret: boolean
   sourceEnv: string
   sourceEnvID?: string
+  sourceEnvName?: string
 }
 
 /**

--- a/packages/hoppscotch-common/src/services/team-collection.service.ts
+++ b/packages/hoppscotch-common/src/services/team-collection.service.ts
@@ -140,6 +140,10 @@ export class TeamCollectionsService extends Service<void> {
 
   private teamID: string | null = null
 
+  public get activeTeamID() {
+    return this.teamID
+  }
+
   public collections = ref<TeamCollection[]>([])
   public loadingCollections = ref<string[]>([])
   public pendingTeamCollectionPath = ref<string | null>(null)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6167 

This PR enables direct editing of collection-scoped variables from the request editor's tooltip. It streamlines the workflow by automatically navigating to the correct collection/folder and focusing the specific variable row for immediate editing.

### What's changed
- [x] Enabled the "Edit" action in the environment variable tooltip for collection-scoped variables.
- [x] Implemented a new `resolveCollectionPath` helper to accurately navigate nested Personal and Team collection trees.
- [x] Added `variableToFocus` functionality to the Properties and Variables modals to auto-highlight the target variable.
- [x] Updated `SmartEnvInput` to support a `cursorAtEndOnMount` behavior for improved focus UX on CodeMirror fields.
- [x] Added unit tests in `resolveCollectionPath.spec.ts` for tree resolution logic.
- [x] Resolved Prettier formatting issues and ensured `prod-lint` compatibility.

Showcase of what it's done:

https://github.com/user-attachments/assets/86f3cc8e-e854-4dfc-8cb2-c7396bd6ec62

### Notes to reviewers
-   **Helper extraction**: The logic to find a collection by ID was extracted from `index.vue` into `helpers/collection/resolveCollectionPath.ts` to allow for standalone unit testing and potential reuse in other parts of the app.
-   **CodeMirror focus**: Standard `setSelectionRange` was insufficient for the `SmartEnvInput` (CodeMirror), so I implemented a native CodeMirror cursor dispatch to ensure the cursor is placed at the end of the value without a "select-all" effect.
-   **Workspace switching**: The action handler automatically triggers a workspace switch (Personal vs Team) if the variable being edited belongs to a different collection type than the one currently active in the sidebar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Edit collection-scoped variables directly from the request editor tooltip. Clicking Edit opens the Collection Properties modal in the right workspace and path, auto-selects Variables or Secrets, focuses the exact row, shows the collection name, and places the cursor at the end.

- **New Features**
  - Enabled Edit for collection variables in the tooltip; opens the Properties modal via `modals.collection.properties.open`.
  - Auto-selects Variables or Secrets, focuses the exact row, and places the cursor at the end.
  - Displays the collection’s name using `sourceEnvName`.
  - Added `resolveCollectionPath` for reliable path resolution across Personal and Team trees.

- **Bug Fixes**
  - Deterministic focusing when duplicate variable names exist.
  - Correctly switches to the owning Team workspace before opening the modal.
  - Preserves `sourceEnv` string checks while using `sourceEnvID`/`sourceEnvName`.

<sup>Written for commit fe423df2d767c0282529dbffb74ca88a9f9bddcc. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

