### PR TITLE
fix(common): restore magic-link sign-in flow on cloud for orgs

### DIFF
--- a/packages/hoppscotch-common/src/pages/enter.vue
+++ b/packages/hoppscotch-common/src/pages/enter.vue
@@ -33,12 +33,13 @@ export default defineComponent({
   async mounted() {
     const { redirect, ...queryParams } = this.route.query
 
-    // Org subdomain magic-link flow: redirect back to the originating subdomain
-    if (
-      platform.organization &&
-      !platform.organization.isDefaultCloudInstance &&
-      typeof redirect === "string"
-    ) {
+    // Firebase delivers magic links to the default cloud instance
+    // (e.g. hoppscotch.io) `/enter` route because `continueUrl` must
+    // point there for trust-domain verification. Org-subdomain
+    // (e.g. subdomain.hoppscotch.io) logins redirect back to the
+    // originating subdomain; `getSafeRedirectUrl()` restricts the
+    // target to the default cloud instance domain and its subdomains.
+    if (platform.organization && typeof redirect === "string") {
       const redirectTarget = getSafeRedirectUrl(
         redirect,
         platform.organization.getRootDomain()


### PR DESCRIPTION
Closes #6234, FE-1225.

Magic-link sign-ins for cloud for orgs were completing on the default cloud instance instead of the originating org subdomain. Firebase sends the link to the trusted `continueUrl` domain, so the redirect code runs on `hoppscotch.io/enter`; the removed `isDefaultCloudInstance` gate prevented that page from sending users back to their org.

### What's changed

- Removed the `!platform.organization.isDefaultCloudInstance` gate in `enter.vue`.
- Kept the #5982 redirect protections in place: `getSafeRedirectUrl()` still allows only the default cloud domain and its subdomains, and `isSignInWithEmailLink()` still requires a real Firebase magic-link URL.
- Updated the comment to document why the default cloud `/enter` route redirects back to the originating org subdomain.

### Notes to reviewers

The redirect block now fires only when all four checks pass: `platform.organization`, a string `redirect`, a safe redirect target, and a Firebase magic-link URL.

| Build path | Effect |
| --- | --- |
| Cloud web, cloud for orgs | Redirects from default cloud `/enter` back to the originating org subdomain. |
| Cloud web, default cloud | No `?redirect=`, so it falls through to `processMagicLink()` as before. |
| Cloud desktop | Firebase email-link sign-in is not applicable, so no behaviour change. |
| Self-hosted web/desktop | Uses `?token=`, not this `?redirect=` flow; `platform.organization` is absent, so no-op. |
| Desktop shell `cloud-org` | Inherits the loaded web bundle behaviour; this block only runs when the bundle supplies `platform.organization` and a valid redirect. |

Manual test path: open `<org>.hoppscotch.io` in a fresh incognito, request a magic link, click the email link, and confirm sign-in returns to the org subdomain without asking for email again.

Security envelope: existing `getSafeRedirectUrl` coverage remains the relevant regression suite for the allowlist behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores magic‑link sign‑in for cloud orgs by redirecting from the default cloud `/enter` back to the originating org subdomain when a safe `redirect` is present. Prevents sign‑ins from completing on the default instance and aligns with Firebase’s single `continueUrl` domain.

- **Bug Fixes**
  - Removed the `isDefaultCloudInstance` gate in `packages/hoppscotch-common/src/pages/enter.vue`; kept `getSafeRedirectUrl()` (restricts to the default cloud domain and its subdomains) and `isSignInWithEmailLink()` checks; updated the comment to explain why default `/enter` redirects back to the org subdomain.

<sup>Written for commit 615bd7f72afdc3c52b08d195f50a954089a9b0ba. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6237?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

