### PR TITLE
fix(desktop): unified store scope and migration reroute

### DIFF
--- a/packages/hoppscotch-common/src/composables/desktop-settings.ts
+++ b/packages/hoppscotch-common/src/composables/desktop-settings.ts
@@ -2,7 +2,13 @@ import { reactive, ref, readonly } from "vue"
 import * as E from "fp-ts/Either"
 import { invoke } from "@tauri-apps/api/core"
 
-import { Store } from "~/kernel/store"
+// Bind to the unified, process-wide store rather than the org-scoped
+// default `Store`. Desktop settings are machine-level configuration
+// (for example the "disable update checks" toggle), and the Tauri
+// shell reads them through its own `kernel/store.ts` wrapper at the
+// same physical path. Going through the org-scoped store would route
+// writes to a different file and the shell would never see them.
+import { UnifiedStore as Store } from "~/kernel/store"
 import {
   DESKTOP_SETTINGS_SCHEMA,
   DESKTOP_SETTINGS_STORE_KEY,
@@ -52,6 +58,16 @@ const loaded = ref(false)
 let initPromise: Promise<void> | undefined
 
 async function loadInitial(): Promise<void> {
+  // Open the unified store before reading. The shell already inits this
+  // path through its own `DesktopPersistenceService.init`, but the
+  // webview runs in a separate window with its own process state, so
+  // the underlying Tauri store still needs to be opened here. Repeat
+  // calls land on the same on-disk file and are harmless.
+  const initResult = await Store.init()
+  if (E.isLeft(initResult)) {
+    Log.warn(LOG_TAG, "Failed to init unified store", initResult.left)
+  }
+
   const result = await Store.get<unknown>(
     DESKTOP_SETTINGS_STORE_NAMESPACE,
     DESKTOP_SETTINGS_STORE_KEY

--- a/packages/hoppscotch-common/src/composables/update-check.ts
+++ b/packages/hoppscotch-common/src/composables/update-check.ts
@@ -3,7 +3,12 @@ import * as E from "fp-ts/Either"
 import { invoke } from "@tauri-apps/api/core"
 import { listen, type UnlistenFn } from "@tauri-apps/api/event"
 
-import { Store } from "~/kernel/store"
+// Bind to the unified, process-wide store rather than the org-scoped
+// default `Store`. Persisted `UpdateState` is machine-level, not
+// per-org, and the Tauri shell reads the same physical file through
+// its own `kernel/store.ts` wrapper. Going through the org-scoped
+// store would route writes to a file the shell never reads.
+import { UnifiedStore as Store } from "~/kernel/store"
 import {
   UPDATE_STATE_SCHEMA,
   UPDATE_STATE_STORE_KEY,
@@ -251,6 +256,16 @@ function nextState(current: UpdateState, event: UpdateEvent): UpdateState {
 }
 
 async function loadPersistedState(): Promise<void> {
+  // Open the unified store before reading. The shell already opens
+  // this path through `DesktopPersistenceService.init`, but the
+  // webview runs in a separate window with its own process state, so
+  // the underlying Tauri store still needs to be opened here. Repeat
+  // calls land on the same on-disk file and are harmless.
+  const initResult = await Store.init()
+  if (E.isLeft(initResult)) {
+    Log.warn(LOG_TAG, "Failed to init unified store", initResult.left)
+  }
+
   const result = await Store.get<PersistedUpdateState | null>(
     UPDATE_STATE_STORE_NAMESPACE,
     UPDATE_STATE_STORE_KEY

--- a/packages/hoppscotch-common/src/kernel/store.ts
+++ b/packages/hoppscotch-common/src/kernel/store.ts
@@ -25,21 +25,29 @@ import { diag } from "./log"
 // a beforeEach guard in modules/router.ts, and survives full-page reloads
 // because Tauri sets it on the initial webview URL
 const orgParam = new URLSearchParams(window.location.search).get("org")
-const STORE_PATH = orgParam
+const HOST_SCOPED_STORE_PATH = orgParam
   ? `${orgParam.replace(/[^a-zA-Z0-9]/g, "_")}.hoppscotch.store`
   : `${window.location.host}.hoppscotch.store`
 
+// process-wide store file shared across orgs. holds machine-level state
+// (desktop settings, recent-instances list, update state) that should
+// not vary per organization. file name matches the path each shell's
+// own `kernel/store.ts` wrapper writes to and the path
+// `DesktopPersistenceService` uses on the Tauri side, so common
+// composables that bind here read/write the same physical file the
+// shell does.
+const UNIFIED_STORE_PATH = "hoppscotch-unified.store"
+
 diag("store", "--- COMMON store.ts module evaluated ---")
 diag("store", "orgParam:", orgParam ?? "(none)")
-diag("store", "STORE_PATH:", STORE_PATH)
+diag("store", "HOST_SCOPED_STORE_PATH:", HOST_SCOPED_STORE_PATH)
+diag("store", "UNIFIED_STORE_PATH:", UNIFIED_STORE_PATH)
 diag("store", "window.location.host:", window.location.host)
 diag("store", "window.location.href:", window.location.href)
 
-let cachedStorePath: string | undefined
-
-// These are only defined functions if in desktop mode.
-// For more context, take a look at how `hoppscotch-kernel/.../store/v1/` works
-// and how the `web` mode store kernel ignores the first file directory input.
+// Lazy-loaded Tauri APIs. Module-scoped so every scoped store shares
+// the init step and the loaded modules. Web mode never resolves these
+// because `isInitd` returns early outside desktop.
 let invoke:
   | (<T>(cmd: string, args?: Record<string, unknown>) => Promise<T>)
   | undefined
@@ -102,40 +110,56 @@ export const getLogsDir = async (): Promise<string> => {
   return await invoke<string>("get_logs_dir")
 }
 
-const getStorePath = async (): Promise<string> => {
-  if (cachedStorePath) {
-    diag("store", "getStorePath: returning cached:", cachedStorePath)
+// Factory for a Store wrapper bound to a specific store file. Each
+// instance keeps its own resolved-path cache so two scoped stores
+// never alias their absolute paths. Tauri-API loading and kernel
+// module access are module-scoped above, so the factory only
+// handles the per-store concerns.
+function createScopedStore(staticPath: string) {
+  let cachedStorePath: string | undefined
+
+  const getStorePath = async (): Promise<string> => {
+    if (cachedStorePath) {
+      diag(
+        "store",
+        `getStorePath(${staticPath}): returning cached:`,
+        cachedStorePath
+      )
+      return cachedStorePath
+    }
+
+    if (getKernelMode() === "desktop") {
+      await isInitd()
+      if (join) {
+        try {
+          const storeDir = await getStoreDir()
+          cachedStorePath = await join(storeDir, staticPath)
+          diag(
+            "store",
+            `getStorePath(${staticPath}): resolved desktop path:`,
+            cachedStorePath
+          )
+          return cachedStorePath
+        } catch (error) {
+          diag(
+            "store",
+            `getStorePath(${staticPath}): failed to get store dir:`,
+            String(error)
+          )
+          console.error("Failed to get store directory:", error)
+        }
+      }
+    }
+
+    cachedStorePath = staticPath
+    diag(
+      "store",
+      `getStorePath(${staticPath}): using fallback path:`,
+      cachedStorePath
+    )
     return cachedStorePath
   }
 
-  if (getKernelMode() === "desktop") {
-    await isInitd()
-    if (join) {
-      try {
-        const storeDir = await getStoreDir()
-        cachedStorePath = await join(storeDir, STORE_PATH)
-        diag(
-          "store",
-          "getStorePath: resolved desktop path:",
-          cachedStorePath,
-          "(STORE_PATH:",
-          STORE_PATH,
-          ")"
-        )
-        return cachedStorePath
-      } catch (error) {
-        diag("store", "getStorePath: failed to get store dir:", String(error))
-        console.error("Failed to get store directory:", error)
-      }
-    }
-  }
-
-  cachedStorePath = STORE_PATH
-  diag("store", "getStorePath: using fallback STORE_PATH:", cachedStorePath)
-  return cachedStorePath
-}
-
-export const Store = (() => {
   const module = () => getModule("store")
 
   return {
@@ -143,9 +167,13 @@ export const Store = (() => {
 
     init: async () => {
       const storePath = await getStorePath()
-      diag("store", "Store.init() called with path:", storePath)
+      diag("store", `Store.init(${staticPath}) called with path:`, storePath)
       const result = await module().init(storePath)
-      diag("store", "Store.init() completed for path:", storePath)
+      diag(
+        "store",
+        `Store.init(${staticPath}) completed for path:`,
+        storePath
+      )
       return result
     },
 
@@ -156,7 +184,11 @@ export const Store = (() => {
       options?: StorageOptions
     ): Promise<E.Either<StoreError, void>> => {
       const storePath = await getStorePath()
-      diag("store", `Store.set(${namespace}, ${key}) on path:`, storePath)
+      diag(
+        "store",
+        `Store.set(${namespace}, ${key}) on ${staticPath}:`,
+        storePath
+      )
       return module().set(storePath, namespace, key, value, options)
     },
 
@@ -165,7 +197,11 @@ export const Store = (() => {
       key: string
     ): Promise<E.Either<StoreError, T | undefined>> => {
       const storePath = await getStorePath()
-      diag("store", `Store.get(${namespace}, ${key}) on path:`, storePath)
+      diag(
+        "store",
+        `Store.get(${namespace}, ${key}) on ${staticPath}:`,
+        storePath
+      )
       const result = await module().get<T>(storePath, namespace, key)
       if (E.isRight(result)) {
         const val = result.right
@@ -177,9 +213,16 @@ export const Store = (() => {
               : typeof val === "object"
                 ? `object(${Object.keys(val as Record<string, unknown>).length} keys)`
                 : typeof val
-        diag("store", `Store.get(${namespace}, ${key}) => Right(${shape})`)
+        diag(
+          "store",
+          `Store.get(${namespace}, ${key}) on ${staticPath} => Right(${shape})`
+        )
       } else {
-        diag("store", `Store.get(${namespace}, ${key}) => Left:`, result.left)
+        diag(
+          "store",
+          `Store.get(${namespace}, ${key}) on ${staticPath} => Left:`,
+          result.left
+        )
       }
       return result
     },
@@ -230,4 +273,16 @@ export const Store = (() => {
       return extendStore(module(), storePath, namespace)
     },
   } as const
-})()
+}
+
+// Org-scoped store. Holds per-org state (auth tokens, collections,
+// environments, settings that vary by organization). Default Store
+// for almost every consumer in common.
+export const Store = createScopedStore(HOST_SCOPED_STORE_PATH)
+
+// Process-wide store shared across orgs. Holds machine-level state
+// like desktop settings, the recent-instances list, and update state.
+// Use this for anything that should persist regardless of which org
+// the user is viewing, and for state that the desktop shell also
+// reads or writes through its own kernel/store wrapper.
+export const UnifiedStore = createScopedStore(UNIFIED_STORE_PATH)

--- a/packages/hoppscotch-common/src/kernel/store.ts
+++ b/packages/hoppscotch-common/src/kernel/store.ts
@@ -169,11 +169,7 @@ function createScopedStore(staticPath: string) {
       const storePath = await getStorePath()
       diag("store", `Store.init(${staticPath}) called with path:`, storePath)
       const result = await module().init(storePath)
-      diag(
-        "store",
-        `Store.init(${staticPath}) completed for path:`,
-        storePath
-      )
+      diag("store", `Store.init(${staticPath}) completed for path:`, storePath)
       return result
     },
 

--- a/packages/hoppscotch-desktop/src/services/persistence.service.ts
+++ b/packages/hoppscotch-desktop/src/services/persistence.service.ts
@@ -111,25 +111,44 @@ const migrations: Migration[] = [
     // migration can prune it once the v2 definition has stabilized.
     version: 2,
     migrate: async () => {
-      // Skip if `desktopSettings` already exists. Two paths can re-run
-      // this migration after it succeeded once. A user downgrades to a
-      // pre-v2 build, which resets `SCHEMA_VERSION` to "1" because the
-      // older code does not recognize "2" and rolls it back. A
-      // re-upgrade then sees v1 again and tries to migrate. The other
-      // path is a corrupted `SCHEMA_VERSION` value, which the
-      // `runMigrations` parse-defense coerces to "1" so every
-      // migration reruns from scratch. In both cases, falling through
-      // to the legacy carry-forward below would overwrite any user-set
-      // v2 fields with `disableUpdateNotifications` plus schema
-      // defaults, undoing the user's work. Treating presence of the
-      // `desktopSettings` key as the canonical "v2 happened" signal
-      // makes the migration truly idempotent without depending on
-      // `SCHEMA_VERSION` being trustworthy.
+      // Decide whether to skip based on the existing `desktopSettings`
+      // payload. Two paths can re-run this migration after it succeeded
+      // once. A user downgrades to a pre-v2 build, which resets
+      // `SCHEMA_VERSION` to "1" because the older code does not
+      // recognize "2" and rolls it back. A re-upgrade then sees v1
+      // again and tries to migrate. The other path is a corrupted
+      // `SCHEMA_VERSION` value, which the `runMigrations` parse-defense
+      // coerces to "1" so every migration reruns from scratch. In both
+      // cases, blindly running the legacy carry-forward would
+      // overwrite any user-set v2 fields with
+      // `disableUpdateNotifications` plus schema defaults, undoing the
+      // user's work.
+      //
+      // Three reachable cases here, each handled explicitly. A `Left`
+      // from `Store.get` means the store is degraded (file I/O
+      // failure, or not yet open) and there is no way to tell whether
+      // v2 already ran. Propagating the `Left` aborts the migration
+      // before `runMigrations` bumps `SCHEMA_VERSION`, so the next
+      // launch retries on a hopefully-recovered store. A `Right` with
+      // a present and schema-valid payload is the canonical "v2
+      // already happened" signal, since the migration itself is what
+      // writes a valid payload, so a stored value implies the
+      // migration ran successfully at least once. A `Right` with
+      // either no payload (fresh install) or a malformed payload
+      // (partial object, wrong field types) falls through to the
+      // legacy carry-forward, which writes a fresh schema-defaults
+      // `desktopSettings` and self-heals the corruption.
       const existingResult = await Store.get<unknown>(
         STORE_NAMESPACE,
         STORE_KEYS.DESKTOP_SETTINGS
       )
-      if (E.isRight(existingResult) && existingResult.right !== undefined) {
+      if (E.isLeft(existingResult)) {
+        return existingResult
+      }
+      if (
+        existingResult.right !== undefined &&
+        DESKTOP_SETTINGS_SCHEMA.safeParse(existingResult.right).success
+      ) {
         return E.right(undefined)
       }
 

--- a/packages/hoppscotch-desktop/src/services/persistence.service.ts
+++ b/packages/hoppscotch-desktop/src/services/persistence.service.ts
@@ -111,6 +111,28 @@ const migrations: Migration[] = [
     // migration can prune it once the v2 definition has stabilized.
     version: 2,
     migrate: async () => {
+      // Skip if `desktopSettings` already exists. Two paths can re-run
+      // this migration after it succeeded once. A user downgrades to a
+      // pre-v2 build, which resets `SCHEMA_VERSION` to "1" because the
+      // older code does not recognize "2" and rolls it back. A
+      // re-upgrade then sees v1 again and tries to migrate. The other
+      // path is a corrupted `SCHEMA_VERSION` value, which the
+      // `runMigrations` parse-defense coerces to "1" so every
+      // migration reruns from scratch. In both cases, falling through
+      // to the legacy carry-forward below would overwrite any user-set
+      // v2 fields with `disableUpdateNotifications` plus schema
+      // defaults, undoing the user's work. Treating presence of the
+      // `desktopSettings` key as the canonical "v2 happened" signal
+      // makes the migration truly idempotent without depending on
+      // `SCHEMA_VERSION` being trustworthy.
+      const existingResult = await Store.get<unknown>(
+        STORE_NAMESPACE,
+        STORE_KEYS.DESKTOP_SETTINGS
+      )
+      if (E.isRight(existingResult) && existingResult.right !== undefined) {
+        return E.right(undefined)
+      }
+
       const legacyResult = await Store.get<Partial<LegacyPortableSettings>>(
         STORE_NAMESPACE,
         STORE_KEYS.PORTABLE_SETTINGS


### PR DESCRIPTION
The desktop-settings toggle in the new settings page 
persisted to a per-org store file but the Tauri shell read its 
startup gate from a different physical file, 
so `disableUpdateChecks` never took effect at startup. The
v2 migration also overwrote any user-set `desktopSettings`
fields when re-run after a downgrade-then-reupgrade or a
corrupted `SCHEMA_VERSION`.

Closes FE-1223
Closes FE-1224

## Store path fix

The `useDesktopSettings` and `useUpdateCheck` composables in
`hoppscotch-common` import `Store` from `~/kernel/store`, which
on desktop resolves to
`${window.location.host}.hoppscotch.store` (a per-org file).
The Tauri shell's `DesktopPersistenceService` reads and writes
the same namespace and key but goes through
`hoppscotch-desktop/src/kernel/store.ts`, pinned to
`hoppscotch-unified.store` (a process-wide file). Same
namespace, same key, different files: the toggle persisted to
one store and `StandardHome.vue`'s startup gate read from
another, so the auto-check fired regardless of the user's
setting.

The fix extracts a `createScopedStore(staticPath)` factory in
common's `kernel/store.ts` and exports a second scoped instance,
`UnifiedStore`, pinned to `hoppscotch-unified.store`. The
existing `Store` export keeps the host-scoped path it had
before and the same `as const` API, so the six existing
consumers (kernel-interceptor stores, common's persistence
service) compile and run unchanged. Tauri-API loading and
kernel module access stay module-scoped above the factory, so
both stores share the init step.

Both desktop composables now
`import { UnifiedStore as Store }`, leaving the rest of each
file untouched. Each composable's load-on-first-use path opens
the unified store via `Store.init()` before reading. The
kernel's `TauriStoreManager` deduplicates by path and its own
`init()` is guarded against repeat calls, so this is safe even
after the shell already initialized the same file through
`DesktopPersistenceService`.

## Backwards compatibility

Nothing about the schema or the persisted format changes. The
two store files (org-scoped and unified) already exist on disk
for desktop builds, and this patch routes the desktop
composables to the same physical file the shell already uses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop update-check toggle at startup by unifying the store scope, and makes the v2 migration idempotent to preserve user settings. Addresses FE-1223 and FE-1224.

- **Bug Fixes**
  - Route `useDesktopSettings` and `useUpdateCheck` to `UnifiedStore` (`hoppscotch-unified.store`) and call `init()` before reads so `disableUpdateChecks` takes effect on startup.
  - v2 migration now skips when a schema-valid `desktopSettings` exists, propagates read errors to avoid bumping `SCHEMA_VERSION` on a bad store, and only carries forward from legacy on missing/invalid payloads.

- **Refactors**
  - Added `createScopedStore()` and exported `UnifiedStore`; `Store` stays host-scoped. Tauri API loading remains module-scoped; no schema changes.

<sup>Written for commit e7061ba63227954c0e72e638c34637151fa0ae6f. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

