### PR TITLE
fix(backend): harden onboarding config endpoint

### DIFF
--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -7,6 +7,7 @@ import {
   INFRA_CONFIG_NOT_FOUND,
   INFRA_CONFIG_OPERATION_NOT_ALLOWED,
   INFRA_CONFIG_UPDATE_FAILED,
+  ONBOARDING_CANNOT_BE_RERUN,
 } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
 import * as helper from './helper';
@@ -344,6 +345,190 @@ describe('InfraConfigService', () => {
           },
         ]);
         expect(result).toEqualLeft(INFRA_CONFIG_INVALID_INPUT);
+      });
+    });
+  });
+
+  describe('getOnboardingConfig', () => {
+    const VALID_TOKEN = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+    function makeConfigs(
+      overrides: Partial<Record<string, string>> = {},
+    ): { name: InfraConfigEnum; value: string }[] {
+      const defaults: Record<string, string> = {
+        [InfraConfigEnum.ONBOARDING_COMPLETED]: 'false',
+        [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: VALID_TOKEN,
+      };
+      return Object.entries({ ...defaults, ...overrides }).map(
+        ([name, value]) => ({ name: name as InfraConfigEnum, value }),
+      );
+    }
+
+    function setupOpenWindow(
+      tokenInDb: string | undefined = VALID_TOKEN,
+    ): void {
+      const configs =
+        tokenInDb !== undefined
+          ? makeConfigs({
+              [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: tokenInDb,
+            })
+          : [
+              {
+                name: InfraConfigEnum.ONBOARDING_COMPLETED as InfraConfigEnum,
+                value: 'false',
+              },
+            ];
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(configs));
+      mockUserService.getUsersCount.mockResolvedValueOnce(0);
+    }
+
+    describe('completion-state gate', () => {
+      it('should block access when onboarding is completed and users exist', async () => {
+        jest
+          .spyOn(infraConfigService, 'getMany')
+          .mockResolvedValueOnce(
+            E.right(
+              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'true' }),
+            ),
+          );
+        mockUserService.getUsersCount.mockResolvedValueOnce(1);
+
+        const result =
+          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
+        expect(result).toEqualLeft(ONBOARDING_CANNOT_BE_RERUN);
+      });
+
+      it('should allow access when onboarding is completed but no users exist (re-run window)', async () => {
+        jest
+          .spyOn(infraConfigService, 'getMany')
+          .mockResolvedValueOnce(
+            E.right(
+              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'true' }),
+            ),
+          );
+        mockUserService.getUsersCount.mockResolvedValueOnce(0);
+
+        const result =
+          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
+        expect(result).toEqualRight(expect.any(Object));
+      });
+
+      it('should allow access when onboarding is not yet completed even if users exist', async () => {
+        jest
+          .spyOn(infraConfigService, 'getMany')
+          .mockResolvedValueOnce(
+            E.right(
+              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'false' }),
+            ),
+          );
+        mockUserService.getUsersCount.mockResolvedValueOnce(5);
+
+        const result =
+          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
+        expect(result).toEqualRight(expect.any(Object));
+      });
+    });
+
+    describe('token validation (bootstrap window open)', () => {
+      it('should return config values for a valid matching token', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result =
+          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: VALID_TOKEN,
+          }),
+        );
+      });
+
+      it('should redact all values for an empty-string token', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result = await infraConfigService.getOnboardingConfig('');
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values for a whitespace-only token', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result = await infraConfigService.getOnboardingConfig('   ');
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values when token is undefined (missing query param)', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result = await infraConfigService.getOnboardingConfig(
+          undefined as unknown as string,
+        );
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values when token is null', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result = await infraConfigService.getOnboardingConfig(
+          null as unknown as string,
+        );
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values for an incorrect token', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result =
+          await infraConfigService.getOnboardingConfig('wrong-token');
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values when the recovery token row is missing from DB', async () => {
+        setupOpenWindow(undefined);
+        const result =
+          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_COMPLETED]: null,
+          }),
+        );
+      });
+
+      it('should redact all values when the recovery token in DB is an empty string', async () => {
+        setupOpenWindow('');
+        const result = await infraConfigService.getOnboardingConfig('');
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
+      });
+
+      it('should redact all values for an array-shaped token (?token[]=x bypass attempt)', async () => {
+        setupOpenWindow(VALID_TOKEN);
+        const result = await infraConfigService.getOnboardingConfig(
+          [VALID_TOKEN] as unknown as string,
+        );
+        expect(result).toEqualRight(
+          expect.objectContaining({
+            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
+          }),
+        );
       });
     });
   });

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -350,186 +350,165 @@ describe('InfraConfigService', () => {
   });
 
   describe('getOnboardingConfig', () => {
-    const VALID_TOKEN = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const RECOVERY_TOKEN = 'valid-recovery-token-123';
 
-    function makeConfigs(
-      overrides: Partial<Record<string, string>> = {},
-    ): { name: InfraConfigEnum; value: string }[] {
-      const defaults: Record<string, string> = {
-        [InfraConfigEnum.ONBOARDING_COMPLETED]: 'false',
-        [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: VALID_TOKEN,
-      };
-      return Object.entries({ ...defaults, ...overrides }).map(
-        ([name, value]) => ({ name: name as InfraConfigEnum, value }),
-      );
-    }
+    const mockConfigs = [
+      {
+        name: InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
+        value: RECOVERY_TOKEN,
+      },
+      { name: InfraConfigEnum.GOOGLE_CLIENT_ID, value: 'google-id' },
+      {
+        name: InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
+        value: 'google',
+      },
+    ];
 
-    function setupOpenWindow(
-      tokenInDb: string | undefined = VALID_TOKEN,
-    ): void {
-      const configs =
-        tokenInDb !== undefined
-          ? makeConfigs({
-              [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: tokenInDb,
-            })
-          : [
-              {
-                name: InfraConfigEnum.ONBOARDING_COMPLETED as InfraConfigEnum,
-                value: 'false',
-              },
-            ];
+    it('should return config values when token is valid', async () => {
       jest
         .spyOn(infraConfigService, 'getMany')
-        .mockResolvedValueOnce(E.right(configs));
-      mockUserService.getUsersCount.mockResolvedValueOnce(0);
-    }
+        .mockResolvedValueOnce(E.right(mockConfigs));
 
-    describe('completion-state gate', () => {
-      it('should block access when onboarding is completed and users exist', async () => {
-        jest
-          .spyOn(infraConfigService, 'getMany')
-          .mockResolvedValueOnce(
-            E.right(
-              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'true' }),
-            ),
-          );
-        mockUserService.getUsersCount.mockResolvedValueOnce(1);
+      const result =
+        await infraConfigService.getOnboardingConfig(RECOVERY_TOKEN);
 
-        const result =
-          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
-        expect(result).toEqualLeft(ONBOARDING_CANNOT_BE_RERUN);
-      });
-
-      it('should allow access when onboarding is completed but no users exist (re-run window)', async () => {
-        jest
-          .spyOn(infraConfigService, 'getMany')
-          .mockResolvedValueOnce(
-            E.right(
-              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'true' }),
-            ),
-          );
-        mockUserService.getUsersCount.mockResolvedValueOnce(0);
-
-        const result =
-          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
-        expect(result).toEqualRight(expect.any(Object));
-      });
-
-      it('should allow access when onboarding is not yet completed even if users exist', async () => {
-        jest
-          .spyOn(infraConfigService, 'getMany')
-          .mockResolvedValueOnce(
-            E.right(
-              makeConfigs({ [InfraConfigEnum.ONBOARDING_COMPLETED]: 'false' }),
-            ),
-          );
-        mockUserService.getUsersCount.mockResolvedValueOnce(5);
-
-        const result =
-          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
-        expect(result).toEqualRight(expect.any(Object));
-      });
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]).toBe(
+          RECOVERY_TOKEN,
+        );
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBe(
+          'google-id',
+        );
+      }
     });
 
-    describe('token validation (bootstrap window open)', () => {
-      it('should return config values for a valid matching token', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result =
-          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: VALID_TOKEN,
-          }),
-        );
-      });
+    it('should return null values when token does not match', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
 
-      it('should redact all values for an empty-string token', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result = await infraConfigService.getOnboardingConfig('');
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      const result =
+        await infraConfigService.getOnboardingConfig('wrong-token');
 
-      it('should redact all values for a whitespace-only token', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result = await infraConfigService.getOnboardingConfig('   ');
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
 
-      it('should redact all values when token is undefined (missing query param)', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result = await infraConfigService.getOnboardingConfig(
-          undefined as unknown as string,
-        );
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+    it('should return null values when token is empty string', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
 
-      it('should redact all values when token is null', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result = await infraConfigService.getOnboardingConfig(
-          null as unknown as string,
-        );
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      const result = await infraConfigService.getOnboardingConfig('');
 
-      it('should redact all values for an incorrect token', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result =
-          await infraConfigService.getOnboardingConfig('wrong-token');
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
 
-      it('should redact all values when the recovery token row is missing from DB', async () => {
-        setupOpenWindow(undefined);
-        const result =
-          await infraConfigService.getOnboardingConfig(VALID_TOKEN);
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_COMPLETED]: null,
-          }),
-        );
-      });
+    it('should return null values when token is whitespace only', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
 
-      it('should redact all values when the recovery token in DB is an empty string', async () => {
-        setupOpenWindow('');
-        const result = await infraConfigService.getOnboardingConfig('');
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      const result = await infraConfigService.getOnboardingConfig('   ');
 
-      it('should redact all values for an array-shaped token (?token[]=x bypass attempt)', async () => {
-        setupOpenWindow(VALID_TOKEN);
-        const result = await infraConfigService.getOnboardingConfig(
-          [VALID_TOKEN] as unknown as string,
-        );
-        expect(result).toEqualRight(
-          expect.objectContaining({
-            [InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN]: null,
-          }),
-        );
-      });
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return null values when token is null', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
+
+      const result = await infraConfigService.getOnboardingConfig(
+        null as unknown as string,
+      );
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return null values when token is undefined', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
+
+      const result = await infraConfigService.getOnboardingConfig(
+        undefined as unknown as string,
+      );
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return null values when token is an array', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
+
+      const result = await infraConfigService.getOnboardingConfig(
+        [] as unknown as string,
+      );
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return null values when token is a number', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(mockConfigs));
+
+      const result = await infraConfigService.getOnboardingConfig(
+        42 as unknown as string,
+      );
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return null values when ONBOARDING_RECOVERY_TOKEN is absent from configs', async () => {
+      const configsWithoutToken = mockConfigs.filter(
+        (c) => c.name !== InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
+      );
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.right(configsWithoutToken));
+
+      const result =
+        await infraConfigService.getOnboardingConfig(RECOVERY_TOKEN);
+
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect(result.right[InfraConfigEnum.GOOGLE_CLIENT_ID]).toBeNull();
+      }
+    });
+
+    it('should return left with error when getMany fails', async () => {
+      jest
+        .spyOn(infraConfigService, 'getMany')
+        .mockResolvedValueOnce(E.left(INFRA_CONFIG_NOT_FOUND));
+
+      const result =
+        await infraConfigService.getOnboardingConfig(RECOVERY_TOKEN);
+
+      expect(result).toEqualLeft(INFRA_CONFIG_NOT_FOUND);
     });
   });
 });

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -7,7 +7,6 @@ import {
   INFRA_CONFIG_NOT_FOUND,
   INFRA_CONFIG_OPERATION_NOT_ALLOWED,
   INFRA_CONFIG_UPDATE_FAILED,
-  ONBOARDING_CANNOT_BE_RERUN,
 } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
 import * as helper from './helper';
@@ -428,9 +427,7 @@ describe('InfraConfigService', () => {
         .spyOn(infraConfigService, 'getMany')
         .mockResolvedValueOnce(E.right(mockConfigs));
 
-      const result = await infraConfigService.getOnboardingConfig(
-        null as unknown as string,
-      );
+      const result = await infraConfigService.getOnboardingConfig(null);
 
       expect(E.isRight(result)).toBe(true);
       if (E.isRight(result)) {
@@ -443,9 +440,7 @@ describe('InfraConfigService', () => {
         .spyOn(infraConfigService, 'getMany')
         .mockResolvedValueOnce(E.right(mockConfigs));
 
-      const result = await infraConfigService.getOnboardingConfig(
-        undefined as unknown as string,
-      );
+      const result = await infraConfigService.getOnboardingConfig(undefined);
 
       expect(E.isRight(result)).toBe(true);
       if (E.isRight(result)) {
@@ -458,9 +453,8 @@ describe('InfraConfigService', () => {
         .spyOn(infraConfigService, 'getMany')
         .mockResolvedValueOnce(E.right(mockConfigs));
 
-      const result = await infraConfigService.getOnboardingConfig(
-        [] as unknown as string,
-      );
+      // @ts-expect-error Testing invalid input
+      const result = await infraConfigService.getOnboardingConfig([]);
 
       expect(E.isRight(result)).toBe(true);
       if (E.isRight(result)) {
@@ -473,9 +467,8 @@ describe('InfraConfigService', () => {
         .spyOn(infraConfigService, 'getMany')
         .mockResolvedValueOnce(E.right(mockConfigs));
 
-      const result = await infraConfigService.getOnboardingConfig(
-        42 as unknown as string,
-      );
+      // @ts-expect-error Testing invalid input
+      const result = await infraConfigService.getOnboardingConfig(42);
 
       expect(E.isRight(result)).toBe(true);
       if (E.isRight(result)) {

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -609,7 +609,10 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
       (config) => config.name === InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
     )?.value;
 
-    const tokenIsValid = token?.trim().length > 0 && token === recoveryToken;
+    const tokenIsValid =
+      typeof token === 'string' &&
+      token?.trim().length > 0 &&
+      token === recoveryToken;
 
     const onboardingConfig = configs.right.reduce((acc, config) => {
       acc[config.name] = tokenIsValid ? config.value : null;

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -608,7 +608,8 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
     const recoveryToken = configs.right.find(
       (config) => config.name === InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
     )?.value;
-    const tokenIsValid = token === recoveryToken;
+
+    const tokenIsValid = token.trim().length > 0 && token === recoveryToken;
 
     const onboardingConfig = configs.right.reduce((acc, config) => {
       acc[config.name] = tokenIsValid ? config.value : null;

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -609,7 +609,7 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
       (config) => config.name === InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
     )?.value;
 
-    const tokenIsValid = token.trim().length > 0 && token === recoveryToken;
+    const tokenIsValid = token?.trim().length > 0 && token === recoveryToken;
 
     const onboardingConfig = configs.right.reduce((acc, config) => {
       acc[config.name] = tokenIsValid ? config.value : null;

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -611,7 +611,7 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
 
     const tokenIsValid =
       typeof token === 'string' &&
-      token?.trim().length > 0 &&
+      token.trim().length > 0 &&
       token === recoveryToken;
 
     const onboardingConfig = configs.right.reduce((acc, config) => {

--- a/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
@@ -104,6 +104,24 @@ export class OnboardingController {
     type: GetOnboardingConfigResponse,
   })
   async getOnboardingConfig(@Query('token') token: string) {
+    const onboardingStatus =
+      await this.infraConfigService.getOnboardingStatus();
+
+    if (E.isLeft(onboardingStatus))
+      throwHTTPErr(<RESTError>{
+        message: onboardingStatus.left,
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      });
+
+    if (
+      onboardingStatus.right.onboardingCompleted &&
+      !onboardingStatus.right.canReRunOnboarding
+    )
+      throwHTTPErr(<RESTError>{
+        message: ONBOARDING_CANNOT_BE_RERUN,
+        statusCode: HttpStatus.BAD_REQUEST,
+      });
+
     const onboardingConfig =
       await this.infraConfigService.getOnboardingConfig(token);
 


### PR DESCRIPTION
Addresses [GHSA-7c8p-hj4p-3q3f](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-7c8p-hj4p-3q3f).

Closes the unauthenticated onboarding config disclosure on self-hosted backends where `ONBOARDING_RECOVERY_TOKEN` is empty or unset. A `GET /v1/onboarding/config?token=` request would previously return seeded infra-config values (OAuth client IDs, SMTP settings, allowed auth providers) without authentication.

### What's changed

- Tightened token validation in `getOnboardingConfig` to reject empty, whitespace-only, and non-string token values.
- Added a completion-state gate on `GET /v1/onboarding/config` that rejects requests once onboarding is complete and the instance has at least one user, mirroring the gate already in place on `POST /onboarding/config`.
- Added service-level regression tests covering 9 input permutations (valid, wrong, empty, whitespace, null, undefined, array, number, missing-config-row).

### Notes to reviewers

- The endpoint remains intentionally unauthenticated for first-run onboarding — there's no admin session yet at that point. The fix prevents re-running onboarding after the instance has any user, which closes the disclosure path.
- Cubic's auto-summary above references an earlier commit (`2b378ad73`) that proposed `crypto.timingSafeEqual`. That hardening was dropped on review; the practical fix is the truthiness + completion-state gate. Cubic will regenerate on the next commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens token validation and adds a completion gate on onboarding GET config to prevent exposure.
Now uses constant‑time token compare (`crypto.timingSafeEqual`) with a length pre-check; only trimmed, non‑empty matches return values, others get nulls; completed non‑rerunnable requests get 400 and onboarding status failures return 422, with tests for edge cases.

<sup>Written for commit 2b378ad73a4c697be88edacc56a3ca5190c7a1e8. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6240">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

