### PR TITLE
fix(common): subfolder add-new in team collections respects write access

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
@@ -486,12 +486,16 @@
                 :label="t('add.new')"
                 filled
                 outline
+                :disabled="hasNoTeamAccess"
+                :title="hasNoTeamAccess ? t('team.no_access') : ''"
                 @click="
-                  node.data.type === 'collections' &&
-                  emit('add-folder', {
-                    path: node.id,
-                    folder: node.data.data.data,
-                  })
+                  hasNoTeamAccess
+                    ? null
+                    : node.data.type === 'collections' &&
+                      emit('add-folder', {
+                        path: node.id,
+                        folder: node.data.data.data,
+                      })
                 "
               />
             </template>

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1051,6 +1051,13 @@ const addFolder = (payload: {
   path: string
   folder: HoppCollection | TeamCollection
 }) => {
+  if (
+    collectionsType.value.type === "team-collections" &&
+    !hasTeamWriteAccess.value
+  ) {
+    return
+  }
+
   const { path, folder } = payload
   editingFolder.value = folder
   editingFolderPath.value = path


### PR DESCRIPTION
Closes FE-1226

Fix team collections viewer-access behavior for subfolder creation.

### What's changed

- Disabled the subfolder "Add new" action in the team collections empty-state for users without team write access, mirroring the existing pattern on the import + add-new buttons in the same component.
- Added a defensive guard in the shared `addFolder` handler to short-circuit for team collections without write access, catching any programmatic paths that bypass the UI disable.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team collections access control by disabling subfolder creation for users without team write access and blocking the add-folder modal from restricted paths. Addresses Linear FE-1226 and aligns viewer-only behavior with other restricted actions.

- **Bug Fixes**
  - In `hoppscotch-common` TeamCollections, disable “Add new” when `hasNoTeamAccess` and show `team.no_access` tooltip.
  - In `hoppscotch-common` collections index, guard `addFolder` to no-op for team collections without write access.

<sup>Written for commit 59395eb908fb115869dc135a74e3b2cc15757f41. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6243?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

