### PR TITLE
fix: make \ comply with RFC 4122 v4 UUID format

### DIFF
--- a/packages/hoppscotch-data/src/predefinedVariables.ts
+++ b/packages/hoppscotch-data/src/predefinedVariables.ts
@@ -43,18 +43,14 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
     key: "$randomUUID",
     description: "A random 36-character UUID.",
     getValue: () => {
-      const characters = "0123456789abcdef"
-      let uuid = ""
-      for (let i = 0; i < 36; i++) {
-        if (i === 8 || i === 13 || i === 18 || i === 23) {
-          uuid += "-"
-        } else {
-          uuid += characters.charAt(
-            Math.floor(Math.random() * characters.length)
-          )
-        }
-      }
-      return uuid
+      return (
+        globalThis.crypto?.randomUUID?.() ??
+        "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0
+          const v = c === "x" ? r : (r & 0x3) | 0x8
+          return v.toString(16)
+        })
+      )
     },
   },
 


### PR DESCRIPTION
## Problem
$randomUUID was generating UUIDs that do not comply with RFC 4122 v4.

The old implementation used a simple loop over Math.random() characters
without setting the required version bit (4) or variant bits (8/9/a/b),
so the 3rd and 4th segments were completely random instead of spec-compliant.

## Root cause
File: packages/hoppscotch-data/src/predefinedVariables.ts

The loop placed random hex characters at ALL positions including positions
that RFC 4122 requires to be fixed (version = 4, variant = 8/9/a/b).

## Fix
- Primary: globalThis.crypto.randomUUID() — native API, fully compliant
- Fallback: manual replacement that correctly forces version bit to 4
  and variant bits to 8, 9, a, or b

## Validation
Tested output against RFC 4122 v4 regex:
/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
Result: true 

Closes #6124

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `$randomUUID` to generate RFC 4122 v4-compliant UUIDs in `packages/hoppscotch-data/src/predefinedVariables.ts` (closes #6124). Uses `globalThis.crypto.randomUUID()` when available, with a spec-correct fallback that forces version 4 and variant 8/9/a/b.

<sup>Written for commit a6c68f3f6e64e5792066030465b134763ab9420b. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6250?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

