### PR TITLE
fix(cli): ship `semver` as a runtime dependency

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "type": "module",

--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -52,6 +52,7 @@
     "lodash-es": "4.18.1",
     "papaparse": "5.5.3",
     "qs": "6.15.1",
+    "semver": "7.7.4",
     "tough-cookie": "6.0.1",
     "verzod": "0.4.0",
     "xmlbuilder2": "4.0.3",
@@ -66,7 +67,6 @@
     "@types/qs": "6.15.0",
     "fp-ts": "2.16.11",
     "prettier": "3.8.3",
-    "semver": "7.7.4",
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vitest": "4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       qs:
         specifier: 6.15.1
         version: 6.15.1
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
       tough-cookie:
         specifier: 6.0.1
         version: 6.0.1
@@ -484,9 +487,6 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
-      semver:
-        specifier: 7.7.4
-        version: 7.7.4
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
Closes #6255, FE-1231.

`@hoppscotch/cli@0.31.0` fails to launch on clean global installations or when using `npx @hoppscotch/cli@latest`, due to a missing required runtime package. This issue prevents users from successfully starting the CLI after installation.

### What's Changed

- Moved `semver` to the production dependency set to ensure it is included with the published CLI package.
- Updated the CLI lockfile accordingly to reflect this dependency change.
- Incremented the CLI package version to `0.31.1`.

### Notes to reviewers

- The `bin/hopp.js` file is published directly to npm, whereas `tsup` only bundles `src/index.ts`. Therefore, the runtime imports for the bin shim must be included in the production `dependencies`.
- This misclassification has existed for some time, previously hidden by an unintentional transitive hoist: `isolated-vm@6.0.2 → prebuild-install → node-abi → semver`. The update to `isolated-vm@6.1.2` in version `0.31.0` switched to `node-gyp-build` ([laverdet/isolated-vm#546](https://github.com/laverdet/isolated-vm/pull/546)), which removed the transitive provider, thus revealing the underlying issue.
- To reproduce the problem, run `npm install -g @hoppscotch/cli@0.31.0 && hopp -v`, which will produce an error. With this change, the same command against `0.31.1` executes successfully. Validation can be performed using [verdaccio](https://github.com/verdaccio/verdaccio) or a similar tool.