### PR TITLE
fix(common): persist team request examples on save

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1733,6 +1733,9 @@ const addExample = (payload: {
     editingRequestIndex.value = parseInt(requestIndex.toString())
   } else {
     editingRequestID.value = requestIndex.toString()
+    // Capture the parent collection path so the new example-response tab can
+    // resolve its `saveContext.collectionID` and inherited properties.
+    editingFolderPath.value = folderPath
   }
   displayModalAddExample(true)
 }
@@ -1871,8 +1874,11 @@ const onAddExample = async () => {
         },
         () => {
           // Capture IDs before closing the modal — `displayModalAddExample(false)`
-          // calls `resetSelectedData()` which nulls `editingRequestID` /
-          // `editingFolderPath`, making downstream tab sync silently no-op.
+          // calls `resetSelectedData()`, which nulls `editingRequestID` and
+          // would make `if (!requestID) return` short-circuit the request-tab
+          // sync below. `editingFolderPath` is captured here too so the new
+          // example-response tab's `saveContext.collectionID` and inherited
+          // properties resolve correctly.
           const requestID = editingRequestID.value
           const collectionID = editingFolderPath.value
 

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1870,12 +1870,15 @@ const onAddExample = async () => {
           modalLoadingState.value = false
         },
         () => {
+          // Capture IDs before closing the modal — `displayModalAddExample(false)`
+          // calls `resetSelectedData()` which nulls `editingRequestID` /
+          // `editingFolderPath`, making downstream tab sync silently no-op.
+          const requestID = editingRequestID.value
+          const collectionID = editingFolderPath.value
+
           modalLoadingState.value = false
           toast.success(t("response.saved"))
           displayModalAddExample(false)
-
-          const requestID = editingRequestID.value
-          const collectionID = editingFolderPath.value
 
           if (!requestID) return
 


### PR DESCRIPTION
Closes #6248

Saving a request in a team workspace was wiping out any examples that had been added to it via the **Add Example** right-click action. The mutation that creates the example always reached the backend (so the example briefly appeared in the tree), but the in-memory request tab never picked up the new `responses`, so the next request save serialized an empty `responses` map back to the backend and erased the example.

### What's changed

- `packages/hoppscotch-common/src/components/collections/index.vue`: in the team-collection branch of the `Add Example` success callback, capture `editingRequestID` / `editingFolderPath` **before** calling `displayModalAddExample(false)`. The modal-close path runs `resetSelectedData()`, which nulls those refs; the previous order read them after the reset, so `if (!requestID) return` always short-circuited and the open request tab's `responses` were never synced. As a result, the dirty tab still held empty `responses`, and the next "Save" wrote them back over the backend.

### Notes to reviewers

- Reproduces only in **team workspaces** (personal collections are unaffected — they use a different code path that captures the IDs from the local function scope, not refs).
- Repro:
  1. In a team workspace, create a collection and a request.
  2. Right-click the request → **Add Example** → name → save. The example appears in the tree.
  3. Open the request tab and click **Save**.
  4. Before this fix: the example disappears from the tree and from the exported collection JSON. After this fix: it stays.
- Two-line reorder + comment, no behavior change beyond the bug fix; `if (!requestID) return` still guards the rest of the callback.
- Saving an example via **Save as Example** from the response panel was unaffected and continues to work as before.
