### PR TITLE
Fix/curl import asterisk 6249

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,46 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    // Regression test for https://github.com/hoppscotch/hoppscotch/issues/6249
+    // Asterisk in query value must not be stripped during URL preprocessing.
+    command: `curl -X POST 'https://x.x.cn/x/x/x?bi=%5B%221440*2976%22%5D&bik=25&pageId=xxx' -H 'content-type: application/json; charset=UTF-8' -d '{"country":"xxx"}'`,
+    response: makeRESTRequest({
+      method: "POST",
+      name: "Untitled",
+      endpoint: "https://x.x.cn/x/x/x",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: "application/json",
+        body: `{\n  "country": "xxx"\n}`,
+      },
+      headers: [],
+      params: [
+        {
+          active: true,
+          key: "bi",
+          value: `["1440*2976"]`,
+          description: "",
+        },
+        {
+          active: true,
+          key: "bik",
+          value: "25",
+          description: "",
+        },
+        {
+          active: true,
+          key: "pageId",
+          value: "xxx",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1069,9 +1069,11 @@ data2: {"type":"test2","typeId":"123"}`,
     }),
   },
   {
-    // Coverage for unreserved/sub-delim characters and Hoppscotch env
-    // template braces in cURL URL query values.
-    command: `curl 'https://api.example.com/v1/items?ids=[1,2,3]&template={{userId}}&filter=name~john&price=$100&flag=!yes'`,
+    // Coverage for unreserved/sub-delim characters and literal braces
+    // (Postman-style template placeholders) in cURL URL query values.
+    // `--globoff` is required because curl would otherwise treat `[...]`
+    // and `{...}` as URL globbing patterns.
+    command: `curl --globoff 'https://api.example.com/v1/items?ids=[1,2,3]&template={{userId}}&filter=name~john&price=$100&flag=!yes'`,
     response: makeRESTRequest({
       method: "GET",
       name: "Untitled",

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1068,6 +1068,58 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    // Coverage for unreserved/sub-delim characters and Hoppscotch env
+    // template braces in cURL URL query values.
+    command: `curl 'https://api.example.com/v1/items?ids=[1,2,3]&template={{userId}}&filter=name~john&price=$100&flag=!yes'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://api.example.com/v1/items",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [],
+      params: [
+        {
+          active: true,
+          key: "ids",
+          value: "[1,2,3]",
+          description: "",
+        },
+        {
+          active: true,
+          key: "template",
+          value: "{{userId}}",
+          description: "",
+        },
+        {
+          active: true,
+          key: "filter",
+          value: "name~john",
+          description: "",
+        },
+        {
+          active: true,
+          key: "price",
+          value: "$100",
+          description: "",
+        },
+        {
+          active: true,
+          key: "flag",
+          value: "!yes",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -42,7 +42,12 @@ export const parseCurlCommand = (curlCommand: string) => {
 
   curlCommand = preProcessCurlCommand(curlCommand)
 
-  const args: parser.Arguments = parser(curlCommand)
+  // Declare known boolean curl flags so yargs-parser doesn't consume the
+  // following positional (e.g. the URL) as the flag's value.
+  const args: parser.Arguments = parser(curlCommand, {
+    boolean: ["globoff"],
+    alias: { globoff: ["g"] },
+  })
 
   const parsedArguments = pipe(
     args,

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -14,7 +14,6 @@ const replaceables: { [key: string]: string } = {
   "--data-binary": "-d",
   "--user": "-u",
   "--get": "-G",
-  "--globoff": "",
 }
 
 const paperCuts = flow(

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -14,6 +14,7 @@ const replaceables: { [key: string]: string } = {
   "--data-binary": "-d",
   "--user": "-u",
   "--get": "-G",
+  "--globoff": "",
 }
 
 const paperCuts = flow(

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*!$~[\]\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*!$~[\]{}\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*!$~[\]\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>


### PR DESCRIPTION
Closes #6249

The cURL importer was silently stripping any character outside a small explicit allowlist during URL preprocessing, which dropped valid URL characters such as `*` from query parameter values. For the issue's reproducer, `?bi=...%221440*2976%22...` was parsed as `1440*2976` → `14402976`, breaking the imported request.

The preprocessing step uses a negated character-class regex to scrub the raw URL string before handing it to `new URL(...)`. Several characters that are perfectly valid in URLs (RFC 3986 sub-delims and unreserved) plus Hoppscotch's `{{var}}` environment template braces were missing from that allowlist, so they were stripped instead of preserved.

### What's changed

- Extended the URL preprocessor allowlist in `helpers/curl/sub_helpers/url.ts` to include:
  - `*` — direct fix for #6249
  - `!`, `$`, `~` — RFC 3986 sub-delims/unreserved that were also being stripped
  - `[`, `]` — used in array-style query values and IPv6 literals
  - `{`, `}` — Hoppscotch environment variable templates (`{{var}}`)
- Added two regression samples to `curlparser.spec.js`:
  - The exact reproducer from the issue, asserting `bi` retains `1440*2976`
  - A combined sample covering `[]`, `{{...}}`, `~`, `$`, `!` round-tripping in query values

### Notes to reviewers

- The fix is intentionally scoped to widening the allowlist; the broader question of whether this strip step is needed at all (since `new URL(...)` validates anyway) is left out of scope.
- No other parser path uses this allowlist — verified via grep; headers and body parsing are unaffected.
- Existing 29 cURL parser samples continue to pass; total is now 31.
- Three commits on this branch — fine to squash on merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import dropping valid URL characters by widening the URL preprocessor allowlist and handling `--globoff` as a boolean flag, preserving `*` and other RFC 3986-safe symbols. Closes #6249.

- **Bug Fixes**
  - Expanded allowlist in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts` to keep `*`, `!`, `$`, `~`, `[`, `]`, `{`, `}`, and other valid URL chars.
  - Treat `--globoff`/`-g` as a boolean in `packages/hoppscotch-common/src/helpers/curl/curlparser.ts` to avoid consuming the URL; added regression tests in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` for `bi=["1440*2976"]` and a `--globoff` case covering `[]`, `{{...}}`, `~`, `$`, `!`.

<sup>Written for commit f17130a4822cdd5151319101a34a1a4a45e7050d. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6260?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

